### PR TITLE
[CSL-705] Fix Windows install path (x86/x64)

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -13,7 +13,7 @@ writeNSIS = do
     _ <- constantStr "Version" (str version)
     name "Daedalus $Version"                  -- The name of the installer
     outFile "daedalus-win64-$Version-installer.exe"           -- Where to produce the installer
-    installDir "$PROGRAMFILES\\Daedalus"   -- The default installation directory
+    installDir "$PROGRAMFILES64\\Daedalus"   -- The default installation directory
     installDirRegKey HKLM "Software/Daedalus" "Install_Dir"
     requestExecutionLevel Highest     
 


### PR DESCRIPTION
Daedalus.exe is a 64-bit application and therefore must be installed to
`C:\Program Files` rather than `C:\Program Files (x86)`, as explained in NSIS'
docs: http://nsis.sourceforge.net/Docs/Chapter4.html#varconstant

The change may also fix the Windows Desktop link icon, but that must be
verified.