### PR TITLE
Fix/daef 30 redemption overlay should cover wallet nav

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,9 @@
     "no-underscore-dangle": 0,
     "no-console": 0,
     "no-mixed-operators": 0,
-    "prefer-template": 0
+    "prefer-template": 0,
+    "no-unused-vars": 1,
+    "no-trailing-spaces": 1
   },
   "plugins": [
     "flowtype-errors",

--- a/app/assets/images/close-cross-redemption.svg
+++ b/app/assets/images/close-cross-redemption.svg
@@ -1,1 +1,0 @@
-<svg width="22" height="22" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg"><title>12027686-8353-499D-A2D5-DD3BAC5ABDD4</title><path d="M13.967 11L22 19.033 19.033 22 11 13.967 2.967 22 0 19.033 8.033 11 0 2.967 2.967 0 11 8.033 19.033 0 22 2.967z" fill="#5E6066" fill-rule="evenodd"/></svg>

--- a/app/assets/images/close-cross-white.svg
+++ b/app/assets/images/close-cross-white.svg
@@ -1,0 +1,1 @@
+<svg width="22" height="22" viewBox="0 0 22 22" xmlns="http://www.w3.org/2000/svg"><title>B758FE3E-D295-4A3F-8562-ED9DDAA087A0</title><path d="M22 19.033L19.033 22 11 13.967 2.967 22 0 19.033 8.033 11 0 2.967 2.967 0 11 8.033 19.033 0 22 2.967 13.967 11z" fill="#FFF" fill-rule="evenodd" opacity=".6"/></svg>

--- a/app/components/layout/SidebarLayout.js
+++ b/app/components/layout/SidebarLayout.js
@@ -10,12 +10,13 @@ export default class SidebarLayout extends Component {
   static propTypes = {
     children: oneOrManyChildElements,
     sidebar: PropTypes.element.isRequired,
-    notification: PropTypes.element,
     topbar: PropTypes.element.isRequired,
+    notification: PropTypes.element,
+    contentDialog: PropTypes.element,
   };
 
   render() {
-    const { children, sidebar, topbar, notification } = this.props;
+    const { children, sidebar, topbar, notification, contentDialog } = this.props;
     return (
       <div className={styles.component}>
         <div className={styles.sidebar}>
@@ -26,8 +27,11 @@ export default class SidebarLayout extends Component {
             {topbar}
           </div>
           {notification}
-          <div className={styles.content}>
-            {children}
+          <div className={styles.contentWrapper}>
+            <div className={styles.content}>
+              {children}
+            </div>
+            {contentDialog}
           </div>
         </div>
       </div>

--- a/app/components/layout/SidebarLayout.scss
+++ b/app/components/layout/SidebarLayout.scss
@@ -22,8 +22,15 @@ $topBarHeight: 84px;
 .topbar {
   height: $topBarHeight;
   flex-shrink: 0;
+  // Show elements that overflow the topbar above the content area
+  z-index: 1;
 }
 
 .content {
+  height: 100%;
+}
+
+.contentWrapper {
+  position: relative;
   height: calc(100% - #{$topBarHeight});
 }

--- a/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
@@ -5,6 +5,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import DialogCloseButton from '../../widgets/DialogCloseButton';
 import styles from './AdaRedemptionSuccessOverlay.scss';
 import successIcon from '../../../assets/images/success-big.svg';
+import closeCrossWhite from '../../../assets/images/close-cross-white.svg';
 
 const messages = defineMessages({
   headline: {
@@ -36,7 +37,7 @@ export default class AdaRedemptionSuccessOverlay extends Component {
           <h1 className={styles.headline}>{intl.formatMessage(messages.headline)}</h1>
           <div className={styles.amount}>{amount} ADA</div>
         </div>
-        <DialogCloseButton onClose={onClose} />
+        <DialogCloseButton onClose={onClose} icon={closeCrossWhite} />
       </div>
     );
   }

--- a/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.scss
+++ b/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.scss
@@ -1,5 +1,6 @@
 .component {
   position: absolute;
+  top: 0;
   width: 100%;
   height: 100%;
   background-color: rgba(36, 61, 98, 0.88);

--- a/app/components/wallet/layouts/WalletWithNavigation.js
+++ b/app/components/wallet/layouts/WalletWithNavigation.js
@@ -3,12 +3,13 @@ import React, { Component, PropTypes } from 'react';
 import { observer } from 'mobx-react';
 import WalletNavigation from '../navigation/WalletNavigation';
 import styles from './WalletWithNavigation.scss';
+import { oneOrManyChildElements } from '../../../propTypes';
 
 @observer
 export default class WalletWithNavigation extends Component {
 
   static propTypes = {
-    children: PropTypes.element.isRequired,
+    children: oneOrManyChildElements,
     isActiveScreen: PropTypes.func.isRequired,
     onWalletNavItemClick: PropTypes.func
   };

--- a/app/components/widgets/DialogCloseButton.js
+++ b/app/components/widgets/DialogCloseButton.js
@@ -5,14 +5,15 @@ import styles from './DialogCloseButton.scss';
 export default class DialogCloseButton extends Component {
 
   static propTypes = {
-    onClose: PropTypes.func.isRequired
+    onClose: PropTypes.func.isRequired,
+    icon: PropTypes.string,
   };
 
   render() {
-    const { onClose } = this.props;
+    const { onClose, icon } = this.props;
     return (
       <button onClick={onClose} className={styles.component}>
-        <img src={closeCross} role="presentation" />
+        <img src={icon || closeCross} role="presentation" />
       </button>
     );
   }

--- a/app/components/widgets/forms/AdaCertificateUploadWidget.js
+++ b/app/components/widgets/forms/AdaCertificateUploadWidget.js
@@ -6,7 +6,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import certificateNormalIcon from '../../../assets/images/cert-ic.svg';
 import certificateLockedIcon from '../../../assets/images/cert-locked-ic.svg';
 import certificateInvalidIcon from '../../../assets/images/cert-bad-ic.svg';
-import closeCrossIcon from '../../../assets/images/close-cross-redemption.svg';
+import closeCrossIcon from '../../../assets/images/close-cross.svg';
 import styles from './AdaCertificateUploadWidget.scss';
 
 const messages = defineMessages({

--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -91,6 +91,7 @@ export default class MainLayout extends Component {
     const isWalletBackupInProgress = this.props.stores.walletBackup.inProgress;
     const isNodeUpdateAvailable = this.props.stores.nodeUpdate.isUpdateAvailable;
     const isUpdatePostponed = this.props.stores.nodeUpdate.isUpdatePostponed;
+    let activeDialog = null;
 
     const sidebarMenus = {
       wallets: {
@@ -119,44 +120,45 @@ export default class MainLayout extends Component {
         <NodeSyncStatusIcon isSynced={isSynced} syncPercentage={syncPercentage} />
       </TopBar>
     );
-    const addWalletRestoreDialog = wallets.isWalletRestoreDialogOpen ? (
-      <WalletRestoreDialog
-        onSubmit={this.handleRestoreWalletSubmit}
-        onCancel={toggleWalletRestore}
-        error={restoreRequest.error}
-        mnemonicValidator={mnemonic => this.props.stores.wallets.isValidMnemonic(mnemonic)}
-      />
-    ) : null;
-    const addWalletDialog = (
-      wallets.isAddWalletDialogOpen && !isWalletBackupInProgress ? <WalletAddPage /> : null
-    );
-    const createWalletDialog = wallets.isCreateWalletDialogOpen ? (
-      <WalletCreateDialog
-        onSubmit={this.handleAddWalletSubmit}
-        onCancel={toggleCreateWalletDialog}
-      />
-    ) : null;
-    const addWalletBackupDialog = (
-      isWalletBackupInProgress ? <WalletBackupPage /> : null
-    );
+
+    // TODO: Refactor dialogs logic away from the layout
+
+    if (wallets.isWalletRestoreDialogOpen) {
+      activeDialog = (
+        <WalletRestoreDialog
+          onSubmit={this.handleRestoreWalletSubmit}
+          onCancel={toggleWalletRestore}
+          error={restoreRequest.error}
+          mnemonicValidator={mnemonic => this.props.stores.wallets.isValidMnemonic(mnemonic)}
+        />
+      );
+    } else if (wallets.isAddWalletDialogOpen && !isWalletBackupInProgress) {
+      activeDialog = <WalletAddPage />;
+    } else if (wallets.isCreateWalletDialogOpen) {
+      activeDialog = (
+        <WalletCreateDialog
+          onSubmit={this.handleAddWalletSubmit}
+          onCancel={toggleCreateWalletDialog}
+        />
+      );
+    } else if (isWalletBackupInProgress) {
+      activeDialog = <WalletBackupPage />;
+    } else if (isWalletKeyImportDialogOpen) {
+      activeDialog = <WalletKeyImportPage />;
+    }
+
     const addNodeUpdateNotification = (
       isNodeUpdateAvailable && !isUpdatePostponed ? <NodeUpdatePage /> : null
     );
-    const addWalletKeyImportDialog = (
-      isWalletKeyImportDialogOpen ? <WalletKeyImportPage /> : null
-    );
+
     return (
       <SidebarLayout
         sidebar={sidebarComponent}
         topbar={topbar}
         notification={addNodeUpdateNotification}
+        contentDialog={activeDialog}
       >
         {this.props.children}
-        {addWalletDialog}
-        {createWalletDialog}
-        {addWalletRestoreDialog}
-        {addWalletBackupDialog}
-        {addWalletKeyImportDialog}
       </SidebarLayout>
     );
   }

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -60,12 +60,12 @@ export default class Wallet extends Component {
         >
           {this.props.children}
         </WalletWithNavigation>
-        {showAdaRedemptionSuccessMessage && (
+        {showAdaRedemptionSuccessMessage ? (
           <AdaRedemptionSuccessOverlay
             amount={amountRedeemed}
             onClose={actions.adaRedemption.closeAdaRedemptionSuccessOverlay}
           />
-        )}
+        ) : null}
       </MainLayout>
     );
   }

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -1,10 +1,12 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
 import { observer, inject } from 'mobx-react';
-import Layout from '../MainLayout';
+import MainLayout from '../MainLayout';
 import WalletWithNavigation from '../../components/wallet/layouts/WalletWithNavigation';
 import LoadingSpinner from '../../components/widgets/LoadingSpinner';
 import { oneOrManyChildElements } from '../../propTypes';
+import AdaRedemptionSuccessOverlay from '../../components/wallet/ada-redemption/AdaRedemptionSuccessOverlay';
+
 
 @inject('stores', 'actions') @observer
 export default class Wallet extends Component {
@@ -17,10 +19,17 @@ export default class Wallet extends Component {
       wallets: PropTypes.shape({
         hasLoadedWallets: PropTypes.bool.isRequired
       }).isRequired,
+      adaRedemption: PropTypes.shape({
+        showAdaRedemptionSuccessMessage: PropTypes.bool.isRequired,
+        amountRedeemed: PropTypes.number.isRequired,
+      }),
     }).isRequired,
     actions: PropTypes.shape({
       router: PropTypes.shape({
         goToRoute: PropTypes.func.isRequired,
+      }),
+      adaRedemption: PropTypes.shape({
+        closeAdaRedemptionSuccessOverlay: PropTypes.func.isRequired,
       }),
     }).isRequired,
     children: oneOrManyChildElements,
@@ -39,17 +48,25 @@ export default class Wallet extends Component {
   };
 
   render() {
-    const { wallets } = this.props.stores;
-    if (!wallets.active) return <Layout><LoadingSpinner /></Layout>;
+    const { wallets, adaRedemption } = this.props.stores;
+    const { actions } = this.props;
+    const { showAdaRedemptionSuccessMessage, amountRedeemed } = adaRedemption;
+    if (!wallets.active) return <MainLayout><LoadingSpinner /></MainLayout>;
     return (
-      <Layout>
+      <MainLayout>
         <WalletWithNavigation
           isActiveScreen={this.isActiveScreen}
           onWalletNavItemClick={this.handleWalletNavItemClick}
         >
           {this.props.children}
         </WalletWithNavigation>
-      </Layout>
+        {showAdaRedemptionSuccessMessage && (
+          <AdaRedemptionSuccessOverlay
+            amount={amountRedeemed}
+            onClose={actions.adaRedemption.closeAdaRedemptionSuccessOverlay}
+          />
+        )}
+      </MainLayout>
     );
   }
 }

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -8,7 +8,6 @@ import WalletSummary from '../../components/wallet/summary/WalletSummary';
 import WalletNoTransactions from '../../components/wallet/transactions/WalletNoTransactions';
 import VerticalFlexContainer from '../../components/layout/VerticalFlexContainer';
 import Request from '../../stores/lib/Request';
-import AdaRedemptionSuccessOverlay from '../../components/wallet/ada-redemption/AdaRedemptionSuccessOverlay';
 
 const messages = defineMessages({
   noTransactions: {
@@ -33,15 +32,6 @@ export default class WalletSummaryPage extends Component {
         totalUnconfirmedAmount: PropTypes.number.isRequired,
         recentTransactionsRequest: PropTypes.instanceOf(Request),
       }),
-      adaRedemption: PropTypes.shape({
-        showAdaRedemptionSuccessMessage: PropTypes.bool.isRequired,
-        amountRedeemed: PropTypes.number.isRequired,
-      }),
-    }).isRequired,
-    actions: PropTypes.shape({
-      adaRedemption: PropTypes.shape({
-        closeAdaRedemptionSuccessOverlay: PropTypes.func.isRequired,
-      }),
     }).isRequired,
   };
 
@@ -51,8 +41,7 @@ export default class WalletSummaryPage extends Component {
 
   render() {
     const { intl } = this.context;
-    const actions = this.props.actions;
-    const { wallets, transactions, adaRedemption } = this.props.stores;
+    const { wallets, transactions } = this.props.stores;
     const {
       hasAny,
       totalAvailable,
@@ -61,8 +50,6 @@ export default class WalletSummaryPage extends Component {
       totalUnconfirmedAmount
     } = transactions;
     const wallet = wallets.active;
-    const { showAdaRedemptionSuccessMessage, amountRedeemed } = adaRedemption;
-    let adaRedemptionSuccessMessage = null;
     let walletTransactions = null;
     const noTransactionsLabel = intl.formatMessage(messages.noTransactions);
 
@@ -79,15 +66,6 @@ export default class WalletSummaryPage extends Component {
       walletTransactions = <WalletNoTransactions label={noTransactionsLabel} />;
     }
 
-    if (showAdaRedemptionSuccessMessage) {
-      adaRedemptionSuccessMessage = (
-        <AdaRedemptionSuccessOverlay
-          amount={amountRedeemed}
-          onClose={actions.adaRedemption.closeAdaRedemptionSuccessOverlay}
-        />
-      );
-    }
-
     return (
       <VerticalFlexContainer>
         <WalletSummary
@@ -98,7 +76,6 @@ export default class WalletSummaryPage extends Component {
           isLoadingTransactions={recentTransactionsRequest.isExecutingFirstTime}
         />
         {walletTransactions}
-        {adaRedemptionSuccessMessage}
       </VerticalFlexContainer>
     );
   }

--- a/app/stores/AdaRedemptionStore.js
+++ b/app/stores/AdaRedemptionStore.js
@@ -26,7 +26,7 @@ export default class AdaRedemptionStore extends Store {
   @observable walletId: ?string = null;
   @observable error: ?LocalizableError = null;
   @observable amountRedeemed: number = 0;
-  @observable showAdaRedemptionSuccessMessage: bool = false;
+  @observable showAdaRedemptionSuccessMessage: boolean = false;
   @observable redeemAdaRequest = new Request(this.api, 'redeemAda');
 
   setup() {


### PR DESCRIPTION
This PR fixes the incorrect implementation of the ada redemption overlay (it did only cover the content area and not the wallet navigation -> [see design specs](https://app.zeplin.io/project.html#pid=57acfaa7436a750316161a8b&sid=58920589f2b3164f5b7a7996))

**BEFORE**
<img width="902" alt="screenshot 2017-03-27 um 18 06 37" src="https://cloud.githubusercontent.com/assets/172414/24366387/4b0a0b76-1319-11e7-8bdc-395030f7fcec.png">

**AFTER**
<img width="901" alt="screenshot 2017-03-27 um 18 05 58" src="https://cloud.githubusercontent.com/assets/172414/24366392/4f170ff2-1319-11e7-8508-d7035b759be2.png">
