### PR TITLE
fixes small ui glitch on wallet summary

### DIFF
--- a/app/components/wallet/home/WalletNoTransactions.scss
+++ b/app/components/wallet/home/WalletNoTransactions.scss
@@ -1,5 +1,5 @@
 .component {
-  height: calc(100% - 80px);
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/components/wallet/home/WalletTransactionsList.scss
+++ b/app/components/wallet/home/WalletTransactionsList.scss
@@ -2,7 +2,6 @@
 
 .component {
   padding-left: 20px;
-  height: calc(100% - 93px);
   overflow-y: scroll;
 
   &::-webkit-scrollbar-button {

--- a/app/components/wallet/summary/WalletSummary.scss
+++ b/app/components/wallet/summary/WalletSummary.scss
@@ -8,6 +8,7 @@
 }
 
 .component {
+  overflow: visible;
   margin: 20px;
   padding: 20px 30px;
   border-radius: 4px;


### PR DESCRIPTION
Fixes cut-off text in the wallet summary on small window sizes:

**BEFORE:**
![screenshot 2017-02-16 um 16 47 28](https://cloud.githubusercontent.com/assets/172414/23029931/669f25f4-f46c-11e6-900f-3b7a2fb9d74a.png)

**NOW**
![screenshot 2017-02-16 um 17 21 07](https://cloud.githubusercontent.com/assets/172414/23029941/71e08fca-f46c-11e6-8b2e-6a8ae972d782.png)
