### PR TITLE
make sidebar minimized by default

### DIFF
--- a/app/components/sidebar/Sidebar.js
+++ b/app/components/sidebar/Sidebar.js
@@ -24,7 +24,7 @@ export default class Sidebar extends Component {
     }).isRequired,
     onCategoryClicked: PropTypes.func,
     hidden: PropTypes.bool,
-    showMenu: PropTypes.bool,
+    isMaximized: PropTypes.bool,
     activeWalletId: PropTypes.string
   };
 
@@ -33,15 +33,19 @@ export default class Sidebar extends Component {
   }
 
   render() {
-    const { hidden, showMenu, menus, onCategoryClicked, activeWalletId } = this.props;
-    const sidebarStyles = classNames([
-      styles.component,
-      hidden ? styles.hidden : styles.visible,
-    ]);
+    const { hidden, isMaximized, menus, onCategoryClicked, activeWalletId } = this.props;
 
+    let sidebarStyle = null;
+    let categoriesStyle = null;
     let subMenu = null;
+    let hasMinimizedCategories = true;
 
-    if (showMenu && this.matches('/wallets')) {
+    if (hidden) {
+      sidebarStyle = styles.hidden;
+    } else if (isMaximized) {
+      categoriesStyle = styles.maximized;
+      hasMinimizedCategories = false;
+    } else if (this.matches('/wallets')) {
       subMenu = (
         <SidebarWalletsMenu
           visible={this.matches('/wallets')}
@@ -51,22 +55,28 @@ export default class Sidebar extends Component {
           isActiveWallet={id => id === activeWalletId}
         />
       );
+      categoriesStyle = styles.minimized;
+    } else {
+      sidebarStyle = styles.minimized;
     }
+
+    const sidebarStyles = classNames([styles.component, sidebarStyle]);
+
     return (
       <div className={sidebarStyles}>
-        <div className={subMenu != null ? styles.minimized : styles.maximized}>
+        <div className={categoriesStyle}>
           <SidebarCategory
             label="Wallets"
             icon={walletsIcon}
             active={this.matches('/wallets')}
-            minimized={subMenu != null}
+            minimized={hasMinimizedCategories}
             onClick={() => onCategoryClicked('/wallets')}
           />
           <SidebarCategory
             label="Settings"
             icon={settingsIcon}
             active={this.matches('/settings')}
-            minimized={subMenu != null}
+            minimized={hasMinimizedCategories}
             onClick={() => onCategoryClicked('/settings')}
           />
         </div>

--- a/app/components/sidebar/Sidebar.scss
+++ b/app/components/sidebar/Sidebar.scss
@@ -1,6 +1,7 @@
 @import './sidebarConfig';
 
 .component {
+  width: $sidebar-width;
   background-color: $sidebar-bg;
   display: flex;
   height: 100%;
@@ -8,16 +9,12 @@
   overflow: hidden;
 }
 
-.visible {
-  width: $sidebar-width;
-}
-
 .hidden {
   width: 0;
 }
 
 .minimized {
-  min-width: 84px;
+  width: 84px;
 }
 
 .maximized {

--- a/app/containers/Layout.js
+++ b/app/containers/Layout.js
@@ -65,7 +65,7 @@ export default class Layout extends Component {
         route={sidebar.route}
         menus={sidebarMenus}
         hidden={sidebar.hidden}
-        showMenu={sidebar.showMenu}
+        isMaximized={sidebar.isMaximized}
         onCategoryClicked={(cat) => controller.sidebar.changeSidebarRoute(cat)}
         activeWalletId={activeWallet.wallet.address}
       />

--- a/app/controllers/SidebarController.js
+++ b/app/controllers/SidebarController.js
@@ -19,10 +19,10 @@ export default class SidebarController {
     const { sidebar } = this.state;
     if (sidebar.route === route) {
       // Toggle menu if it's the current route
-      sidebar.showMenu = !sidebar.showMenu;
+      sidebar.isMaximized = !sidebar.isMaximized;
     } else {
       sidebar.route = route;
-      sidebar.showMenu = true;
+      sidebar.isMaximized = false;
       if (route === '/settings') {
         if (this.state.router) this.state.router.transitionTo(route);
       }

--- a/app/state/sidebar.js
+++ b/app/state/sidebar.js
@@ -5,7 +5,7 @@ export type sidebarState = {
   state: appState,
   route: string,
   hidden: bool,
-  showMenu: bool,
+  isMaximized: bool,
   wallets: () => Array<Object>,
 };
 
@@ -13,7 +13,7 @@ export default (state: appState): sidebarState => ({
   state,
   route: '/wallets',
   hidden: false,
-  showMenu: true,
+  isMaximized: false,
   wallets: () => (
     state.user.wallets.map(wallet => ({
       id: wallet.address,


### PR DESCRIPTION
Fixes the sidebar minimizing behavior as discussed with Alex in the last meeting. It is now minimized by default (eg: when switching between categories) and only maximized when user explicitly maximizes it by clicking on the category again.