### PR TITLE
[daef-57] add wallet deletion feature

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "promise/no-native": 0,
     "react/jsx-no-bind": "off",
     "react/jsx-filename-extension": ["error", { "extensions": [".js", ".jsx"] }],
+    "react/jsx-closing-bracket-location": 1,
     "react/prefer-stateless-function": "off",
     "react/no-unused-prop-types": [1, { "skipShapeProps": true }],
     "flowtype-errors/show-errors": 2,
@@ -35,7 +36,12 @@
     "no-mixed-operators": 0,
     "prefer-template": 0,
     "no-unused-vars": 1,
-    "no-trailing-spaces": 1
+    "no-trailing-spaces": 1,
+    "padded-blocks": 1,
+    "no-undef": 1,
+    "arrow-body-style": 1,
+    "key-spacing": 1,
+    "no-empty-function": 1
   },
   "plugins": [
     "flowtype-errors",

--- a/app/actions/dialogs-actions.js
+++ b/app/actions/dialogs-actions.js
@@ -1,0 +1,12 @@
+import PropTypes from 'prop-types';
+import defineActions from './lib/actions';
+
+export default defineActions({
+  open: {
+    dialog: PropTypes.func.isRequired,
+  },
+  close: {},
+  updateDataForActiveDialog: {
+    data: PropTypes.object.isRequired,
+  }
+});

--- a/app/actions/dialogs-actions.js
+++ b/app/actions/dialogs-actions.js
@@ -5,8 +5,9 @@ export default defineActions({
   open: {
     dialog: PropTypes.func.isRequired,
   },
-  close: {},
+  closeActiveDialog: {},
   updateDataForActiveDialog: {
     data: PropTypes.object.isRequired,
-  }
+  },
+  resetActiveDialog: {}
 });

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -8,6 +8,7 @@ import sidebarActions from './sidebar-actions';
 import windowActions from './window-actions';
 import networkStatusActions from './network-status-actions';
 import profileActions from './profile-actions';
