### PR TITLE
[DAEF-66] show absolute syncing percentage with 2 decimals

### DIFF
--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -64,7 +64,7 @@ export default class Loading extends Component {
         {isSyncing && (
           <div className={styles.syncing}>
             <h1 className={styles.headline}>
-              {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(0)}%
+              {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(2)}%
             </h1>
           </div>
         )}{!isSyncing && !isConnecting && isLoadingWallets && (

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -25,7 +25,7 @@ export default class NetworkStatusStore extends Store {
     return !this.isConnected;
   }
 
-  @computed get syncPercentage(): number {
+  @computed get relativeSyncPercentage(): number {
     if (this.networkDifficulty > 0 && this._localDifficultyStartedWith !== null) {
       const relativeLocal = this.localDifficulty - this._localDifficultyStartedWith;
       const relativeNetwork = this.networkDifficulty - this._localDifficultyStartedWith;
@@ -38,6 +38,14 @@ export default class NetworkStatusStore extends Store {
 
       if (relativeLocal >= relativeNetwork) return 100;
       return relativeLocal / relativeNetwork * 100;
+    }
+    return 0;
+  }
+
+  @computed get syncPercentage(): number {
+    if (this.networkDifficulty > 0) {
+      if (this.localDifficulty >= this.networkDifficulty) return 100;
+      return this.localDifficulty / this.networkDifficulty * 100;
     }
     return 0;
   }


### PR DESCRIPTION
As discussed showing the absolute percent provides better UX since it is confusing that syncing always drops back to `0%` with relative percentages (on app restarts). The 2 decimal points should provide enough fine grained info about sub-percentage loading to remain informative.

<img width="232" alt="screenshot 2017-03-01 um 13 44 21" src="https://cloud.githubusercontent.com/assets/172414/23460336/32d893c2-fe85-11e6-9e7c-1a3a70caa29f.png">
