### PR TITLE
Fix packaging for mac and linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "faker": "^3.1.0",
     "immutability-helper": "^2.0.0",
     "lodash": "^4.17.2",
+    "mkdirp": "^0.5.1",
     "mobx": "^3.1.0",
     "mobx-react": "^4.1.0",
     "mobx-react-form": "^1.18.16",


### PR DESCRIPTION
@domenkozar: Packaged application was not starting on Mac and Linux since there were Windows specific things in `electron/main.development.js`. Also, the directory for cardano-node logs was not created if it does not exist. This PR introduces temporary fix. Please make improvements if needed.