### PR TITLE
[daef-23] introduce file logging

### DIFF
--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -2,6 +2,7 @@
 import ClientApi from 'daedalus-client-api';
 import { action } from 'mobx';
 import { ipcRenderer } from 'electron';
+import Log from 'electron-log';
 import Wallet from '../domain/Wallet';
 import WalletTransaction from '../domain/WalletTransaction';
 import type {
@@ -55,14 +56,14 @@ export default class CardanoClientApi {
   }
 
   async getWallets() {
-    console.debug('CardanoClientApi::getWallets called');
+    Log.debug('CardanoClientApi::getWallets called');
     const response = await ClientApi.getWallets();
     return response.map(data => this._createWalletFromServerData(data));
   }
 
   async getTransactions(request: getTransactionsRequest) {
     const { walletId, searchTerm, skip, limit } = request;
-    console.debug('CardanoClientApi::getTransactions called with', request);
+    Log.debug('CardanoClientApi::getTransactions called with', request);
     const history = await ClientApi.searchHistory(walletId, searchTerm, skip, limit);
     return new Promise((resolve) => resolve({
       transactions: history[0].map(data => this._createTransactionFromServerData(data, walletId)),
@@ -71,7 +72,7 @@ export default class CardanoClientApi {
   }
 
   async createWallet(request: createWalletRequest) {
-    console.debug('CardanoClientApi::createWallet called with', request);
+    Log.debug('CardanoClientApi::createWallet called with', request);
     const response = await ClientApi.newWallet('CWTPersonal', 'ADA', request.name, request.mnemonic);
     return this._createWalletFromServerData(response);
   }
@@ -86,7 +87,7 @@ export default class CardanoClientApi {
   }
 
   async createTransaction(request: createTransactionRequest) {
-    console.debug('CardanoClientApi::createTransaction called with', request);
+    Log.debug('CardanoClientApi::createTransaction called with', request);
     const { sender, receiver, amount, currency } = request;
     const description = 'no description provided';
     const title = 'no title provided';
@@ -150,7 +151,7 @@ export default class CardanoClientApi {
 
   async restoreWallet(request: walletRestoreRequest) {
     const { recoveryPhrase, walletName } = request;
-    console.debug('CardanoClientApi::restoreWallet called with', request);
+    Log.debug('CardanoClientApi::restoreWallet called with', request);
     try {
       const restoredWallet = await ClientApi.restoreWallet('CWTPersonal', 'ADA', walletName, recoveryPhrase);
       return this._createWalletFromServerData(restoredWallet);
@@ -169,7 +170,7 @@ export default class CardanoClientApi {
   }
 
   async importWalletFromKey(request: importKeyRequest) {
-    console.debug('CardanoClientApi::importWalletFromKey called with', request);
+    Log.debug('CardanoClientApi::importWalletFromKey called with', request);
     try {
       const importedWallet = await ClientApi.importKey(request.filePath);
       return this._createWalletFromServerData(importedWallet);
@@ -184,7 +185,7 @@ export default class CardanoClientApi {
 
   async redeemAda(request: redeemAdaRequest) {
     const { redemptionCode, walletId } = request;
-    console.debug('CardanoClientApi::redeemAda called with', request);
+    Log.debug('CardanoClientApi::redeemAda called with', request);
     try {
       const response: ServerWalletStruct = await ClientApi.redeemADA(redemptionCode, walletId);
       // TODO: Update response when it is implemented on the backend,
@@ -215,7 +216,7 @@ export default class CardanoClientApi {
   }
 
   _onNotify = (rawMessage: string) => {
-    console.debug('CardanoClientApi::notify message: ', rawMessage);
+    Log.debug('CardanoClientApi::notify message: ', rawMessage);
     // TODO: "ConnectionClosed" messages are not JSON parsable … so we need to catch that case here!
     let message = rawMessage;
     if (message !== 'ConnectionClosed') {
@@ -225,19 +226,19 @@ export default class CardanoClientApi {
   };
 
   _onNotifyError = (error: Error) => {
-    console.debug('CardanoClientApi::notify error: ', error);
+    Log.debug('CardanoClientApi::notify error: ', error);
     this.notifyCallbacks.forEach(cb => cb.error(error));
   };
 
 
   async nextUpdate() {
-    console.debug('CardanoClientApi::nextUpdate called');
+    Log.debug('CardanoClientApi::nextUpdate called');
     let nextUpdate = null;
     try {
       nextUpdate = JSON.parse(await ClientApi.nextUpdate());
-      console.debug('CardanoClientApi::nextUpdate returned', nextUpdate);
+      Log.debug('CardanoClientApi::nextUpdate returned', nextUpdate);
     } catch (error) {
-      console.log(error);
+      Log.debug(error);
       // TODO: Api is trowing an error when update is not available, handle other errors
     }
     return nextUpdate;
@@ -279,14 +280,13 @@ export default class CardanoClientApi {
   }
 
   async getSyncProgress() {
-    console.debug('CardanoClientApi::syncProgress called');
+    Log.debug('CardanoClientApi::syncProgress called');
     const response = await ClientApi.syncProgress();
-    console.log('CardanoClientApi::syncProgress response', response);
+    Log.debug('CardanoClientApi::syncProgress response', response);
     const localDifficulty = response._spLocalCD.getChainDifficulty;
     // In some cases we dont get network difficulty & we need to wait for it from the notify API
     let networkDifficulty = null;
     if (response._spNetworkCD) networkDifficulty = response._spNetworkCD.getChainDifficulty;
-    console.log({ localDifficulty, networkDifficulty });
     return { localDifficulty, networkDifficulty };
   }
 

--- a/app/stores/AdaRedemptionStore.js
+++ b/app/stores/AdaRedemptionStore.js
@@ -2,6 +2,7 @@
 import { action, observable } from 'mobx';
 import { ipcRenderer } from 'electron';
 import { isString } from 'lodash';
+import Log from 'electron-log';
 import Store from './lib/Store';
 import Request from './lib/Request';
 import { PARSE_REDEMPTION_CODE } from '../../electron/ipc-api/parse-redemption-code-from-pdf';
@@ -73,12 +74,12 @@ export default class AdaRedemptionStore extends Store {
   _parseCodeFromCertificate() {
     if (this.certificate == null) throw new Error('Certificate File is required for parsing.');
     const path = this.certificate.path;
-    console.debug('Parsing ADA Redemption code from certificate', path);
+    Log.debug('Parsing ADA Redemption code from certificate', path);
     ipcRenderer.send(PARSE_REDEMPTION_CODE.REQUEST, path, this.passPhrase);
   }
 
   _onCodeParsed = action((event, code) => {
-    console.debug('Redemption code parsed from certificate:', code);
+    Log.debug('Redemption code parsed from certificate:', code);
     this.redemptionCode = code;
   });
 
@@ -111,7 +112,7 @@ export default class AdaRedemptionStore extends Store {
   });
 
   _onAdaSuccessfullyRedeemed = action(({ walletId, amount }) => {
-    console.debug('ADA successfully redeemed for wallet', walletId);
+    Log.debug('ADA successfully redeemed for wallet', walletId);
     this.stores.wallets.goToWalletRoute(walletId);
     this.amountRedeemed = amount;
     this.showAdaRedemptionSuccessMessage = true;

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -1,5 +1,6 @@
 // @flow
 import { observable, action, computed, runInAction } from 'mobx';
+import Log from 'electron-log';
 import Store from './lib/Store';
 import Request from './lib/Request';
 
@@ -50,10 +51,10 @@ export default class NetworkStatusStore extends Store {
       const relativeNetwork = this.networkDifficulty - this._localDifficultyStartedWith;
       // In case node is in sync after first local difficulty messages
       // local and network difficulty will be the same (0)
-      console.debug('Network difficulty: ', this.networkDifficulty);
-      console.debug('Local difficulty: ', this.localDifficulty);
-      console.debug('Relative local difficulty: ', relativeLocal);
-      console.debug('Relative network difficulty: ', relativeNetwork);
+      Log.debug('Network difficulty: ', this.networkDifficulty);
+      Log.debug('Local difficulty: ', this.localDifficulty);
+      Log.debug('Relative local difficulty: ', relativeLocal);
+      Log.debug('Relative network difficulty: ', relativeNetwork);
 
       if (relativeLocal >= relativeNetwork) return 100;
       return relativeLocal / relativeNetwork * 100;
@@ -85,7 +86,7 @@ export default class NetworkStatusStore extends Store {
         this._localDifficultyStartedWith = initialDifficulty.localDifficulty;
         this.localDifficulty = initialDifficulty.localDifficulty;
         this.networkDifficulty = initialDifficulty.networkDifficulty;
-        console.debug('Initial difficulty: ', initialDifficulty);
+        Log.debug('Initial difficulty: ', initialDifficulty);
       });
     }
   };
@@ -113,7 +114,7 @@ export default class NetworkStatusStore extends Store {
           this.isConnected = false;
           break;
         default:
-          console.log('Unknown server notification received:', message);
+          Log.warn('Unknown server notification received:', message);
       }
     }));
   }

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -87,7 +87,6 @@ export default class WalletsStore extends Store {
         const nextWalletInList = this.all[nextIndexInList];
         this.goToWalletRoute(nextWalletInList.id);
       } else {
-        console.log('NO WALLETS');
         this.active = null;
         this.actions.router.goToRoute({ route: '/no-wallets' });
       }

--- a/electron/lib/getLogFilePath.js
+++ b/electron/lib/getLogFilePath.js
@@ -1,0 +1,12 @@
+import path from 'path';
+
+export default (platform, env, appName) => {
+  switch (platform) {
+    case 'darwin': {
+      return path.join(env['HOME'], 'Library', 'Application Support', appName, 'Logs', 'Daedalus.log');
+    }
+    case 'win32': {
+      return path.join(env['APPDATA'], appName, 'Logs', 'Daedalus.log');
+    }
+  }
+};

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -1,8 +1,12 @@
 import { app, BrowserWindow, Menu, shell, ipcMain, dialog } from 'electron';
+import Log from 'electron-log';
 import osxMenu from './menus/osx';
-import fs from 'fs';
 import winLinuxMenu from './menus/win-linux';
 import ipcApi from './ipc-api';
+
+// Configure default logger levels for console and file outputs
+Log.transports.console.level = 'warn';
+Log.transports.file.level = 'debug';
 
 let menu;
 let mainWindow = null;

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -1,12 +1,15 @@
 import { app, BrowserWindow, Menu, shell, ipcMain, dialog } from 'electron';
 import Log from 'electron-log';
+import getAppName from 'electron-log/lib/transports/file/get-app-name';
 import osxMenu from './menus/osx';
 import winLinuxMenu from './menus/win-linux';
 import ipcApi from './ipc-api';
+import getLogFilePath from './lib/getLogFilePath';
 
 // Configure default logger levels for console and file outputs
 Log.transports.console.level = 'warn';
 Log.transports.file.level = 'debug';
+Log.transports.file.file = getLogFilePath(process.platform, process.env, getAppName());
 
 let menu;
 let mainWindow = null;

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "classnames": "^2.2.5",
     "css-modules-require-hook": "^4.0.5",
     "electron-debug": "^1.0.1",
+    "electron-log": "^2.0.2",
     "es6-error": "^4.0.1",
     "faker": "^3.1.0",
     "immutability-helper": "^2.0.0",


### PR DESCRIPTION
This PR introduces file and main process logging via [electron-log](https://www.npmjs.com/package/electron-log) and configures them like this:

```js
Log.transports.console.level = 'warn';
Log.transports.file.level = 'debug';
```

The result is that we don't have any unnecessary outputs in the dev tools anymore (yeah!) and by default everything is logged to the file and only `warn` messages are appearing in the terminal where you started the app (e.g: with `npm run dev`). Any normal `console.log` messages will still appear in the dev tool console (handy for development).

This also means that we can now log on the main process (e.g: when decrypting files / reading PDFs etc.)

The log files will be written into the same folder as the other logs (from cardano-node etc.) are:
osx: `$HOME/Library/Application Support/Daedalus/Logs/Daedalus.log`
windows: `%APPDATA%\Daedalus\Logs\Daedalus.log`

**Note: I will move the server reporting to a separate ticket because honestly i have no idea how this should be implemented and what we have here is already better than nothing** 