### PR TITLE
[CSL-531] Use NSIS DSL fork to inject unsupported options

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -49,7 +49,8 @@ writeNSIS = do
     _ <- constantStr "Version" (str version)
     name "Daedalus $Version"                  -- The name of the installer
     outFile "daedalus-win64-$Version-installer.exe"           -- Where to produce the installer
-    -- see ndmitchell/nsis#10
+    injectGlobalLiteral $ "VIProductVersion " <> version
+    -- see ndmitchell/nsis#10 and https://github.com/jmitchell/nsis/tree/feature/escape-hatch
     {- unicode True -}
     injectGlobalLiteral "Unicode true"
     installDir "$PROGRAMFILES64\\Daedalus"   -- The default installation directory

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -49,8 +49,9 @@ writeNSIS = do
     _ <- constantStr "Version" (str version)
     name "Daedalus $Version"                  -- The name of the installer
     outFile "daedalus-win64-$Version-installer.exe"           -- Where to produce the installer
-    -- See enableUnicodeNSIS hack; should eventually be replaced by line below.
+    -- see ndmitchell/nsis#10
     {- unicode True -}
+    injectGlobalLiteral "Unicode true"
     installDir "$PROGRAMFILES64\\Daedalus"   -- The default installation directory
     installDirRegKey HKLM "Software/Daedalus" "Install_Dir"
     requestExecutionLevel Highest
@@ -97,19 +98,9 @@ writeNSIS = do
       delete [] "$DESKTOP\\Daedalus.lnk"
       -- Note: we leave user data alone
 
--- TODO (jmitchell): Monitor https://github.com/ndmitchell/nsis/pull/10 and
--- clean this up once it's merged and deployed. See commented out line above in
--- writeNSIS.
-enableUnicodeNSIS :: IO ()
-enableUnicodeNSIS = do
-  nsiScript <- readFile "daedalus.nsi"
-  appendFile "new-daedalus.nsi" $ "Unicode true\n" ++ nsiScript
-  renameFile "new-daedalus.nsi" "daedalus.nsi"
-
 main :: IO ()
 main = do
   echo "Writing daedalus.nsi"
   writeNSIS
-  enableUnicodeNSIS
   echo "Generating NSIS installer daedalus-win64-installer.exe"
   procs "C:\\Program Files (x86)\\NSIS\\makensis" ["daedalus.nsi"] mempty

--- a/installers/stack.yaml
+++ b/installers/stack.yaml
@@ -3,7 +3,10 @@ flags: {}
 extra-package-dbs: []
 
 packages:
-- '.'
+  - location: .
+  - location:
+      git: https://github.com/jmitchell/nsis.git
+      commit: 0658f28beb62d023655dd285a07fb9e3fdab416b
 
 resolver: lts-7.16
 


### PR DESCRIPTION
Until the ndmitchell/nsis#11 PR (or similar) is merged and published in the NSIS DSL package, we can use [my fork](https://github.com/jmitchell/nsis/tree/feature/escape-hatch) with the `injectLiteral` and `injectGlobalLiteral` functions. They're used in this PR to set `Unicode true` (replacing my earlier ugly hack) and the appropriate `VIProductVersion`.