### PR TITLE
Fix/daef 106 error on add new wallet

### DIFF
--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -246,6 +246,10 @@ export default class WalletsStore extends Store {
     }
   };
 
+  @action _unsetActiveWallet = () => {
+    this.active = null;
+  };
+
   @action _setIsWalletDialogOpen = (isOpen: boolean) => {
     this.isAddWalletDialogOpen = isOpen;
   };
@@ -264,6 +268,9 @@ export default class WalletsStore extends Store {
     const currentRoute = this.stores.app.currentRoute;
     const hasActiveWallet = !!this.active;
     const hasAnyWalletsLoaded = this.hasAnyLoaded;
+
+    // There are not wallets loaded (yet) -> unset active and return
+    if (!hasAnyWalletsLoaded) return this._unsetActiveWallet();
     const match = matchRoute(`${this.BASE_ROUTE}/:id(*page)`, currentRoute);
     if (match) {
       // We have a route for a specific wallet -> lets try to find it

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -99,7 +99,7 @@ export default class WalletsStore extends Store {
     this._newWalletDetails.mnemonic = this.stores.walletBackup.recoveryPhrase.join(' ');
     const wallet = await this.createWalletRequest.execute(this._newWalletDetails).promise;
     if (wallet) {
-      await this.walletsRequest.patch(result => result.push(wallet));
+      await this.walletsRequest.patch(result => { result.push(wallet); });
       this.goToWalletRoute(wallet.id);
       runInAction(() => { this.isAddWalletDialogOpen = false; });
     }

--- a/app/stores/lib/CachedRequest.js
+++ b/app/stores/lib/CachedRequest.js
@@ -78,6 +78,17 @@ export default class CachedRequest extends Request {
     return this;
   }
 
+  /**
+   * Asynchronously patch the result of the request.
+   * This can be used for optimistic UI updates before the server has confirmed the change.
+   *
+   * @param modify {Function} - Custom function to path the result (which gets passed in as
+   * only param) You can either change the result directly (e.g: `result.push(something)` or
+   * if you need to replace the whole result of the request you need to return it from this
+   * function.
+   *
+   * @returns {Promise}
+   */
   patch(modify: Function): Promise<any> {
     return new Promise((resolve) => {
       setTimeout(action(() => {


### PR DESCRIPTION
This PR fixes the bug/error that happened when adding new wallets, which was caused due to the way the `Request::patch` function works -> when you return a value, it replaces the whole result!

Additionally it fixes the way we are setting the active wallet on route changes (we didn't cover the case when there are no wallets loaded at all).