### PR TITLE
fixes 'search appearing when transactions' bug

### DIFF
--- a/app/api/fixtures.js
+++ b/app/api/fixtures.js
@@ -63,7 +63,7 @@ export const wallets: Array<walletStruct> = [
     address: faker.finance.bitcoinAddress(),
     type: 'personal',
     currency: 'ada',
-    amount: 2500,
+    amount: 100,
     name: 'Transporting',
     isBackupCompleted: true,
     recoveryPhrase: randomWords(12)
@@ -74,7 +74,7 @@ export const wallets: Array<walletStruct> = [
     address: faker.finance.bitcoinAddress(),
     type: 'personal',
     currency: 'btc',
-    amount: 1000,
+    amount: 0,
     name: 'Pocket money',
     isBackupCompleted: true,
     recoveryPhrase: randomWords(12)
@@ -192,5 +192,4 @@ export const transactions = generateRandomTransactions(firstWallet, 30).concat([
   cardTransaction(thirdWallet, moment().subtract(1, 'days').toDate()),
   exchange(thirdWallet),
   cardTransaction(wallets[3].id, new Date()),
-  exchange(wallets[4].id, new Date())
 ]);

--- a/app/containers/wallet/WalletHomePage.js
+++ b/app/containers/wallet/WalletHomePage.js
@@ -60,13 +60,13 @@ export default class WalletHomePage extends Component {
       filtered,
     } = this.props.stores.transactions;
     const { searchLimit, searchTerm } = searchOptions;
-
+    const wasSearched = searchTerm !== '';
     let walletTransactions = null;
     let transactionSearch = null;
     const noTransactionsLabel = intl.formatMessage(messages.noTransactions);
     const noTransactionsFoundLabel = intl.formatMessage(messages.noTransactionsFound);
 
-    if (hasAny) {
+    if (wasSearched || hasAny) {
       transactionSearch = (
         <div style={{ flexShrink: 0 }}>
           <WalletTransactionsSearch
@@ -86,10 +86,10 @@ export default class WalletHomePage extends Component {
           onLoadMore={actions.loadMoreTransactions}
         />
       );
+    } else if (wasSearched && !hasAny) {
+      walletTransactions = <WalletNoTransactions label={noTransactionsFoundLabel} />;
     } else if (!hasAny) {
       walletTransactions = <WalletNoTransactions label={noTransactionsLabel} />;
-    } else {
-      walletTransactions = <WalletNoTransactions label={noTransactionsFoundLabel} />;
     }
 
     return (

--- a/app/containers/wallet/WalletHomePage.js
+++ b/app/containers/wallet/WalletHomePage.js
@@ -62,14 +62,26 @@ export default class WalletHomePage extends Component {
     const { searchLimit, searchTerm } = searchOptions;
 
     let walletTransactions = null;
+    let transactionSearch = null;
     const noTransactionsLabel = intl.formatMessage(messages.noTransactions);
     const noTransactionsFoundLabel = intl.formatMessage(messages.noTransactionsFound);
+
+    if (hasAny) {
+      transactionSearch = (
+        <div style={{ flexShrink: 0 }}>
+          <WalletTransactionsSearch
+            searchTerm={searchTerm}
+            onChange={this._handleSearchInputChange}
+          />
+        </div>
+      );
+    }
 
     if (searchRequest.isExecuting || hasAny) {
       walletTransactions = (
         <WalletTransactionsList
           transactions={filtered}
-          isLoadingTransactions={searchRequest.isExecutingFirstTime}
+          isLoadingTransactions={searchRequest.isExecuting}
           hasMoreToLoad={totalAvailable > searchLimit}
           onLoadMore={actions.loadMoreTransactions}
         />
@@ -82,14 +94,7 @@ export default class WalletHomePage extends Component {
 
     return (
       <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-        {(searchRequest.isExecuting || hasAny) && (
-          <div style={{ flexShrink: 0 }}>
-            <WalletTransactionsSearch
-              searchTerm={searchTerm}
-              onChange={this._handleSearchInputChange}
-            />
-          </div>
-        )}
+        {transactionSearch}
         {walletTransactions}
       </div>
     );


### PR DESCRIPTION
This PR fixes the UX bug that search field appeared shortly before it was clear that there are no transactions. Additionally it makes the "no transactions found" message work correctly (only when searched). To test this I just made one of the stub wallets empty and without any transactions.