### PR TITLE
implement toggleable transaction details

### DIFF
--- a/app/actions/wallet-actions.js
+++ b/app/actions/wallet-actions.js
@@ -17,7 +17,8 @@ export const createWallet = (props) => {
           type: 'card',
           amount: -502.40,
           currency: '$',
-          date: new Date()
+          date: new Date(),
+          description: ''
         },
         {
           id: 't-id-2',
@@ -25,7 +26,11 @@ export const createWallet = (props) => {
           type: 'adaExpend',
           amount: 500,
           currency: 'ADA',
-          date: new Date()
+          date: new Date(),
+          exchange: '502.40 ADA for 3.20 USD',
+          conversionRate: '1 USD = 157 ADA',
+          transactionId: '4f43b64ec9009ded75cc353f301d9f23a3c936d9b306af8fbb59f43e95244fe8',
+          description: 'for invoice 1023'
         },
         {
           id: 't-id-3',
@@ -33,7 +38,11 @@ export const createWallet = (props) => {
           type: 'adaIncome',
           amount: -400.58,
           currency: 'ADA',
-          date: moment().subtract(1, 'days').toDate()
+          date: moment().subtract(1, 'days').toDate(),
+          exchange: '502.40 ADA for 3.20 USD',
+          conversionRate: '1 USD = 157 ADA',
+          transactionId: '4f43b64ec9009ded75cc353f301d9f23a3c936d9b306af8fbb59f43e95244fe8',
+          description: 'for invoice 1023'
         },
         {
           id: 't-id-4',
@@ -41,7 +50,11 @@ export const createWallet = (props) => {
           type: 'exchange',
           amount: -100000,
           currency: 'ADA',
-          date: moment().subtract(1, 'days').toDate()
+          date: moment().subtract(1, 'days').toDate(),
+          exchange: '502.40 ADA for 1.25 ETH',
+          conversionRate: '1 ETH = 401.92 ADA',
+          transactionId: '4f43b64ec9009ded75cc353f301d9f23a3c936d9b306af8fbb59f43e95244fe8',
+          description: ''
         },
       ]
     };

--- a/app/components/wallet/WalletHome.scss
+++ b/app/components/wallet/WalletHome.scss
@@ -13,8 +13,7 @@
 }
 
 .transaction {
-  height: 84px;
-  margin-bottom: 10px;
-  padding: 20px;
+  padding: 0 20px;
+  margin: 20px 0;
 }
 

--- a/app/components/widgets/Transaction.js
+++ b/app/components/widgets/Transaction.js
@@ -41,25 +41,68 @@ export default class Transaction extends Component {
     intl: intlShape.isRequired,
   };
 
+  state = {
+    isExpanded: false
+  };
+
+  toggleDetails() {
+    this.setState({ isExpanded: !this.state.isExpanded });
+  }
+
   render() {
-    const { title, type, amount, currency } = this.props.data;
+    const data = this.props.data;
+    const { isExpanded } = this.state;
     const { intl } = this.context;
-    let typeMessage = type;
+    let typeMessage = data.type;
+    const contentStyles = classNames([
+      styles.content,
+      this.props.isLastInList ? styles.last : null
+    ]);
     const detailsStyles = classNames([
       styles.details,
-      this.props.isLastInList ? styles.lastDetails : null
+      isExpanded ? styles.expanded : styles.closed
     ]);
-    if (type === 'adaExpend' || type === 'adaIncome') typeMessage = 'ada';
+    if (data.type === 'adaExpend' || data.type === 'adaIncome') typeMessage = 'ada';
     return (
       <div className={styles.component}>
-        <div className={styles[type]} />
-        <div className={detailsStyles}>
-          <div className={styles.header}>
-            <div className={styles.title}>{title}</div>
-            <div className={styles.amount}>{amount} {currency}</div>
-          </div>
+        <div className={styles[data.type]} />
+        <div className={contentStyles}>
+
+          {/* ==== Clickable Header -> toggles details ==== */}
+
+          <button className={styles.header} onClick={this.toggleDetails.bind(this)}>
+            <div className={styles.title}>{data.title}</div>
+            <div className={styles.amount}>{data.amount} {data.currency}</div>
+          </button>
+
           <div className={styles.type}>{intl.formatMessage(messages[typeMessage])}</div>
 
+          {/* ==== Toggleable Transaction Details ==== */}
+
+          <div className={detailsStyles}>
+            {data.exchange && data.conversionRate && (
+              <div className={styles.conversion}>
+                <div>
+                  <h2>Exchange</h2>
+                  <span>{data.exchange}</span>
+                </div>
+                <div className={styles.conversionRate}>
+                  <h2>Conversion Rate</h2>
+                  <span>{data.conversionRate}</span>
+                </div>
+              </div>
+            )}
+            {data.transactionId && (
+              <div>
+                <h2>TransactionId</h2>
+                <span>{data.transactionId}</span>
+              </div>
+            )}
+            <div>
+              <h2>Description</h2>
+              <span>{data.description !== '' ? data.description : 'No description yet'}</span>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/app/components/widgets/Transaction.scss
+++ b/app/components/widgets/Transaction.scss
@@ -42,25 +42,46 @@
 
 // ========= DETAILS =========
 
-.details {
+.content {
   width: 100%;
   margin-left: 20px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
   border-bottom: 1px solid #dfe4e8;
   padding-bottom: 30px;
   padding-top: 6px;
 }
 
-.lastDetails {
+.last {
   border: none;
   padding-bottom: 0;
+}
+
+.details {
+  height: auto;
+  h2 {
+    font-family: $font-medium;
+    font-size: 16px;
+    margin-bottom: 8px;
+    margin-top: 20px;
+  }
+  span {
+    font-family: $font-light;
+    font-size: 14px;
+  }
+}
+
+.closed {
+  max-height: 0;
+  overflow: hidden;
+}
+
+.expanded {
+  max-height: 100%;
 }
 
 .header {
   display: flex;
   width: 100%;
+  cursor: pointer;
 }
 
 .title, .amount {
@@ -79,4 +100,12 @@
   font-family: $font-light;
   font-size: 14px;
   margin-top: 8px;
+}
+
+.conversion {
+  display: flex;
+}
+
+.conversionRate {
+  margin-left: 76px;
 }

--- a/app/styles/index.global.scss
+++ b/app/styles/index.global.scss
@@ -45,6 +45,17 @@ table {
   border-spacing: 0;
 }
 
+// Buttons should not have any special style applied by default
+button {
+  background: none;
+  border: none;
+  padding: 0;
+
+  &:focus {
+    outline: 0;
+  }
+}
+
 // ============ FONTS ===========
 
 @font-face {


### PR DESCRIPTION
This PR implements toggleable transaction details. The details are rendered conditionally, only if they exist in the transaction data. I did not add the `Address` field since we discussed that it probably will not be included in the MVP. Also does not include the description editing feature.

<img width="1273" alt="screenshot 2016-11-11 um 12 40 36" src="https://cloud.githubusercontent.com/assets/172414/20214064/212651d4-a80c-11e6-8912-aff6b8edff52.png">