### PR TITLE
Fix transaction icons in order for them to look as design specs

### DIFF
--- a/app/components/widgets/Transaction.scss
+++ b/app/components/widgets/Transaction.scss
@@ -31,7 +31,6 @@
 
 .adaExpend {
   @extend %type-box;
-  border-radius: 20px;
   background-color: #f2e6e6;
   background-image: url("../../assets/images/send-ic.svg");
   background-position-y: 7px;


### PR DESCRIPTION
This PR improves look of transaction icons:
- makes them correct size
- money send icon picture is positioned as per designs specs

![screen shot 2016-11-21 at 18 52 52](https://cloud.githubusercontent.com/assets/4280521/20494136/e91eb5ac-b01b-11e6-944d-092ecc5781bc.png)
