### PR TITLE
[DAEF-74] removes back and clear button from recovery phrase dialog

### DIFF
--- a/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -93,18 +93,23 @@ export default class WalletRecoveryPhraseEntryDialog extends Component {
 
     const enteredPhraseString = enteredPhrase.reduce((phrase, { word }) => `${phrase} ${word}`, '');
 
-    const actions = [
-      {
+    const actions = [];
+
+    actions.push({
+      label: intl.formatMessage(messages.buttonLabelConfirm),
+      onClick: onFinishBackup,
+      disabled: !canFinishBackup,
+      primary: true
+    });
+
+    // Only show "Clear" button when user is not yet done with entering mnemonic
+    if (!isValid) {
+      actions.unshift({
         label: intl.formatMessage(messages.buttonLabelClear),
         onClick: onClear,
-      },
-      {
-        label: intl.formatMessage(messages.buttonLabelConfirm),
-        onClick: onFinishBackup,
-        disabled: !canFinishBackup,
-        primary: true
-      }
-    ];
+      });
+    }
+
     return (
       <Dialog
         title={intl.formatMessage(messages.recoveryPhrase)}
@@ -134,7 +139,9 @@ export default class WalletRecoveryPhraseEntryDialog extends Component {
         )}
 
         <DialogCloseButton onClose={onCancelBackup} />
-        <DialogBackButton onBack={onRestartBackup} />
+
+        {!isValid ? <DialogBackButton onBack={onRestartBackup} /> : null}
+
         {isValid && (
           <div>
             <CheckboxWithLongLabel


### PR DESCRIPTION
User should not be able to go back or clear the mnemonic after he/she entered it correctly:

<img width="902" alt="screenshot 2017-03-31 um 18 43 32" src="https://cloud.githubusercontent.com/assets/172414/24560233/311a1ce8-1642-11e7-9c80-a2a7be1bc7b7.png">