### PR TITLE
add loading spinner component and use it for app startup

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -11,6 +11,7 @@ import Wallet from './containers/wallet/Wallet';
 import Settings from './containers/settings/Settings';
 import translations from './i18n/translations';
 import WalletCreatePage from './containers/wallet/WalletCreatePage';
+import LoadingSpinner from './components/widgets/LoadingSpinner';
 
 @observer
 export default class App extends Component {
@@ -27,7 +28,7 @@ export default class App extends Component {
   render() {
     const { state, controller } = this.props;
     if (state.isApplicationLoading) {
-      return <div>Loading...</div>;
+      return <LoadingSpinner style={{ height: '100%' }} />;
     }
     const { activeWallet } = this.props.state;
     const { wallet } = activeWallet;

--- a/app/components/wallet/home/WalletTransactionsList.js
+++ b/app/components/wallet/home/WalletTransactionsList.js
@@ -6,6 +6,7 @@ import moment from 'moment';
 import classnames from 'classnames';
 import styles from './WalletTransactionsList.scss';
 import Transaction, { transactionShape } from '../../widgets/Transaction';
+import LoadingSpinner from '../../widgets/LoadingSpinner';
 
 defineMessages({
 
@@ -37,7 +38,7 @@ export default class WalletTransactionsList extends Component {
   }
 
   list: HTMLElement;
-  loadingSpinner: HTMLElement;
+  loadingSpinner: LoadingSpinner;
 
   groupTransactionsByDay(transactions:[Object]) {
     const groups = [];
@@ -69,8 +70,9 @@ export default class WalletTransactionsList extends Component {
   }
 
   isSpinnerVisible() {
-    if (this.loadingSpinner == null) return false;
-    const spinnerRect = this.loadingSpinner.getBoundingClientRect();
+    const spinner = this.loadingSpinner;
+    if (spinner == null || spinner.root == null) return false;
+    const spinnerRect = spinner.root.getBoundingClientRect();
     const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight);
     return !(spinnerRect.bottom < 0 || spinnerRect.top - viewHeight >= 0);
   }
@@ -97,7 +99,7 @@ export default class WalletTransactionsList extends Component {
     }
     const componentStyles = classnames([styles.component, shadowStyle]);
     const loadingSpinner = isLoadingTransactions || hasMoreToLoad ? (
-      <div className={styles.spinner} ref={(div) => { this.loadingSpinner = div; }} />
+      <LoadingSpinner ref={(component) => { this.loadingSpinner = component; }} />
     ) : null;
     return (
       <div

--- a/app/components/wallet/home/WalletTransactionsList.scss
+++ b/app/components/wallet/home/WalletTransactionsList.scss
@@ -85,15 +85,3 @@
   margin-bottom: 10px;
   margin-left: 20px;
 }
-
-.spinner {
-  margin: 20px auto;
-  width: 30px;
-  height: 30px;
-  background: url("../../../assets/images/spinner-dark.svg") no-repeat center;
-  background-size: 30px;
-  :global {
-    animation: loading-spin 1.5s linear;
-    animation-iteration-count: infinite;
-  }
-}

--- a/app/components/widgets/LoadingSpinner.js
+++ b/app/components/widgets/LoadingSpinner.js
@@ -1,0 +1,12 @@
+// @flow
+import React, { Component } from 'react';
+import styles from './LoadingSpinner.scss';
+
+export default class LoadingSpinner extends Component {
+
+  root: HTMLElement;
+
+  render() {
+    return <div className={styles.component} ref={(div) => { this.root = div; }} />;
+  }
+}

--- a/app/components/widgets/LoadingSpinner.scss
+++ b/app/components/widgets/LoadingSpinner.scss
@@ -1,0 +1,11 @@
+.component {
+  margin: 20px auto;
+  width: 30px;
+  height: 30px;
+  background: url("../../assets/images/spinner-dark.svg") no-repeat center;
+  background-size: 30px;
+  :global {
+    animation: loading-spin 1.5s linear;
+    animation-iteration-count: infinite;
+  }
+}

--- a/app/index.js
+++ b/app/index.js
@@ -23,4 +23,4 @@ const routedApp = (
   <Router><App state={appState} controller={controller} /></Router>
 );
 
-render(routedApp, document.getElementById('root'));
+window.addEventListener('load', () => render(routedApp, document.getElementById('root')));


### PR DESCRIPTION
Adds a dedicated loading spinner component for app loading state and refactors transaction list to use it too. Also fixes app startup to happen when document was properly loaded. I think that's not really relevant for production though … as it seems to happen instantly there.