### PR TITLE
[DAEF-125] improve the way we construct dynamic route paths

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,11 @@
     "no-undef": 1,
     "arrow-body-style": 1,
     "key-spacing": 1,
-    "no-empty-function": 1
+    "no-empty-function": 1,
+    "max-len": 1,
+    "no-useless-escape": 1,
+    "prefer-const": 1,
+    "object-curly-spacing": 1
   },
   "plugins": [
     "flowtype-errors",

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -15,19 +15,38 @@ import WalletSettingsPage from './containers/wallet/WalletSettingsPage';
 import NoWalletsPage from './containers/wallet/NoWalletsPage';
 import LanguageSelectionPage from './containers/profile/LanguageSelectionPage';
 
+export const ROUTES = {
+  ROOT: '/',
+  STAKING: '/staking',
+  ADA_REDEMPTION: '/ada-redemption',
+  NO_WALLETS: '/no-wallets',
+  PROFILE: {
+    LANGUAGE_SELECTION: '/profile/language-selection',
+  },
+  WALLETS: {
+    ROOT: '/wallets',
+    PAGE: '/wallets/:id/:page',
+    SUMMARY: '/wallets/:id/summary',
+    TRANSACTIONS: '/wallets/:id/transactions',
+    SEND: '/wallets/:id/send',
+    RECEIVE: '/wallets/:id/receive',
+    SETTINGS: '/wallets/:id/settings',
+  },
+};
+
 export default (
   <div>
-    <Route path="/" component={LoadingPage} />
-    <Route path="/profile/language-selection" component={LanguageSelectionPage} />
-    <Route path="/staking" component={StakingPage} />
-    <Route path="/ada-redemption" component={AdaRedemptionPage} />
-    <Route path="/no-wallets" component={NoWalletsPage} />
-    <Route path="/wallets" component={Wallet}>
-      <Route path=":id/summary" component={WalletSummaryPage} />
-      <Route path=":id/transactions" component={WalletTransactionsPage} />
-      <Route path=":id/send" component={WalletSendPage} />
-      <Route path=":id/receive" component={WalletReceivePage} />
-      <Route path=":id/settings" component={WalletSettingsPage} />
+    <Route path={ROUTES.ROOT} component={LoadingPage} />
+    <Route path={ROUTES.PROFILE.LANGUAGE_SELECTION} component={LanguageSelectionPage} />
+    <Route path={ROUTES.STAKING} component={StakingPage} />
+    <Route path={ROUTES.ADA_REDEMPTION} component={AdaRedemptionPage} />
+    <Route path={ROUTES.NO_WALLETS} component={NoWalletsPage} />
+    <Route component={Wallet}>
+      <Route path={ROUTES.WALLETS.SUMMARY} component={WalletSummaryPage} />
+      <Route path={ROUTES.WALLETS.TRANSACTIONS} component={WalletTransactionsPage} />
+      <Route path={ROUTES.WALLETS.SEND} component={WalletSendPage} />
+      <Route path={ROUTES.WALLETS.RECEIVE} component={WalletReceivePage} />
+      <Route path={ROUTES.WALLETS.SETTINGS} component={WalletSettingsPage} />
     </Route>
   </div>
 );

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -41,7 +41,7 @@ export default (
     <Route path={ROUTES.STAKING} component={StakingPage} />
     <Route path={ROUTES.ADA_REDEMPTION} component={AdaRedemptionPage} />
     <Route path={ROUTES.NO_WALLETS} component={NoWalletsPage} />
-    <Route component={Wallet}>
+    <Route path={ROUTES.WALLETS.ROOT} component={Wallet}>
       <Route path={ROUTES.WALLETS.SUMMARY} component={WalletSummaryPage} />
       <Route path={ROUTES.WALLETS.TRANSACTIONS} component={WalletTransactionsPage} />
       <Route path={ROUTES.WALLETS.SEND} component={WalletSendPage} />

--- a/app/actions/router-actions.js
+++ b/app/actions/router-actions.js
@@ -4,5 +4,6 @@ import defineActions from './lib/actions';
 export default defineActions({
   goToRoute: {
     route: PropTypes.string.isRequired,
+    params: PropTypes.object,
   },
 });

--- a/app/containers/wallet/Wallet.js
+++ b/app/containers/wallet/Wallet.js
@@ -6,7 +6,8 @@ import WalletWithNavigation from '../../components/wallet/layouts/WalletWithNavi
 import LoadingSpinner from '../../components/widgets/LoadingSpinner';
 import { oneOrManyChildElements } from '../../propTypes';
 import AdaRedemptionSuccessOverlay from '../../components/wallet/ada-redemption/AdaRedemptionSuccessOverlay';
-
+import { buildRoute } from '../../lib/routing-helpers';
+import { ROUTES } from '../../Routes';
 
 @inject('stores', 'actions') @observer
 export default class Wallet extends Component {
@@ -35,16 +36,19 @@ export default class Wallet extends Component {
     children: oneOrManyChildElements,
   };
 
-  isActiveScreen = (screen: string) => {
+  isActiveScreen = (page: string) => {
     const { app, wallets } = this.props.stores;
     if (!wallets.active) return false;
-    const screenRoute = `${wallets.BASE_ROUTE}/${wallets.active.id}/${screen}`;
+    const screenRoute = buildRoute(ROUTES.WALLETS.PAGE, { id: wallets.active.id, page });
     return app.currentRoute === screenRoute;
   };
 
-  handleWalletNavItemClick = (item: string) => {
+  handleWalletNavItemClick = (page: string) => {
     const { wallets } = this.props.stores;
-    this.props.actions.router.goToRoute({ route: `${wallets.BASE_ROUTE}/${wallets.active.id}/${item}` });
+    this.props.actions.router.goToRoute({
+      route: ROUTES.WALLETS.PAGE,
+      params: { id: wallets.active.id, page },
+    });
   };
 
   render() {

--- a/app/containers/wallet/WalletSettingsPage.js
+++ b/app/containers/wallet/WalletSettingsPage.js
@@ -2,14 +2,14 @@
 import React, { Component, PropTypes } from 'react';
 import { inject, observer } from 'mobx-react';
 import WalletSettings from '../../components/wallet/WalletSettings';
-import UiDialogsStore from '../../stores/UIDialogsStore';
+import UIDialogsStore from '../../stores/UIDialogsStore';
 
 @inject('actions', 'stores') @observer
 export default class WalletSettingsPage extends Component {
 
   static propTypes = {
     stores: PropTypes.shape({
-      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
+      uiDialogs: PropTypes.instanceOf(UIDialogsStore).isRequired,
     }).isRequired,
     actions: PropTypes.shape({
       dialogs: PropTypes.shape({

--- a/app/containers/wallet/WalletSettingsPage.js
+++ b/app/containers/wallet/WalletSettingsPage.js
@@ -2,14 +2,14 @@
 import React, { Component, PropTypes } from 'react';
 import { inject, observer } from 'mobx-react';
 import WalletSettings from '../../components/wallet/WalletSettings';
-import UIDialogsStore from '../../stores/UIDialogsStore';
+import UiDialogsStore from '../../stores/UiDialogsStore';
 
 @inject('actions', 'stores') @observer
 export default class WalletSettingsPage extends Component {
 
   static propTypes = {
     stores: PropTypes.shape({
-      uiDialogs: PropTypes.instanceOf(UIDialogsStore).isRequired,
+      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
     }).isRequired,
     actions: PropTypes.shape({
       dialogs: PropTypes.shape({

--- a/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
 import { inject, observer } from 'mobx-react';
-import UIDialogsStore from '../../../stores/UIDialogsStore';
+import UiDialogsStore from '../../../stores/UiDialogsStore';
 import WalletsStore from '../../../stores/WalletsStore';
 import DeleteWalletConfirmationDialog from '../../../components/wallet/settings/DeleteWalletConfirmationDialog';
 
@@ -11,7 +11,7 @@ export default class DeleteWalletDialogContainer extends Component {
   static propTypes = {
     stores: PropTypes.shape({
       wallets: PropTypes.instanceOf(WalletsStore).isRequired,
-      uiDialogs: PropTypes.instanceOf(UIDialogsStore).isRequired,
+      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
     }).isRequired,
     actions: PropTypes.shape({
       dialogs: PropTypes.shape({

--- a/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
 import { inject, observer } from 'mobx-react';
-import UiDialogsStore from '../../../stores/UIDialogsStore';
+import UIDialogsStore from '../../../stores/UIDialogsStore';
 import WalletsStore from '../../../stores/WalletsStore';
 import DeleteWalletConfirmationDialog from '../../../components/wallet/settings/DeleteWalletConfirmationDialog';
 
@@ -11,7 +11,7 @@ export default class DeleteWalletDialogContainer extends Component {
   static propTypes = {
     stores: PropTypes.shape({
       wallets: PropTypes.instanceOf(WalletsStore).isRequired,
-      uiDialogs: PropTypes.instanceOf(UiDialogsStore).isRequired,
+      uiDialogs: PropTypes.instanceOf(UIDialogsStore).isRequired,
     }).isRequired,
     actions: PropTypes.shape({
       dialogs: PropTypes.shape({

--- a/app/lib/routing-helpers.js
+++ b/app/lib/routing-helpers.js
@@ -1,3 +1,88 @@
 import RouteParser from 'route-parser';
 
 export const matchRoute = (pattern, path) => new RouteParser(pattern).match(path);
+
+/**
+ * Build a route from a pattern like `/wallets/:id` to `/wallets/123`
+ * by calling it with the pattern + params:
+ *
+ * buildRoute('/wallets/:id', { id: 123 });
+ *
+ * Code taken from:
+ * https://github.com/adamziel/react-router-named-routes/blob/master/lib/index.js
+ *
+ * @param pattern
+ * @param params
+ */
+export const buildRoute = (pattern, params) => {
+  function toArray(val) {
+    return Object.prototype.toString.call(val) !== '[object Array]' ? [val] : val;
+  }
+  const reRepeatingSlashes = /\/+/g; // '/some//path'
+  const reSplatParams = /\*{1,2}/g;  // '/some/*/complex/**/path'
+  const reResolvedOptionalParams = /\(([^:*?#]+?)\)/g; // '/path/with/(resolved/params)'
+  // '/path/with/(groups/containing/:unresolved/optional/:params)'
+  const reUnresolvedOptionalParams = /\([^:?#]*:[^?#]*?\)/g;
+  const reTokens = /<(.*?)>/g;
+  const reSlashTokens = /_!slash!_/g;
+
+  let routePath = pattern;
+  const tokens = {};
+
+  if (params) {
+    Object.keys(params).forEach((paramName) => {
+      let paramValue = params[paramName];
+
+      // special param name in RR, used for '*' and '**' placeholders
+      if (paramName === 'splat') {
+        // when there are multiple globs, RR defines 'splat' param as array.
+        paramValue = toArray(paramValue);
+        let i = 0;
+        routePath = routePath.replace(reSplatParams, (match) => {
+          const val = paramValue[i++];
+          if (val == null) {
+            return '';
+          }
+          const tokenName = `splat${i}`;
+          if (match === '*') {
+            tokens[tokenName] = encodeURIComponent(val);
+          } else {
+            // don't escape slashes for double star, as '**' considered greedy by RR spec
+            tokens[tokenName] = encodeURIComponent(
+              val.toString().replace(/\//g, '_!slash!_')
+            ).replace(reSlashTokens, '/');
+          }
+          return `<${tokenName}>`;
+        });
+      } else {
+        // Rougly resolve all named placeholders.
+        // Cases:
+        // - '/path/:param'
+        // - '/path/(:param)'
+        // - '/path(/:param)'
+        // - '/path(/:param/):another_param'
+        // - '/path/:param(/:another_param)'
+        // - '/path(/:param/:another_param)'
+        const paramRegex = new RegExp('(/|\\(|\\)|^):' + paramName + '(/|\\)|\\(|$)');
+        routePath = routePath.replace(paramRegex, (match, g1, g2) => {
+          tokens[paramName] = encodeURIComponent(paramValue);
+          return `${g1}<${paramName}>${g2}`;
+        });
+      }
+    });
+  }
+
+  return routePath
+  // Remove braces around resolved optional params (i.e. '/path/(value)')
+    .replace(reResolvedOptionalParams, '$1')
+    // Remove all sequences containing at least one unresolved optional param
+    .replace(reUnresolvedOptionalParams, '')
+    // After everything related to RR syntax is removed, insert actual values
+    .replace(reTokens, (match, token) => tokens[token])
+    // Remove repeating slashes
+    .replace(reRepeatingSlashes, '/')
+    // Always remove ending slash for consistency
+    .replace(/\/+$/, '')
+    // If there was a single slash only, keep it
+    .replace(/^$/, '/');
+};

--- a/app/stores/AppStore.js
+++ b/app/stores/AppStore.js
@@ -5,6 +5,8 @@ import Request from './lib/Request';
 import CachedRequest from './lib/CachedRequest';
 import globalMessages from '../i18n/global-messages';
 import LocalizableError from '../i18n/LocalizableError';
+import { ROUTES } from '../Routes';
+import { buildRoute } from '../lib/routing-helpers';
 
 export default class AppStore extends Store {
 
@@ -54,13 +56,13 @@ export default class AppStore extends Store {
   _redirectToLanguageSelectionIfNoLocaleSet = () => {
     const { isConnected } = this.stores.networkStatus;
     if (isConnected && this.hasLoadedCurrentLocale && !this.isCurrentLocaleSet) {
-      this.actions.router.goToRoute({ route: '/profile/language-selection' });
+      this.actions.router.goToRoute({ route: ROUTES.PROFILE.LANGUAGE_SELECTION });
     }
   };
 
   _redirectToLoadingScreenWhenDisconnected = () => {
     if (!this.stores.networkStatus.isConnected) {
-      this.actions.router.goToRoute({ route: '/' });
+      this.actions.router.goToRoute({ route: ROUTES.ROOT });
     }
   };
 
@@ -69,14 +71,16 @@ export default class AppStore extends Store {
     this.getProfileLocaleRequest.invalidate().patch(() => locale);
   };
 
-  _updateRouteLocation = ({ route }: { route: string }) => {
+  _updateRouteLocation = (options: { route: string, params: ?Object }) => {
+    const routePath = buildRoute(options.route, options.params);
+    console.log(options.route, options.params, routePath);
     const currentRoute = this.stores.router.location.pathname;
-    if (currentRoute !== route) this.stores.router.push(route);
+    if (currentRoute !== routePath) this.stores.router.push(routePath);
   };
 
   _redirectToMainUiAfterLocaleIsSet = () => {
-    if (this.isCurrentLocaleSet && this.currentRoute === '/profile/language-selection') {
-      this.actions.router.goToRoute({ route: '/' });
+    if (this.isCurrentLocaleSet && this.currentRoute === ROUTES.PROFILE.LANGUAGE_SELECTION) {
+      this.actions.router.goToRoute({ route: ROUTES.ROOT });
     }
   };
 

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -2,6 +2,7 @@
 import { observable, action, computed, runInAction } from 'mobx';
 import Store from './lib/Store';
 import Request from './lib/Request';
+import { ROUTES } from '../Routes';
 
 // To avoid slow reconnecting on store reset, we cache the most important props
 let cachedDifficulties = null;
@@ -120,24 +121,27 @@ export default class NetworkStatusStore extends Store {
 
   _redirectToWalletAfterSync = () => {
     const { app, wallets } = this.stores;
-    if (app.currentRoute === '/profile/language-selection') return;
+    if (app.currentRoute === ROUTES.PROFILE.LANGUAGE_SELECTION) return;
     // TODO: introduce smarter way to bootsrap initial screens
     if (this.isConnected && this.isSynced && wallets.hasLoadedWallets && app.currentRoute === '/') {
       runInAction(() => { this.isLoadingWallets = false; });
       if (wallets.first) {
-        this.actions.router.goToRoute({ route: wallets.getWalletRoute(wallets.first.id) });
+        this.actions.router.goToRoute({
+          route: ROUTES.WALLETS.SUMMARY,
+          params: { id: wallets.first.id }
+        });
       } else {
-        this.actions.router.goToRoute({ route: '/no-wallets' });
+        this.actions.router.goToRoute({ route: ROUTES.NO_WALLETS });
       }
       this.actions.networkStatus.isSyncedAndReady();
     }
   };
 
   _redirectToLoadingWhenDisconnected = () => {
-    if (this.stores.app.currentRoute === '/profile/language-selection') return;
+    if (this.stores.app.currentRoute === ROUTES.PROFILE.LANGUAGE_SELECTION) return;
     if (!this.isConnected) {
       this._setInitialDifficulty();
-      this.actions.router.goToRoute({ route: '/' });
+      this.actions.router.goToRoute({ route: ROUTES.ROOT });
     }
   };
 

--- a/app/stores/UiDialogsStore.js
+++ b/app/stores/UiDialogsStore.js
@@ -2,7 +2,7 @@
 import { observable, action } from 'mobx';
 import Store from './lib/Store';
 
-export default class UIDialogsStore extends Store {
+export default class UiDialogsStore extends Store {
 
   @observable activeDialog: ?Function = null;
   @observable secondsSinceActiveDialogIsOpen: number = 0;

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -3,15 +3,15 @@ import { observable, computed, action, runInAction } from 'mobx';
 import _ from 'lodash';
 import Store from './lib/Store';
 import Wallet from '../domain/Wallet';
-import { matchRoute } from '../lib/routing-helpers';
+import { matchRoute, buildRoute } from '../lib/routing-helpers';
 import CachedRequest from './lib/CachedRequest';
 import Request from './lib/Request';
 import environment from '../environment';
 import config from '../config';
+import { ROUTES } from '../Routes';
 
 export default class WalletsStore extends Store {
 
-  BASE_ROUTE = '/wallets';
   WALLET_REFRESH_INTERVAL = 5000;
 
   @observable active = null;
@@ -87,9 +87,8 @@ export default class WalletsStore extends Store {
         const nextWalletInList = this.all[nextIndexInList];
         this.goToWalletRoute(nextWalletInList.id);
       } else {
-        console.log('NO WALLETS');
         this.active = null;
-        this.actions.router.goToRoute({ route: '/no-wallets' });
+        this.actions.router.goToRoute({ route: ROUTES.NO_WALLETS });
       }
     });
     this.refreshWalletsData();
@@ -148,8 +147,8 @@ export default class WalletsStore extends Store {
     return this.all.length > 0 ? this.all[0] : null;
   }
 
-  getWalletRoute = (walletId: string, screen: string = 'summary'): string => (
-    `${this.BASE_ROUTE}/${walletId}/${screen}`
+  getWalletRoute = (walletId: string, page: string = 'summary'): string => (
+    buildRoute({ route: ROUTES.WALLETS.PAGE, params: { id: walletId, page } })
   );
 
   getWalletById = (id: string): ?Wallet => this.all.find(w => w.id === id);
@@ -271,7 +270,7 @@ export default class WalletsStore extends Store {
 
     // There are not wallets loaded (yet) -> unset active and return
     if (!hasAnyWalletsLoaded) return this._unsetActiveWallet();
-    const match = matchRoute(`${this.BASE_ROUTE}/:id(*page)`, currentRoute);
+    const match = matchRoute(`${ROUTES.WALLETS.ROOT}/:id(*page)`, currentRoute);
     if (match) {
       // We have a route for a specific wallet -> lets try to find it
       const walletForCurrentRoute = this.all.find(w => w.id === match.id);
@@ -283,7 +282,7 @@ export default class WalletsStore extends Store {
         this._setActiveWallet({ walletId: this.all[0].id });
         if (this.active) this.goToWalletRoute(this.active.id);
       }
-    } else if (matchRoute(this.BASE_ROUTE, currentRoute)) {
+    } else if (matchRoute(ROUTES.WALLETS.ROOT, currentRoute)) {
       // The route does not specify any wallet -> pick first wallet
       if (!hasActiveWallet && hasAnyWalletsLoaded) {
         this._setActiveWallet({ walletId: this.all[0].id });

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -148,7 +148,7 @@ export default class WalletsStore extends Store {
   }
 
   getWalletRoute = (walletId: string, page: string = 'summary'): string => (
-    buildRoute({ route: ROUTES.WALLETS.PAGE, params: { id: walletId, page } })
+    buildRoute(ROUTES.WALLETS.PAGE, { id: walletId, page })
   );
 
   getWalletById = (id: string): ?Wallet => this.all.find(w => w.id === id);

--- a/app/stores/index.js
+++ b/app/stores/index.js
@@ -10,7 +10,7 @@ import WalletBackupStore from './WalletBackupStore';
 import NetworkStatusStore from './NetworkStatusStore';
 import AdaRedemptionStore from './AdaRedemptionStore';
 import NodeUpdateStore from './NodeUpdateStore';
-import UIDialogsStore from './UIDialogsStore';
+import UiDialogsStore from './UiDialogsStore';
 
 const storeClasses = {
   app: AppStore,
@@ -23,7 +23,7 @@ const storeClasses = {
   networkStatus: NetworkStatusStore,
   adaRedemption: AdaRedemptionStore,
   nodeUpdate: NodeUpdateStore,
-  uiDialogs: UIDialogsStore,
+  uiDialogs: UiDialogsStore,
 };
 
 // Constant that does never change during lifetime
@@ -65,5 +65,5 @@ export type storesType = {
   networkStatus: NetworkStatusStore,
   adaRedemption: AdaRedemptionStore,
   nodeUpdate: NodeUpdateStore,
-  uiDialogs: UIDialogsStore,
+  uiDialogs: UiDialogsStore,
 };

--- a/app/stores/index.js
+++ b/app/stores/index.js
@@ -39,6 +39,7 @@ const stores = observable({
   networkStatus: null,
   adaRedemption: null,
   nodeUpdate: null,
+  uiDialogs: null,
 });
 
 // Set up and return the stores for this app -> also used to reset all stores to defaults


### PR DESCRIPTION
This PR improves and simplifies the way we construct routes for redirecting / matching.
Instead of this:
```js
`${wallets.BASE_ROUTE}/${wallets.active.id}/${screen}`
```

you can now do this:
```js
buildRoute(ROUTES.WALLETS.PAGE, { id: wallets.active.id, page })
```

This is less error prone and will be easier to refactor later on.
All the route paths are defined in one place with params etc. so you can just look up what to pass in and it will automatically generate the correct route for you.