### PR TITLE
Fixes broken build

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-dom": "^15.3.2",
     "react-intl": "^2.1.5",
     "react-router": "^4.0.0-alpha.5",
-    "react-toolbox": "git://github.com/react-toolbox/react-toolbox.git#dev",
+    "react-toolbox": "git://github.com/react-toolbox/react-toolbox.git#084e367bb79dd341beb332a45ac95e8181cfe50f",
     "source-map-support": "^0.4.3",
     "validator": "^6.1.0",
     "wallet-address-validator": "^0.1.0"


### PR DESCRIPTION
Build was broken due to `react-toolbox` dependency. This is reproducible by removing `node_modules` and running `npm install`.

Since we are using development branch of that dependency it is now pegged to specific commit which works.  Maintainers of the repo decided to remove the `lib` folder since it was making project more difficult to maintain: https://github.com/react-toolbox/react-toolbox/issues/898
