### PR TITLE
enable dev tools in production

### DIFF
--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -5,10 +5,8 @@ import winLinuxMenu from './menus/win-linux';
 let menu;
 let mainWindow = null;
 const isDev = process.env.NODE_ENV === 'development';
-const isTest = process.env.NODE_ENV === 'test';
-const isDebug = isDev || isTest;
 
-if (isDebug) {
+if (isDev) {
   require('electron-debug')(); // eslint-disable-line global-require
 }
 
@@ -17,7 +15,7 @@ app.on('window-all-closed', () => {
 });
 
 const installExtensions = async () => {
-  if (isDebug) {
+  if (isDev) {
     const installer = require('electron-devtools-installer'); // eslint-disable-line global-require
 
     const extensions = [
@@ -27,7 +25,8 @@ const installExtensions = async () => {
     for (const name of extensions) {
       try {
         await installer.default(installer[name], forceDownload);
-      } catch (e) {} // eslint-disable-line
+      } catch (e) {
+      } // eslint-disable-line
     }
   }
 };
@@ -59,24 +58,23 @@ app.on('ready', async () => {
   });
 
   if (isDev) mainWindow.openDevTools();
-  if (isDebug) {
-    mainWindow.webContents.on('context-menu', (e, props) => {
-      const { x, y } = props;
 
-      Menu.buildFromTemplate([{
-        label: 'Inspect element',
-        click() {
-          mainWindow.inspectElement(x, y);
-        }
-      }]).popup(mainWindow);
-    });
-  }
+  mainWindow.webContents.on('context-menu', (e, props) => {
+    const { x, y } = props;
+
+    Menu.buildFromTemplate([{
+      label: 'Inspect element',
+      click() {
+        mainWindow.inspectElement(x, y);
+      }
+    }]).popup(mainWindow);
+  });
 
   if (process.platform === 'darwin') {
-    menu = Menu.buildFromTemplate(osxMenu(app, mainWindow, isDebug));
+    menu = Menu.buildFromTemplate(osxMenu(app, mainWindow));
     Menu.setApplicationMenu(menu);
   } else {
-    menu = Menu.buildFromTemplate(winLinuxMenu(mainWindow, isDebug));
+    menu = Menu.buildFromTemplate(winLinuxMenu(mainWindow));
     mainWindow.setMenu(menu);
   }
 });

--- a/electron/menus/osx.js
+++ b/electron/menus/osx.js
@@ -1,4 +1,4 @@
-export default (app, window, isDebug) => {
+export default (app, window) => {
   return [{
     label: 'Daedalus',
     submenu: [{
@@ -37,22 +37,22 @@ export default (app, window, isDebug) => {
     }]
   }, {
     label: 'View',
-    submenu: (isDebug) ? [{
+    submenu: [
+      {
         label: 'Reload',
         accelerator: 'Command+R',
         click: () => window.webContents.reload()
-      }, {
+      },
+      {
         label: 'Toggle Full Screen',
         accelerator: 'Ctrl+Command+F',
         click: () => window.setFullScreen(!window.isFullScreen())
-      }, {
+      },
+      {
         label: 'Toggle Developer Tools',
         accelerator: 'Alt+Command+I',
         click: () => window.toggleDevTools()
-      }] : [{
-        label: 'Toggle Full Screen',
-        accelerator: 'Ctrl+Command+F',
-        click: () => window.setFullScreen(!window.isFullScreen())
-      }]
+      }
+    ]
   }];
 };

--- a/electron/menus/win-linux.js
+++ b/electron/menus/win-linux.js
@@ -1,4 +1,4 @@
-export default (window, isDebug) => {
+export default (window) => {
   return [{
     label: '&Daedalus',
     submenu: [{
@@ -10,30 +10,22 @@ export default (window, isDebug) => {
     }]
   }, {
     label: '&View',
-    submenu: (isDebug) ? [{
+    submenu: [
+      {
         label: '&Reload',
         accelerator: 'Ctrl+R',
-        click() {
-          window.webContents.reload();
-        }
-      }, {
+        click() { window.webContents.reload(); }
+      },
+      {
         label: 'Toggle &Full Screen',
         accelerator: 'F11',
-        click() {
-          window.setFullScreen(!window.isFullScreen());
-        }
-      }, {
+        click() { window.setFullScreen(!window.isFullScreen()); }
+      },
+      {
         label: 'Toggle &Developer Tools',
         accelerator: 'Alt+Ctrl+I',
-        click() {
-          window.toggleDevTools();
-        }
-      }] : [{
-        label: 'Toggle &Full Screen',
-        accelerator: 'F11',
-        click() {
-          window.setFullScreen(!window.isFullScreen());
-        }
-      }]
+        click() { window.toggleDevTools(); }
+      }
+    ]
   }];
 };

--- a/webpack/package.js
+++ b/webpack/package.js
@@ -34,11 +34,9 @@ const depsExternal = Object
   .filter(name => !electronCfg.externals.includes(name))
   .map(toNodePath);
 
-
 const appName = argv.name || argv.n || pkg.productName;
 const shouldUseAsar = argv.asar || argv.a || false;
 const shouldBuildAll = argv.all || false;
-
 
 const DEFAULT_OPTS = {
   dir: './',
@@ -68,7 +66,6 @@ if (version) {
     } else {
       DEFAULT_OPTS.version = stdout.split('electron@')[1].replace(/\s/g, '');
     }
-
     startPack();
   });
 }


### PR DESCRIPTION
This PR enables dev tools in production mode!

Note: this was still only achieved by not minifying the JS files … but since Daedalus is a desktop app and open source, this does not matter much.