### PR TITLE
[DAEF-84] Fix button for expanding the sidebar

### DIFF
--- a/app/stores/SidebarStore.js
+++ b/app/stores/SidebarStore.js
@@ -54,7 +54,7 @@ export default class SidebarStore extends Store {
     }
   };
 
-  @action _syncSidebarRouteWithRouter = () => {
+  _syncSidebarRouteWithRouter = () => {
     const route = this.stores.app.currentRoute;
     Object.keys(this.CATEGORIES).forEach((key) => {
       const category = this.CATEGORIES[key];


### PR DESCRIPTION
This PR fixes the button for expanding the sidebar which was not working on initial app launch. 
To verify this fix, launch the app and click on "hamburger" icon to expand the sidebar.