### PR TITLE
CSL-705: fix icon path passed to electron-package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
 test_script:
   - SET DAEDALUS_VERSION=%APPVEYOR_BUILD_VERSION%
   # Package frontend
-  - npm run package -- --icon icons/64x64
+  - npm run package -- --icon installers/icons/64x64
   - cd installers
   # Install stack
   - curl -sSL -o stack.zip --insecure http://www.stackage.org/stack/windows-x86_64


### PR DESCRIPTION
Manually ran `npm run package` locally with the updated path and the resulting
Daedalus.exe in the release directory ends up with the specified icon.
Without this change the program had the default Electron icon.

In case there's concern that the path doesn't correspond to an actual file, the
.ico extension (in Windows) is appended in webpack/package.js.

![daedulus-windows-icon](https://cloud.githubusercontent.com/assets/77286/22540368/a39b8c84-e8d4-11e6-8d0f-035c53f32c6a.png)
