### PR TITLE
[DAEF-77] Fixes transaction ordering and displays transaction date

### DIFF
--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -55,7 +55,7 @@ export default class WalletTransactionsList extends Component {
       group.transactions.push(transaction);
     }
     for (const group of groups) {
-      group.transactions.sort((a, b) => a.date.getTime() - b.date.getTime());
+      group.transactions.sort((a, b) => b.date.getTime() - a.date.getTime());
     }
     return groups;
   }

--- a/app/components/widgets/Transaction.js
+++ b/app/components/widgets/Transaction.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { defineMessages, intlShape } from 'react-intl';
+import moment from 'moment';
 import classNames from 'classnames';
 import styles from './Transaction.scss';
 import adaSymbol from '../../assets/images/ada-symbol.svg';
@@ -85,14 +86,20 @@ export default class Transaction extends Component {
           {/* ==== Clickable Header -> toggles details ==== */}
 
           <button className={styles.header} onClick={this.toggleDetails.bind(this)}>
-            <div className={styles.title}>{data.type === 'adaExpend' ? 'Ada Sent' : 'Ada Received'}</div>
+            <div className={styles.title}>
+              {data.type === 'adaExpend' ? 'Ada Sent' : 'Ada Received'}
+            </div>
             <div className={styles.amount}>{data.amount}
               <img className={styles.currencySymbol} src={adaSymbol} role="presentation" />
             </div>
           </button>
 
           <div className={styles.details}>
-            <div className={styles.type}>{intl.formatMessage(messages[typeMessage])}</div>
+            <div className={styles.type}>
+              {intl.formatMessage(messages[typeMessage])}
+              , {moment(data.date).format('MMMM Do YYYY, h:mm:ss A')}
+              {/* TODO: Use locale to format the date*/}
+            </div>
             <div className={styles.status}>{status}</div>
           </div>
 

--- a/app/components/widgets/Transaction.js
+++ b/app/components/widgets/Transaction.js
@@ -97,7 +97,7 @@ export default class Transaction extends Component {
           <div className={styles.details}>
             <div className={styles.type}>
               {intl.formatMessage(messages[typeMessage])}
-              , {moment(data.date).format('MMMM Do YYYY, h:mm:ss A')}
+              , {moment(data.date).format('hh:mm:ss A')}
               {/* TODO: Use locale to format the date*/}
             </div>
             <div className={styles.status}>{status}</div>


### PR DESCRIPTION
This PR fixes transaction ordering and introduces transaction time in the transaction list. 

![screen shot 2017-03-07 at 07 03 57](https://cloud.githubusercontent.com/assets/4280521/23643813/41c6dfdc-0304-11e7-81c2-894f39283972.png)