+import dialogsActions from './dialogs-actions';
 
 export default {
   router: routerActions,
@@ -20,4 +21,5 @@ export default {
   window: windowActions,
   networkStatus: networkStatusActions,
   profile: profileActions,
+  dialogs: dialogsActions,
 };

--- a/app/actions/wallets-actions.js
+++ b/app/actions/wallets-actions.js
@@ -6,6 +6,9 @@ export default defineActions({
     name: PropTypes.string.isRequired,
     currency: PropTypes.string.isRequired,
   },
+  delete: {
+    walletId: PropTypes.string.isRequired,
+  },
   toggleCreateWalletDialog: {},
   toggleAddWallet: {},
   toggleWalletRestore: {},
@@ -25,4 +28,5 @@ export default defineActions({
     walletId: PropTypes.string.isRequired,
   },
   showWalletAddressCopyNotification: {},
+
 });

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -10,7 +10,8 @@ import type {
   createTransactionRequest,
   walletRestoreRequest,
   redeemAdaRequest,
-  importKeyRequest
+  importKeyRequest,
+  deleteWalletRequest
 } from './index';
 import {
   // ApiMethodNotYetImplementedError,
@@ -73,6 +74,15 @@ export default class CardanoClientApi {
     console.debug('CardanoClientApi::createWallet called with', request);
     const response = await ClientApi.newWallet('CWTPersonal', 'ADA', request.name, request.mnemonic);
     return this._createWalletFromServerData(response);
+  }
+
+  async deleteWallet(request: deleteWalletRequest) {
+    try {
+      await ClientApi.deleteWallet(request.walletId);
+      return true;
+    } catch (error) {
+      throw new GenericApiError();
+    }
   }
 
   async createTransaction(request: createTransactionRequest) {

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -46,6 +46,10 @@ export type createWalletRequest = {
   mnemonic: string,
 };
 
+export type deleteWalletRequest = {
+  walletId: string,
+};
+
 export type createTransactionRequest = {
   walletId: string,
   sender: string,

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -1,20 +1,39 @@
 // @flow
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { observer } from 'mobx-react';
 import styles from './WalletSettings.scss';
+import DeleteWalletButton from './settings/DeleteWalletButton';
+import DeleteWalletConfirmationDialog from './settings/DeleteWalletConfirmationDialog';
+import DeleteWalletDialogContainer from '../../containers/wallet/dialogs/DeleteWalletDialogContainer';
 
 @observer
 export default class WalletSettings extends Component {
 
+  static propTypes = {
+    openDialogAction: PropTypes.func.isRequired,
+    isDialogOpen: PropTypes.func.isRequired,
+  };
+
   render() {
+    const { openDialogAction, isDialogOpen } = this.props;
     return (
       <div className={styles.component}>
 
         <div className={styles.borderedBox}>
 
-          <p>Settings page</p>
+          <div className={styles.deleteWalletButton}>
+            <DeleteWalletButton
+              onClick={() => openDialogAction({
+                dialog: DeleteWalletConfirmationDialog,
+              })}
+            />
+          </div>
 
         </div>
+
+        {isDialogOpen(DeleteWalletConfirmationDialog) ? (
+          <DeleteWalletDialogContainer />
+        ) : null}
 
       </div>
     );

--- a/app/components/wallet/WalletSettings.scss
+++ b/app/components/wallet/WalletSettings.scss
@@ -16,5 +16,5 @@
 .deleteWalletButton {
   display: flex;
   justify-content: center;
-  margin: 30px 0 10px 0;
+  margin: 30px 0 10px;
 }

--- a/app/components/wallet/WalletSettings.scss
+++ b/app/components/wallet/WalletSettings.scss
@@ -12,3 +12,9 @@
   margin: 20px;
   padding: 20px 30px;
 }
+
+.deleteWalletButton {
+  display: flex;
+  justify-content: center;
+  margin: 30px 0 10px 0;
+}

--- a/app/components/wallet/settings/DeleteWalletButton.js
+++ b/app/components/wallet/settings/DeleteWalletButton.js
@@ -1,0 +1,31 @@
+import React, { Component, PropTypes } from 'react';
+import { defineMessages, intlShape } from 'react-intl';
+import styles from './DeleteWalletButton.scss';
+
+const messages = defineMessages({
+  label: {
+    id: 'wallet.settings.deleteWalletButtonLabel',
+    defaultMessage: '!!!Delete wallet',
+    description: 'Label for the delete button on wallet settings',
+  },
+});
+
+export default class DeleteWalletButton extends Component {
+
+  static propTypes = {
+    onClick: PropTypes.func
+  };
+
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  render() {
+    const { onClick } = this.props;
+    return (
+      <button onClick={onClick} className={styles.button}>
+        {this.context.intl.formatMessage(messages.label)}
+      </button>
+    );
+  }
+}

--- a/app/components/wallet/settings/DeleteWalletButton.scss
+++ b/app/components/wallet/settings/DeleteWalletButton.scss
@@ -1,5 +1,5 @@
 .button {
-  color: #ea4c5b;
+  color: $color-light-red;
   font-family: $font-medium;
   font-size: 16px;
   &:hover {

--- a/app/components/wallet/settings/DeleteWalletButton.scss
+++ b/app/components/wallet/settings/DeleteWalletButton.scss
@@ -1,0 +1,8 @@
+.button {
+  color: #ea4c5b;
+  font-family: $font-medium;
+  font-size: 16px;
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
@@ -1,0 +1,125 @@
+// @flow
+import React, { Component, PropTypes } from 'react';
+import { observer } from 'mobx-react';
+import Dialog from 'react-toolbox/lib/dialog/Dialog';
+import Input from 'react-toolbox/lib/input/Input';
+import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
+import DialogCloseButton from '../../widgets/DialogCloseButton';
+import CheckboxWithLongLabel from '../../widgets/forms/CheckboxWithLongLabel';
+import styles from './DeleteWalletConfirmationDialog.scss';
+import globalMessages from '../../../i18n/global-messages';
+
+const messages = defineMessages({
+  dialogTitle: {
+    id: 'wallet.settings.delete.dialog.title',
+    defaultMessage: '!!!Delete Wallet',
+    description: 'Title for the "Delete wallet" dialog.'
+  },
+  confirmButtonLabel: {
+    id: 'wallet.settings.delete.dialog.confirmButtonLabel',
+    defaultMessage: '!!!Delete',
+    description: 'Label for the "Delete (x)" button in the delete wallet dialog.',
+  },
+  wantToDeleteWalletQuestion: {
+    id: 'wallet.settings.delete.dialog.wantToDeleteWalletQuestion',
+    defaultMessage: '!!!Do you really want to delete <strong>{walletName}</strong> wallet?',
+    description: 'Question if the user really wants to delete the wallet.',
+  },
+  confirmBackupNotice: {
+    id: 'wallet.settings.delete.dialog.confirmBackupNotice',
+    defaultMessage: '!!!Make sure you have access to backup before continue. Otherwise you will lose all your funds connected to this wallet.',
+    description: 'Notice to confirm if the user has made a backup of his wallet',
+  },
+  enterRecoveryWordLabel: {
+    id: 'wallet.settings.delete.dialog.enterRecoveryWordLabel',
+    defaultMessage: '!!!Enter the name of the wallet to confirm deletion:',
+    description: 'Instruction for recovery word on delete wallet dialog',
+  }
+});
+
+@observer
+export default class DeleteWalletConfirmationDialog extends Component {
+
+  static propTypes = {
+    walletName: PropTypes.string.isRequired,
+    countdownFn: PropTypes.func.isRequired,
+    isBackupNoticeAccepted: PropTypes.bool.isRequired,
+    confirmationValue: PropTypes.string,
+    onAcceptBackupNotice: PropTypes.func,
+    onContinue: PropTypes.func,
+    onCancel: PropTypes.func,
+    onConfirmationValueChange: PropTypes.func,
+  };
+
+  static defaultProps = {
+    isBackupNoticeAccepted: false,
+    confirmationValue: '',
+  };
+
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  render() {
+    const { intl } = this.context;
+    const {
+      countdownFn,
+      isBackupNoticeAccepted,
+      onAcceptBackupNotice,
+      onCancel,
+      onContinue,
+      walletName,
+      confirmationValue,
+      onConfirmationValueChange
+    } = this.props;
+
+    const countdownRemaining = countdownFn(10);
+    const countdownDisplay = countdownRemaining > 0 ? ` (${countdownRemaining})` : '';
+    const isCountdownFinished = countdownRemaining <= 0;
+    const isWalletNameConfirmationCorrect = confirmationValue === walletName;
+
+    const actions = [
+      {
+        label: intl.formatMessage(globalMessages.cancel),
+        onClick: onCancel,
+      },
+      {
+        label: intl.formatMessage(messages.confirmButtonLabel) + countdownDisplay,
+        onClick: onContinue,
+        disabled: (
+          !isCountdownFinished || !isBackupNoticeAccepted || !isWalletNameConfirmationCorrect
+        ),
+        primary: true
+      },
+    ];
+
+    return (
+      <Dialog
+        title={intl.formatMessage(messages.dialogTitle)}
+        actions={actions}
+        active
+        className={styles.dialog}
+      >
+        <FormattedHTMLMessage
+          {...messages.wantToDeleteWalletQuestion}
+          values={{ walletName }}
+        />
+        <CheckboxWithLongLabel
+          label={intl.formatMessage(messages.confirmBackupNotice)}
+          onChange={onAcceptBackupNotice}
+          checked={isBackupNoticeAccepted}
+        />
+        {isBackupNoticeAccepted ? (
+          <Input
+            className={styles.confirmationInput}
+            label={intl.formatMessage(messages.enterRecoveryWordLabel)}
+            value={confirmationValue}
+            onChange={onConfirmationValueChange}
+          />
+        ) : null}
+        <DialogCloseButton onClose={onCancel} />
+      </Dialog>
+    );
+  }
+
+}

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
@@ -27,7 +27,7 @@ const messages = defineMessages({
   },
   confirmBackupNotice: {
     id: 'wallet.settings.delete.dialog.confirmBackupNotice',
-    defaultMessage: '!!!Make sure you have access to backup before continue. Otherwise you will lose all your funds connected to this wallet.',
+    defaultMessage: '!!!Make sure you have access to backup before continuing. Otherwise, you will lose all your funds connected to this wallet.',
     description: 'Notice to confirm if the user has made a backup of his wallet',
   },
   enterRecoveryWordLabel: {

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -1,0 +1,26 @@
+.dialog {
+  font-family: $font-light;
+
+  :global .button_flat.button_primary {
+
+    background: #ea4c5b;
+
+    &[disabled] {
+      opacity: 0.3;
+    }
+
+    &:not([disabled]) {
+      &:hover {
+        background: #ec5d6b;
+      }
+      &:active {
+        background: #d34452;
+      }
+    }
+  }
+}
+
+.confirmationInput {
+  margin-top: 30px;
+  padding-bottom: 0 !important;
+}

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -6,6 +6,7 @@
     .checkbox_check {
       border-color: #ea4c5b;
       &.checkbox_checked {
+        border-color: #ea4c5b;
         background: #ea4c5b;
       }
     }

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -31,5 +31,4 @@
 
 .confirmationInput {
   margin-top: 30px;
-  padding-bottom: 0 !important;
 }

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -1,20 +1,31 @@
 .dialog {
   font-family: $font-light;
 
-  :global .button_flat.button_primary {
+  :global {
 
-    background: #ea4c5b;
-
-    &[disabled] {
-      opacity: 0.3;
+    .checkbox_check {
+      border-color: #ea4c5b;
+      &.checkbox_checked {
+        background: #ea4c5b;
+      }
     }
 
-    &:not([disabled]) {
-      &:hover {
-        background: #ec5d6b;
+
+
+    .button_flat.button_primary {
+      background: #ea4c5b;
+
+      &[disabled] {
+        opacity: 0.3;
       }
-      &:active {
-        background: #d34452;
+
+      &:not([disabled]) {
+        &:hover {
+          background: #ec5d6b;
+        }
+        &:active {
+          background: #d34452;
+        }
       }
     }
   }

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -2,19 +2,16 @@
   font-family: $font-light;
 
   :global {
-
     .checkbox_check {
-      border-color: #ea4c5b;
+      border-color: $color-light-red;
       &.checkbox_checked {
-        border-color: #ea4c5b;
-        background: #ea4c5b;
+        background: $color-light-red;
+        border-color: $color-light-red;
       }
     }
 
-
-
     .button_flat.button_primary {
-      background: #ea4c5b;
+      background: $color-light-red;
 
       &[disabled] {
         opacity: 0.3;
@@ -22,10 +19,10 @@
 
       &:not([disabled]) {
         &:hover {
-          background: #ec5d6b;
+          background: $color-lighter-red;
         }
         &:active {
-          background: #d34452;
+          background: $color-dark-red;
         }
       }
     }

--- a/app/components/widgets/forms/CheckboxWithLongLabel.scss
+++ b/app/components/widgets/forms/CheckboxWithLongLabel.scss
@@ -17,7 +17,7 @@
 .checkboxLabel {
   font-family: $font-light;
   font-size: 16px;
-  color: #5e6066;
+  color: $theme-label-color;
   white-space: normal;
   line-height: 1.38;
   strong {

--- a/app/components/widgets/forms/CheckboxWithLongLabel.scss
+++ b/app/components/widgets/forms/CheckboxWithLongLabel.scss
@@ -1,14 +1,20 @@
 .component {
   display: flex;
+  padding-top: 30px;
 }
 
 .checkbox {
   flex-basis: 40px;
   flex-shrink: 0;
+  align-self: center;
+
+  :global .checkbox_field {
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .checkboxLabel {
-  margin-top: 30px;
   font-family: $font-light;
   font-size: 16px;
   color: #5e6066;

--- a/app/containers/wallet/WalletSettingsPage.js
+++ b/app/containers/wallet/WalletSettingsPage.js
@@ -1,14 +1,31 @@
 // @flow
-import React, { Component } from 'react';
-import { observer } from 'mobx-react';
+import React, { Component, PropTypes } from 'react';
+import { inject, observer } from 'mobx-react';
 import WalletSettings from '../../components/wallet/WalletSettings';
+import UiDialogsStore from '../../stores/UIDialogsStore';
 
-@observer
+@inject('actions', 'stores') @observer
 export default class WalletSettingsPage extends Component {
 
+  static propTypes = {
+    stores: PropTypes.shape({
+      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
+    }).isRequired,
+    actions: PropTypes.shape({
+      dialogs: PropTypes.shape({
+        open: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+  };
+
   render() {
+    const { actions } = this.props;
+    const { uiDialogs } = this.props.stores;
     return (
-      <WalletSettings />
+      <WalletSettings
+        openDialogAction={actions.dialogs.open}
+        isDialogOpen={uiDialogs.isOpen}
+      />
     );
   }
 

--- a/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
@@ -1,0 +1,52 @@
+// @flow
+import React, { Component, PropTypes } from 'react';
+import { inject, observer } from 'mobx-react';
+import UiDialogsStore from '../../../stores/UIDialogsStore';
+import WalletsStore from '../../../stores/WalletsStore';
+import DeleteWalletConfirmationDialog from '../../../components/wallet/settings/DeleteWalletConfirmationDialog';
+
+@inject('actions', 'stores') @observer
+export default class DeleteWalletDialogContainer extends Component {
+
+  static propTypes = {
+    stores: PropTypes.shape({
+      wallets: PropTypes.instanceOf(WalletsStore).isRequired,
+      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
+    }).isRequired,
+    actions: PropTypes.shape({
+      dialogs: PropTypes.shape({
+        open: PropTypes.func.isRequired,
+        close: PropTypes.func.isRequired,
+        updateDataForActiveDialog: PropTypes.func.isRequired,
+      }).isRequired,
+      wallets: PropTypes.shape({
+        delete: PropTypes.func.isRequired,
+      }).isRequired,
+    }).isRequired,
+  };
+
+  render() {
+    const { actions } = this.props;
+    const { wallets, uiDialogs } = this.props.stores;
+    const dialogData = uiDialogs.dataForActiveDialog;
+    const { updateDataForActiveDialog } = actions.dialogs;
+    return (
+      <DeleteWalletConfirmationDialog
+        walletName={wallets.active.name}
+        hasWalletFunds={wallets.active.hasFunds}
+        countdownFn={uiDialogs.countdownSinceDialogOpened}
+        isBackupNoticeAccepted={dialogData.isBackupNoticeAccepted}
+        onAcceptBackupNotice={() => updateDataForActiveDialog({
+          data: { isBackupNoticeAccepted: true }
+        })}
+        onContinue={() => actions.wallets.delete({ walletId: wallets.active.id })}
+        onCancel={actions.dialogs.close}
+        confirmationValue={dialogData.confirmationValue}
+        onConfirmationValueChange={confirmationValue => updateDataForActiveDialog({
+          data: { confirmationValue }
+        })}
+      />
+    );
+  }
+
+}

--- a/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
@@ -16,7 +16,8 @@ export default class DeleteWalletDialogContainer extends Component {
     actions: PropTypes.shape({
       dialogs: PropTypes.shape({
         open: PropTypes.func.isRequired,
-        close: PropTypes.func.isRequired,
+        closeActiveDialog: PropTypes.func.isRequired,
+        resetActiveDialog: PropTypes.func.isRequired,
         updateDataForActiveDialog: PropTypes.func.isRequired,
       }).isRequired,
       wallets: PropTypes.shape({
@@ -39,8 +40,11 @@ export default class DeleteWalletDialogContainer extends Component {
         onAcceptBackupNotice={() => updateDataForActiveDialog({
           data: { isBackupNoticeAccepted: true }
         })}
-        onContinue={() => actions.wallets.delete({ walletId: wallets.active.id })}
-        onCancel={actions.dialogs.close}
+        onContinue={() => {
+          actions.wallets.delete({ walletId: wallets.active.id });
+          actions.dialogs.resetActiveDialog();
+        }}
+        onCancel={actions.dialogs.closeActiveDialog}
         confirmationValue={dialogData.confirmationValue}
         onConfirmationValueChange={confirmationValue => updateDataForActiveDialog({
           data: { confirmationValue }

--- a/app/domain/Wallet.js
+++ b/app/domain/Wallet.js
@@ -1,5 +1,5 @@
 // @flow
-import { observable, action } from 'mobx';
+import { observable, action, computed } from 'mobx';
 import WalletTransaction from './WalletTransaction';
 
 export default class Wallet {
@@ -25,6 +25,10 @@ export default class Wallet {
 
   @action addTransaction(transaction: WalletTransaction) {
     this.transactions.push(transaction);
+  }
+
+  @computed get hasFunds(): boolean {
+    return this.amount > 0;
   }
 
 }

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -11,6 +11,11 @@ export default defineMessages({
     defaultMessage: '!!!The wallet name must have at least 3 letters.',
     description: 'Error message shown when invalid wallet name was entered in create wallet dialog.'
   },
+  cancel: {
+    id: 'global.labels.cancel',
+    defaultMessage: '!!!Cancel',
+    description: 'The word "cancel" reused at several places (like cancel buttons)',
+  },
   invalidMnemonic: {
     id: 'global.errors.invalidMnemonic',
     defaultMessage: '!!!Invalid phrase entered, please check.',

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -13,6 +13,7 @@
   "global.errors.fieldIsRequired": "This field is required.",
   "global.errors.invalidMnemonic": "Invalid phrase entered, please check.",
   "global.errors.invalidWalletName": "Requires at least 3 letters.",
+  "global.labels.cancel": "Cancel",
   "global.language.chinese": "Chinese",
   "global.language.croatian": "Croatian",
   "global.language.english": "English",
@@ -117,5 +118,11 @@
   "wallet.transaction.type.card": "Card Payment",
   "wallet.transaction.type.exchange": "Exchange Transaction",
   "wallet.transactions.no.transactions": "No transactions",
-  "wallet.transactions.no.transactions.found": "No transactions found"
+  "wallet.transactions.no.transactions.found": "No transactions found",
+  "wallet.settings.deleteWalletButtonLabel": "Delete wallet",
+  "wallet.settings.delete.dialog.title": "Delete wallet",
+  "wallet.settings.delete.dialog.confirmButtonLabel": "Delete",
+  "wallet.settings.delete.dialog.wantToDeleteWalletQuestion": "Do you really want to delete <strong>{walletName}</strong> wallet?",
+  "wallet.settings.delete.dialog.confirmBackupNotice": "Make sure you have access to backup before continue. Otherwise you will lose all your funds connected to this wallet.",
+  "wallet.settings.delete.dialog.enterRecoveryWordLabel": "Enter the name of the wallet to confirm deletion:"
 }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -123,6 +123,6 @@
   "wallet.settings.delete.dialog.title": "Delete wallet",
   "wallet.settings.delete.dialog.confirmButtonLabel": "Delete",
   "wallet.settings.delete.dialog.wantToDeleteWalletQuestion": "Do you really want to delete <strong>{walletName}</strong> wallet?",
-  "wallet.settings.delete.dialog.confirmBackupNotice": "Make sure you have access to backup before continue. Otherwise you will lose all your funds connected to this wallet.",
+  "wallet.settings.delete.dialog.confirmBackupNotice": "Make sure you have access to backup before continuing. Otherwise, you will lose all your funds connected to this wallet.",
   "wallet.settings.delete.dialog.enterRecoveryWordLabel": "Enter the name of the wallet to confirm deletion:"
 }

--- a/app/stores/UIDialogsStore.js
+++ b/app/stores/UIDialogsStore.js
@@ -1,0 +1,52 @@
+// @flow
+import { observable, action } from 'mobx';
+import Store from './lib/Store';
+
+export default class UIDialogsStore extends Store {
+
+  @observable activeDialog: ?Function = null;
+  @observable secondsSinceActiveDialogIsOpen: number = 0;
+  @observable dataForActiveDialog: Object = {};
+
+  _secondsTimerInterval: ?number = null;
+
+  setup() {
+    this.actions.dialogs.open.listen(this._onOpen);
+    this.actions.dialogs.close.listen(this._onClose);
+    this.actions.dialogs.updateDataForActiveDialog.listen(this._onUpdateDataForActiveDialog);
+  }
+
+  isOpen = (dialog: Function): boolean => this.activeDialog === dialog;
+
+  countdownSinceDialogOpened = (countDownTo: number) => (
+    Math.max(countDownTo - this.secondsSinceActiveDialogIsOpen, 0)
+  );
+
+  @action _onOpen = ({ dialog } : { dialog : Function }) => {
+    this._reset();
+    this.activeDialog = dialog;
+    this.dataForActiveDialog = observable(dialog.defaultProps);
+    this.secondsSinceActiveDialogIsOpen = 0;
+    if (this._secondsTimerInterval) clearInterval(this._secondsTimerInterval);
+    this._secondsTimerInterval = setInterval(this._updateSeconds, 1000);
+  };
+
+  @action _onClose = () => {
+    this._reset();
+  };
+
+  @action _updateSeconds = () => {
+    this.secondsSinceActiveDialogIsOpen += 1;
+  };
+
+  @action _onUpdateDataForActiveDialog = ({ data } : { data: Object }) => {
+    Object.assign(this.dataForActiveDialog, data);
+  };
+
+  @action _reset = () => {
+    this.activeDialog = null;
+    this.secondsSinceActiveDialogIsOpen = 0;
+    this.dataForActiveDialog = {};
+  };
+
+}

--- a/app/stores/UIDialogsStore.js
+++ b/app/stores/UIDialogsStore.js
@@ -12,7 +12,8 @@ export default class UIDialogsStore extends Store {
 
   setup() {
     this.actions.dialogs.open.listen(this._onOpen);
-    this.actions.dialogs.close.listen(this._onClose);
+    this.actions.dialogs.closeActiveDialog.listen(this._onClose);
+    this.actions.dialogs.resetActiveDialog.listen(this._reset);
     this.actions.dialogs.updateDataForActiveDialog.listen(this._onUpdateDataForActiveDialog);
   }
 

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -18,6 +18,7 @@ export default class WalletsStore extends Store {
   @observable walletsRequest = new CachedRequest(this.api, 'getWallets');
   @observable importFromKeyRequest = new Request(this.api, 'importWalletFromKey');
   @observable createWalletRequest = new Request(this.api, 'createWallet');
+  @observable deleteWalletRequest = new Request(this.api, 'deleteWallet');
   @observable sendMoneyRequest = new Request(this.api, 'createTransaction');
   @observable getWalletRecoveryPhraseRequest = new Request(this.api, 'getWalletRecoveryPhrase');
   @observable restoreRequest = new Request(this.api, 'restoreWallet');
@@ -39,6 +40,7 @@ export default class WalletsStore extends Store {
   setup() {
     const { wallets, walletBackup } = this.actions;
     wallets.create.listen(this._create);
+    wallets.delete.listen(this._delete);
     wallets.sendMoney.listen(this._sendMoney);
     wallets.toggleAddWallet.listen(this._toggleAddWallet);
     wallets.toggleCreateWalletDialog.listen(this._toggleCreateWalletDialog);
@@ -69,6 +71,14 @@ export default class WalletsStore extends Store {
     } catch (error) {
       throw error;
     }
+  };
+
+  _delete = async (params: { walletId: string }) => {
+    await this.deleteWalletRequest.execute({ walletId: params.walletId });
+    this.refreshWalletsData();
+    runInAction(() => {
+      this.active = null;
+    });
   };
 
   _finishWalletCreation = async () => {
@@ -269,9 +279,9 @@ export default class WalletsStore extends Store {
 
   @action _hideWalletAddressCopyNotification = () => {
     this.isWalletAddressCopyNotificationVisible = false;
-  }
+  };
 
-  _onShowWalletAddressCopyNotification = action(() => {
+  @action _onShowWalletAddressCopyNotification = () => {
     if (this._hideWalletAddressCopyNotificationTimeout) {
       clearTimeout(this._hideWalletAddressCopyNotificationTimeout);
     }
@@ -280,6 +290,6 @@ export default class WalletsStore extends Store {
       config.wallets.ADDRESS_COPY_NOTIFICATION_DURATION
     );
     this.isWalletAddressCopyNotificationVisible = true;
-  });
+  };
 
 }

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -78,13 +78,18 @@ export default class WalletsStore extends Store {
     if (!walletToDelete) return;
     const indexOfWalletToDelete = this.all.indexOf(walletToDelete);
     await this.deleteWalletRequest.execute({ walletId: params.walletId });
+    await this.walletsRequest.patch(result => {
+      result.splice(indexOfWalletToDelete, 1);
+    });
     runInAction(() => {
       if (this.hasAnyWallets) {
         const nextIndexInList = Math.max(indexOfWalletToDelete - 1, 0);
         const nextWalletInList = this.all[nextIndexInList];
         this.goToWalletRoute(nextWalletInList.id);
       } else {
+        console.log('NO WALLETS');
         this.active = null;
+        this.actions.router.goToRoute({ route: '/no-wallets' });
       }
     });
     this.refreshWalletsData();

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -74,11 +74,20 @@ export default class WalletsStore extends Store {
   };
 
   _delete = async (params: { walletId: string }) => {
+    const walletToDelete = this.getWalletById(params.walletId);
+    if (!walletToDelete) return;
+    const indexOfWalletToDelete = this.all.indexOf(walletToDelete);
     await this.deleteWalletRequest.execute({ walletId: params.walletId });
-    this.refreshWalletsData();
     runInAction(() => {
-      this.active = null;
+      if (this.hasAnyWallets) {
+        const nextIndexInList = Math.max(indexOfWalletToDelete - 1, 0);
+        const nextWalletInList = this.all[nextIndexInList];
+        this.goToWalletRoute(nextWalletInList.id);
+      } else {
+        this.active = null;
+      }
     });
+    this.refreshWalletsData();
   };
 
   _finishWalletCreation = async () => {
@@ -134,10 +143,11 @@ export default class WalletsStore extends Store {
     return this.all.length > 0 ? this.all[0] : null;
   }
 
-
   getWalletRoute = (walletId: string, screen: string = 'summary'): string => (
     `${this.BASE_ROUTE}/${walletId}/${screen}`
   );
+
+  getWalletById = (id: string): ?Wallet => this.all.find(w => w.id === id);
 
   isValidAddress = (address: string) => this.api.isValidAddress('ADA', address);
 

--- a/app/stores/index.js
+++ b/app/stores/index.js
@@ -10,6 +10,7 @@ import WalletBackupStore from './WalletBackupStore';
 import NetworkStatusStore from './NetworkStatusStore';
 import AdaRedemptionStore from './AdaRedemptionStore';
 import NodeUpdateStore from './NodeUpdateStore';
+import UIDialogsStore from './UIDialogsStore';
 
 const storeClasses = {
   app: AppStore,
@@ -22,6 +23,7 @@ const storeClasses = {
   networkStatus: NetworkStatusStore,
   adaRedemption: AdaRedemptionStore,
   nodeUpdate: NodeUpdateStore,
+  uiDialogs: UIDialogsStore,
 };
 
 // Constant that does never change during lifetime
@@ -62,4 +64,5 @@ export type storesType = {
   networkStatus: NetworkStatusStore,
   adaRedemption: AdaRedemptionStore,
   nodeUpdate: NodeUpdateStore,
+  uiDialogs: UIDialogsStore,
 };

--- a/app/themes/daedalus/_theme.scss
+++ b/app/themes/daedalus/_theme.scss
@@ -30,7 +30,10 @@ $color-primary-bg: #ebeff2;
 $color-dark-grey-blue: #2f496e;
 $color-light-grey: #c6cdd6;
 $color-lighter-grey: #fafbfc;
-$theme-error-color: rgb(222, 50, 38);
+$color-dark-red: #d34452;
+$color-light-red: #ea4c5b;
+$color-lighter-red: #ec5d6b;
+$theme-error-color: #de3226;
 
 // Buttons
 $button-up-bg: #243e62;

--- a/app/themes/daedalus/button.scss
+++ b/app/themes/daedalus/button.scss
@@ -1,11 +1,11 @@
 @import "~react-toolbox/lib/button/config";
 $button-border-radius: 0.3rem;
+$button-height: 50px;
 @import "~react-toolbox/lib/button/theme";
 
 .flat {
   font-size: 18px;
   font-family: $font-semibold;
-  letter-spacing: 2px;
   text-transform: none;
   background: $button-up-bg;
 

--- a/app/themes/daedalus/dialog.scss
+++ b/app/themes/daedalus/dialog.scss
@@ -6,7 +6,7 @@ $dialog-content-padding: 30px;
 .title {
   text-transform: uppercase;
   font-size: 1.125rem;
-  color: #5e6066;
+  color: $text-color-accent;
   text-align: center;
   font-family: $font-medium;
   letter-spacing: 2px;
@@ -28,7 +28,7 @@ $dialog-content-padding: 30px;
 
 .navigation {
   text-align: center;
-  padding: 0 30px 20px 30px;
+  padding: 0 30px 20px;
   display: flex;
   justify-content: space-between;
 }

--- a/app/themes/daedalus/dialog.scss
+++ b/app/themes/daedalus/dialog.scss
@@ -15,14 +15,22 @@ $dialog-content-padding: 30px;
 .dialog {
   border-radius: 10px;
   min-width: 500px;
+  max-width: 640px;
+}
+
+.normal {
+  width: 70vw;
 }
 
 .body {
-  overflow-y: scroll;
+  overflow-y: visible;
 }
 
 .navigation {
   text-align: center;
+  padding: 0 30px 20px 30px;
+  display: flex;
+  justify-content: space-between;
 }
 
 %button {
@@ -33,9 +41,12 @@ $dialog-content-padding: 30px;
 
 .button {
   @extend %button;
-  min-width: calc(50% - 0.8rem) !important; // TODO: This was not working without important statement
-}
-
-.navigation {
-  padding: 20px 30px;
+  box-sizing: border-box;
+  min-width: calc(50% - #{$dialog-navigation-padding}) !important;
+  padding: 0;
+  margin: 0;
+  &:only-child {
+    margin: auto;
+    width: 65%;
+  }
 }

--- a/app/themes/daedalus/dialog.scss
+++ b/app/themes/daedalus/dialog.scss
@@ -24,6 +24,10 @@ $dialog-content-padding: 30px;
 
 .body {
   overflow-y: visible;
+  :global .input_input:last-of-type {
+    margin-bottom: -32px !important;
+    // TODO: move this to config
+  }
 }
 
 .navigation {

--- a/app/themes/index.global.scss
+++ b/app/themes/index.global.scss
@@ -165,3 +165,10 @@ html, body, #root, #root > [data-reactroot] {
     height: 13px;
   }
 }
+
+
+// General text formatting
+
+strong {
+  font-family: $font-medium;
+}

--- a/stories/WalletDeleteConfirmationDialog.stories.js
+++ b/stories/WalletDeleteConfirmationDialog.stories.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { storiesOf, action } from '@kadira/storybook';
+import StoryDecorator from './support/StoryDecorator';
+import DeleteWalletConfirmationDialog from '../app/components/wallet/settings/DeleteWalletConfirmationDialog';
+
+storiesOf('DeleteWalletConfirmationDialog', module)
+
+  .addDecorator((story) => (
+    <StoryDecorator>
+      {story()}
+    </StoryDecorator>
+  ))
+
+  // ====== Stories ======
+
+  .add('without funds & countdown', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={false}
+        countdownFn={() => 10}
+        isBackupNoticeAccepted={false}
+      />
+    </div>
+  ))
+  .add('without funds - not accepted', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={false}
+        countdownFn={() => 0}
+        isBackupNoticeAccepted={false}
+      />
+    </div>
+  ))
+  .add('without funds - accepted', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={false}
+        countdownFn={() => 0}
+        isBackupNoticeAccepted={true}
+      />
+    </div>
+  ))
+  .add('funds & countdown', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={true}
+        countdownFn={() => 10}
+        isBackupNoticeAccepted={false}
+      />
+    </div>
+  ))
+  .add('funds & accepted', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={true}
+        countdownFn={() => 0}
+        isBackupNoticeAccepted={true}
+      />
+    </div>
+  ))
+  .add('funds & accepted & filled', () => (
+    <div>
+      <DeleteWalletConfirmationDialog
+        walletName={"My Wallet"}
+        hasWalletFunds={true}
+        countdownFn={() => 0}
+        isBackupNoticeAccepted={true}
+        confirmationValue="babushka"
+        onConfirmationValueChange={action('onRecoveryWordChange')}
+      />
+    </div>
+  ));
+

--- a/stories/index.js
+++ b/stories/index.js
@@ -9,3 +9,4 @@ import './AdaRedemptionDialog.stories';
 import './AddWallet.stories';
 import './WalletSummary.stories';
 import './LanguageSelectionForm.stories';
+import './WalletDeleteConfirmationDialog.stories';


### PR DESCRIPTION
This PR adds the wallet deletion feature to the settings page:

<img width="900" alt="screenshot 2017-03-28 um 18 36 23" src="https://cloud.githubusercontent.com/assets/172414/24416933/c0167ac6-13e6-11e7-928f-d0af136dd96f.png">

<img width="898" alt="screenshot 2017-03-28 um 18 36 31" src="https://cloud.githubusercontent.com/assets/172414/24416937/c5356594-13e6-11e7-9f51-a04b1d6637ef.png">

<img width="901" alt="screenshot 2017-03-28 um 18 36 46" src="https://cloud.githubusercontent.com/assets/172414/24416943/c76b6b24-13e6-11e7-8d97-3b24c24c8b73.png">

<img width="901" alt="screenshot 2017-03-28 um 18 36 54" src="https://cloud.githubusercontent.com/assets/172414/24416944/c9d0dade-13e6-11e7-810d-a4c23df37f44.png">

(note: i made the checkbox red after taking the screenshots)

## Additionally this PR adds several re-usable improvements:
- Introduced `UiDialogsStore` to manage active dialog visibility and data
- The data handling of dialogs is greatly simplified with this change (no need to store properties on other stores)
- Used a dedicated container component for the delete wallet dialog -> this means the other containers remain light-weight and we don't have to pass around so much data (please follow that in future PRs and let's refactor existing dialogs to this pattern.
- Fixed the styling / proportions of dialogs in our app