### PR TITLE
[daef-59] fixes broken transactions list styles on small window sizes

### DIFF
--- a/app/components/widgets/Transaction.scss
+++ b/app/components/widgets/Transaction.scss
@@ -1,5 +1,7 @@
 @import '../../themes/daedalus/theme';
 
+$type-box-size: 54px;
+
 .component {
   width: 100%;
   display: flex;
@@ -9,8 +11,8 @@
 // ========= TYPE INDICATORS FOR TRANSACTIONS =========
 
 %type-box {
-  width: 54px;
-  height: 54px;
+  width: $type-box-size;
+  height: $type-box-size;
   background: no-repeat center;
   background-size: 30px;
   border-radius: 10px;
@@ -45,8 +47,8 @@
 // ========= DETAILS =========
 
 .content {
-  width: 100%;
-  margin-left: 20px;
+  width: calc(100% - #{$type-box-size});
+  padding-left: 20px;
   border-bottom: 1px solid #dfe4e8;
   padding-bottom: 22px;
   padding-top: 6px;
@@ -68,6 +70,7 @@
   span {
     font-family: $font-light;
     font-size: 14px;
+    word-break: break-all;
   }
 }
 


### PR DESCRIPTION
Before:
<img width="901" alt="screenshot 2017-02-23 um 10 01 57" src="https://cloud.githubusercontent.com/assets/172414/23251914/35948696-f9af-11e6-9f30-6b78f59cc2f6.png">

With this PR:
<img width="902" alt="screenshot 2017-02-23 um 10 02 24" src="https://cloud.githubusercontent.com/assets/172414/23251925/3b66a0c2-f9af-11e6-90f5-ae21dd0c517c.png">

