### PR TITLE
make no wallet active when on other screens

### DIFF
--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -49,14 +49,7 @@ export default class MainLayout extends Component {
     const { actions, stores } = this.props;
     const { sidebar } = stores;
     const activeWallet = stores.wallets.active;
-
-    if (!activeWallet) {
-      return (
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <LoadingSpinner />
-        </div>
-      );
-    }
+    const activeWalletId = activeWallet ? activeWallet.id : null;
 
     const sidebarMenus = {
       wallets: {
@@ -74,7 +67,7 @@ export default class MainLayout extends Component {
         hidden={sidebar.hidden}
         isMaximized={sidebar.isMaximized}
         onCategoryClicked={route => actions.changeSidebarRoute({ route })}
-        activeWalletId={activeWallet.id}
+        activeWalletId={activeWalletId}
       />
     );
     const appbar = <AppBar onToggleSidebar={actions.toggleSidebar} />;

--- a/app/stores/TransactionsStore.js
+++ b/app/stores/TransactionsStore.js
@@ -22,6 +22,7 @@ export default class TransactionsStore extends Store {
 
   @computed get searchOptions() {
     const wallet = this.stores.wallets.active;
+    if (!wallet) return null;
     let options = this._searchOptionsForWallets[wallet.id];
     if (!options) {
       // Setup options for each requested wallet

--- a/app/stores/UserStore.js
+++ b/app/stores/UserStore.js
@@ -47,9 +47,10 @@ export default class UserStore extends Store {
 
   _resizeWindowOnAuthChange = () => {
     const { router, wallets } = this.stores;
-    if (this.isLoggedIn && this.active && wallets.active) {
+    if (this.isLoggedIn && this.active && wallets.all.length) {
+      const walletToShowAfterLogin = wallets.all[0]; // just pick the first for now
       if (router.location.pathname === '/login') {
-        router.push(wallets.getWalletRoute(wallets.active.id));
+        router.push(wallets.getWalletRoute(walletToShowAfterLogin.id));
       }
       this.actions.resizeWindow({ width: 1024, height: 768 });
     } else {

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -47,8 +47,8 @@ export default class WalletsStore extends Store {
   @computed get active() {
     const currentRoute = this.stores.router.location.pathname;
     const match = matchRoute(`${this.BASE_ROUTE}/:id(*page)`, currentRoute);
-    if (match) return this.all.find(w => w.id === match.id);
-    return this.all[0];
+    if (match) return this.all.find(w => w.id === match.id) || null;
+    return null;
   }
 
   getWalletRoute(walletId: ?string, screen = 'home') {


### PR DESCRIPTION
This PR refactors the wallet logic so that we only have an `active` wallet when we are on a wallet screen. This way the sidebar does not show any wallet as "active" when we are on settings etc.

<img width="1024" alt="screenshot 2017-01-10 um 16 51 44" src="https://cloud.githubusercontent.com/assets/172414/21813068/4171360c-d755-11e6-9081-9c5f1198d927.png">
