### PR TITLE
add global scrollbar style

### DIFF
--- a/app/components/layout/SidebarLayout.scss
+++ b/app/components/layout/SidebarLayout.scss
@@ -8,16 +8,20 @@
   height: 100%;
   box-shadow: 0 0 70px 0 rgba(0,0,0,0.75);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .sidebar {
   flex: 0 0;
+  overflow: visible;
 }
 
 .appbar {
   height: 84px;
+  flex-shrink: 0;
 }
 
 .content {
-  height: calc(100% - 84px);
+  height: 100%;
 }

--- a/app/components/settings/Settings.scss
+++ b/app/components/settings/Settings.scss
@@ -2,6 +2,7 @@
 
 .component {
   padding: 20px;
+  padding-bottom: 0;
   height: 100%;
   overflow-y: auto;
   display: flex;

--- a/app/components/wallet/home/WalletTransactionsList.scss
+++ b/app/components/wallet/home/WalletTransactionsList.scss
@@ -7,24 +7,9 @@
   height: calc(100% - 93px);
   overflow-y: scroll;
 
-  &::-webkit-scrollbar {
-    width: 20px;
-  }
-
   &::-webkit-scrollbar-button {
     height: 10px;
     display: block;
-  }
-
-  &::-webkit-scrollbar-track {
-    background-color: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: #c8ccce;
-    border: 7px solid transparent;
-    border-radius: 12px;
-    background-clip: content-box;
   }
 }
 

--- a/app/components/wallet/layouts/WalletWithNavigation.js
+++ b/app/components/wallet/layouts/WalletWithNavigation.js
@@ -20,7 +20,9 @@ export default class WalletLayoutWithNavigation extends Component {
     const { wallet, children } = this.props;
     return (
       <div className={styles.component}>
-        <WalletNavigation wallet={wallet} />
+        <div className={styles.navigation}>
+          <WalletNavigation wallet={wallet} />
+        </div>
         <div className={styles.page}>
           {children}
         </div>

--- a/app/components/wallet/layouts/WalletWithNavigation.scss
+++ b/app/components/wallet/layouts/WalletWithNavigation.scss
@@ -3,8 +3,16 @@
 .component {
   background-color: $color-primary-bg;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.navigation {
+  height: 200px;
+  flex-shrink: 0;
 }
 
 .page {
-  height: calc(100% - #{$walletNavHeight});
+  height: 100%;
+  overflow: auto;
 }

--- a/app/components/wallet/navigation/WalletNavigation.scss
+++ b/app/components/wallet/navigation/WalletNavigation.scss
@@ -5,11 +5,13 @@
 
 .component {
   display: flex;
+  height: 100%;
 }
 
 .button {
-  display: block;
-  height: 200px;
+  height: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .walletButton {

--- a/app/containers/wallet/WalletHomePage.js
+++ b/app/containers/wallet/WalletHomePage.js
@@ -80,12 +80,14 @@ export default class WalletHomePage extends Component {
     }
 
     return (
-      <div style={{ height: '100%' }}>
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
         {(wallet.transactions.length || hasAnyTransactions) && (
-          <WalletTransactionsSearch
-            searchTerm={transactionsSearchTerm}
-            onChange={this.handleSearchInputChange.bind(this)}
-          />
+          <div style={{ flexShrink: 0 }}>
+            <WalletTransactionsSearch
+              searchTerm={transactionsSearchTerm}
+              onChange={this.handleSearchInputChange.bind(this)}
+            />
+          </div>
         )}
         {walletTransactions}
       </div>

--- a/app/styles/index.global.scss
+++ b/app/styles/index.global.scss
@@ -121,6 +121,26 @@ html, body, #root, #root > [data-reactroot] {
 
 * {
   box-sizing: border-box;
+  overflow:hidden;
+}
+
+// ====== GLOBAL SCROLLBAR STYLE ======
+
+* {
+  &::-webkit-scrollbar {
+    width: 20px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: #c8ccce;
+    border: 7px solid transparent;
+    border-radius: 12px;
+    background-clip: content-box;
+  }
 }
 
 // ======= RE-USABLE ANIMATIONS =======


### PR DESCRIPTION
This PR adds global scrollbar styles and refactors the wallets layout to 100% flex-box.
If you wonder why `* { overflow: hidden }` is necessary, checkout [this stackoverflow thread](http://stackoverflow.com/questions/21515042/scrolling-a-flexbox-with-overflowing-content) (the answer is: no one knows 😉 )

<img width="1155" alt="screenshot 2016-11-24 um 16 46 41" src="https://cloud.githubusercontent.com/assets/172414/20604263/d5ca72f6-b265-11e6-96e6-2c1e8ea40445.png">
