### PR TITLE
[DAEF-138] convert lovelace amounts from backend into ada on frontend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,8 @@
     "max-len": 1,
     "no-useless-escape": 1,
     "prefer-const": 1,
-    "object-curly-spacing": 1
+    "object-curly-spacing": 1,
+    "spaced-comment": 1
   },
   "plugins": [
     "flowtype-errors",

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -3,6 +3,7 @@ import ClientApi from 'daedalus-client-api';
 import { action } from 'mobx';
 import { ipcRenderer } from 'electron';
 import Log from 'electron-log';
+import BigNumber from 'bignumber.js';
 import Wallet from '../domain/Wallet';
 import WalletTransaction from '../domain/WalletTransaction';
 import type {
@@ -24,6 +25,7 @@ import {
   NotEnoughMoneyToSendError
 } from './errors';
 import type { AssuranceModeOption } from '../types/transactionAssuranceTypes';
+import { LOVELACES_PER_ADA } from '../config/numbersConfig';
 
 // const notYetImplemented = () => new Promise((_, reject) => {
 //   reject(new ApiMethodNotYetImplementedError());
@@ -60,7 +62,7 @@ export default class CardanoClientApi {
   async getWallets() {
     Log.debug('CardanoClientApi::getWallets called');
     const response = await ClientApi.getWallets();
-    return response.map(data => this._createWalletFromServerData(data));
+    return response.map(data => _createWalletFromServerData(data));
   }
 
   async getTransactions(request: getTransactionsRequest) {
@@ -68,7 +70,7 @@ export default class CardanoClientApi {
     Log.debug('CardanoClientApi::getTransactions called with', request);
     const history = await ClientApi.searchHistory(walletId, searchTerm, skip, limit);
     return new Promise((resolve) => resolve({
-      transactions: history[0].map(data => this._createTransactionFromServerData(data, walletId)),
+      transactions: history[0].map(data => _createTransactionFromServerData(data, walletId)),
       total: history[1]
     }));
   }
@@ -76,7 +78,7 @@ export default class CardanoClientApi {
   async createWallet(request: createWalletRequest) {
     Log.debug('CardanoClientApi::createWallet called with', request);
     const response = await ClientApi.newWallet('CWTPersonal', 'ADA', request.name, request.mnemonic);
-    return this._createWalletFromServerData(response);
+    return _createWalletFromServerData(response);
   }
 
   async deleteWallet(request: deleteWalletRequest) {
@@ -97,7 +99,7 @@ export default class CardanoClientApi {
       const response = await ClientApi.sendExtended(
         sender, receiver, amount, currency, title, description
       );
-      return this._createTransactionFromServerData(response);
+      return _createTransactionFromServerData(response);
     } catch (error) {
       console.error(error);
       if (error.message.includes('Not enough money to send')) {
@@ -119,34 +121,6 @@ export default class CardanoClientApi {
     return ClientApi.isValidRedeemCode(mnemonic);
   }
 
-  @action _createWalletFromServerData(data: ServerWalletStruct) {
-    return new Wallet({
-      id: data.cwAddress,
-      address: data.cwAddress,
-      amount: data.cwAmount.getCoin,
-      type: data.cwMeta.cwType,
-      currency: data.cwMeta.cwCurrency,
-      name: data.cwMeta.cwName,
-      assurance: data.cwMeta.cwAssurance,
-    });
-  }
-
-  @action _createTransactionFromServerData(data: ServerTransactionStruct) {
-    const isOutgoing = data.ctType.tag === 'CTOut';
-    const coins = data.ctAmount.getCoin;
-    const { ctmTitle, ctmDescription, ctmDate } = data.ctType.contents;
-    return new WalletTransaction({
-      id: data.ctId,
-      title: ctmTitle || isOutgoing ? 'Ada sent' : 'Ada received',
-      type: isOutgoing ? 'adaExpend' : 'adaIncome',
-      currency: 'ada',
-      amount: isOutgoing ? -1 * coins : coins,
-      date: new Date(ctmDate * 1000),
-      description: ctmDescription || '',
-      numberOfConfirmations: data.ctConfirmations,
-    });
-  }
-
   getWalletRecoveryPhrase() {
     return new Promise((resolve) => resolve(ClientApi.generateMnemonic().split(' ')));
   }
@@ -156,7 +130,7 @@ export default class CardanoClientApi {
     Log.debug('CardanoClientApi::restoreWallet called with', request);
     try {
       const restoredWallet = await ClientApi.restoreWallet('CWTPersonal', 'ADA', walletName, recoveryPhrase);
-      return this._createWalletFromServerData(restoredWallet);
+      return _createWalletFromServerData(restoredWallet);
     } catch (error) {
       Log.error(error);
       // TODO: backend will return something different here, if multiple wallets
@@ -176,7 +150,7 @@ export default class CardanoClientApi {
     Log.debug('CardanoClientApi::importWalletFromKey called with', request);
     try {
       const importedWallet = await ClientApi.importKey(request.filePath);
-      return this._createWalletFromServerData(importedWallet);
+      return _createWalletFromServerData(importedWallet);
     } catch (error) {
       console.error(error);
       if (error.message.includes('Wallet with that mnemonics already exists')) {
@@ -193,7 +167,7 @@ export default class CardanoClientApi {
       const response: ServerWalletStruct = await ClientApi.redeemADA(redemptionCode, walletId);
       // TODO: Update response when it is implemented on the backend,
       // currently only wallet is returned
-      return this._createWalletFromServerData(response);
+      return _createWalletFromServerData(response);
     } catch (error) {
       console.error(error);
       throw new RedeemAdaError();
@@ -337,3 +311,33 @@ type ServerTransactionStruct = {
   ctAmount: ServerCoinAmountStruct,
   ctConfirmations: number,
 }
+
+// ========== TRANSFORM SERVER DATA INTO FRONTEND MODELS =========
+
+const _createWalletFromServerData = action((data: ServerWalletStruct) => (
+  new Wallet({
+    id: data.cwAddress,
+    address: data.cwAddress,
+    amount: new BigNumber(data.cwAmount.getCoin).dividedBy(LOVELACES_PER_ADA),
+    type: data.cwMeta.cwType,
+    currency: data.cwMeta.cwCurrency,
+    name: data.cwMeta.cwName,
+    assurance: data.cwMeta.cwAssurance,
+  })
+));
+
+const _createTransactionFromServerData = action((data: ServerTransactionStruct) => {
+  const isOutgoing = data.ctType.tag === 'CTOut';
+  const coins = data.ctAmount.getCoin;
+  const { ctmTitle, ctmDescription, ctmDate } = data.ctType.contents;
+  return new WalletTransaction({
+    id: data.ctId,
+    title: ctmTitle || isOutgoing ? 'Ada sent' : 'Ada received',
+    type: isOutgoing ? 'adaExpend' : 'adaIncome',
+    currency: 'ada',
+    amount: new BigNumber(isOutgoing ? -1 * coins : coins).dividedBy(LOVELACES_PER_ADA),
+    date: new Date(ctmDate * 1000),
+    description: ctmDescription || '',
+    numberOfConfirmations: data.ctConfirmations,
+  });
+});

--- a/app/components/layout/TopBar.js
+++ b/app/components/layout/TopBar.js
@@ -13,7 +13,7 @@ export default class TopBar extends Component {
 
   static propTypes = {
     onToggleSidebar: PropTypes.func,
-    children: oneOrManyChildElements.isRequired,
+    children: oneOrManyChildElements,
     activeWallet: PropTypes.instanceOf(Wallet),
   };
 
@@ -27,7 +27,9 @@ export default class TopBar extends Component {
     const topBarTitle = activeWallet ? (
       <div className={styles.walletInfo}>
         <div className={styles.walletName}>{activeWallet.name}</div>
-        <div className={styles.walletAmount}>{activeWallet.amount + ' ' + activeWallet.currency}</div>
+        <div className={styles.walletAmount}>
+          {activeWallet.amount.toFormat() + ' ' + activeWallet.currency}
+        </div>
       </div>
     ) : null;
 

--- a/app/components/wallet/summary/WalletSummary.js
+++ b/app/components/wallet/summary/WalletSummary.js
@@ -2,7 +2,6 @@
 import React, { Component, PropTypes } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import numeral from 'numeral';
 import adaSymbolBig from '../../../assets/images/ada-symbol-big-dark.svg';
 import adaSymbolSmallest from '../../../assets/images/ada-symbol-smallest-dark.svg';
 import BorderedBox from '../../widgets/BorderedBox';
@@ -26,9 +25,9 @@ export default class WalletSummary extends Component {
 
   static propTypes = {
     walletName: PropTypes.string.isRequired,
-    amount: PropTypes.number.isRequired,
+    amount: PropTypes.string.isRequired,
     numberOfTransactions: PropTypes.number.isRequired,
-    pendingAmount: PropTypes.number.isRequired,
+    pendingAmount: PropTypes.string.isRequired,
     isLoadingTransactions: PropTypes.bool.isRequired,
   };
 
@@ -50,15 +49,13 @@ export default class WalletSummary extends Component {
         <BorderedBox>
           <div className={styles.walletName}>{walletName}</div>
           <div className={styles.walletAmount}>
-            {numeral(amount).format('0,0')}
+            {amount}
             <img src={adaSymbolBig} role="presentation" />
           </div>
-          {pendingAmount > 0 ? (
-            <div className={styles.pendingConfirmation}>
-              {`${intl.formatMessage(messages.pendingConfirmationLabel)}`}: {pendingAmount}
-              <img src={adaSymbolSmallest} role="presentation" />
-            </div>
-          ) : null}
+          <div className={styles.pendingConfirmation}>
+            {`${intl.formatMessage(messages.pendingConfirmationLabel)}`}: {pendingAmount}
+            <img src={adaSymbolSmallest} role="presentation" />
+          </div>
           {!isLoadingTransactions ? (
             <div className={styles.numberOfTransactions}>
               {intl.formatMessage(messages.transactionsLabel)}: {numberOfTransactions}

--- a/app/components/widgets/Transaction.js
+++ b/app/components/widgets/Transaction.js
@@ -115,7 +115,7 @@ export default class Transaction extends Component {
             <div className={styles.title}>
               {data.type === 'adaExpend' ? 'Ada Sent' : 'Ada Received'}
             </div>
-            <div className={styles.amount}>{data.amount}
+            <div className={styles.amount}>{data.amount.toFormat()}
               <img className={styles.currencySymbol} src={adaSymbol} role="presentation" />
             </div>
           </button>

--- a/app/config/numbersConfig.js
+++ b/app/config/numbersConfig.js
@@ -1,1 +1,1 @@
-export const LOVELACES_PER_ADA = 1000000000;
+export const LOVELACES_PER_ADA = 1000000;

--- a/app/config/numbersConfig.js
+++ b/app/config/numbersConfig.js
@@ -1,0 +1,1 @@
+export const LOVELACES_PER_ADA = 1000000000;

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -1,13 +1,14 @@
 // @flow
 import React, { Component, PropTypes } from 'react';
-import { observer, inject, PropTypes as MobxPropTypes } from 'mobx-react';
+import { observer, inject } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
-import Wallet from '../../domain/Wallet';
 import WalletTransactionsList from '../../components/wallet/transactions/WalletTransactionsList';
 import WalletSummary from '../../components/wallet/summary/WalletSummary';
 import WalletNoTransactions from '../../components/wallet/transactions/WalletNoTransactions';
 import VerticalFlexContainer from '../../components/layout/VerticalFlexContainer';
-import Request from '../../stores/lib/Request';
+import WalletsStore from '../../stores/WalletsStore';
+import TransactionsStore from '../../stores/TransactionsStore';
+import SettingsStore from '../../stores/SettingsStore';
 
 const messages = defineMessages({
   noTransactions: {
@@ -22,16 +23,9 @@ export default class WalletSummaryPage extends Component {
 
   static propTypes = {
     stores: PropTypes.shape({
-      wallets: PropTypes.shape({
-        active: PropTypes.instanceOf(Wallet),
-      }),
-      transactions: PropTypes.shape({
-        recent: MobxPropTypes.arrayOrObservableArray.isRequired,
-        hasAny: PropTypes.bool.isRequired,
-        totalAvailable: PropTypes.number.isRequired,
-        totalUnconfirmedAmount: PropTypes.number.isRequired,
-        recentTransactionsRequest: PropTypes.instanceOf(Request),
-      }),
+      wallets: PropTypes.instanceOf(WalletsStore),
+      transactions: PropTypes.instanceOf(TransactionsStore),
+      settings: PropTypes.instanceOf(SettingsStore),
     }).isRequired,
   };
 
@@ -71,9 +65,9 @@ export default class WalletSummaryPage extends Component {
       <VerticalFlexContainer>
         <WalletSummary
           walletName={wallet.name}
-          amount={wallet.amount}
+          amount={wallet.amount.toFormat()}
           numberOfTransactions={totalAvailable}
-          pendingAmount={totalUnconfirmedAmount}
+          pendingAmount={totalUnconfirmedAmount.toFormat()}
           isLoadingTransactions={recentTransactionsRequest.isExecutingFirstTime}
         />
         {walletTransactions}

--- a/app/domain/Wallet.js
+++ b/app/domain/Wallet.js
@@ -1,5 +1,6 @@
 // @flow
 import { observable, action, computed } from 'mobx';
+import BigNumber from 'bignumber.js';
 import WalletTransaction from './WalletTransaction';
 import type { AssuranceMode } from '../types/transactionAssuranceTypes';
 import { assuranceModes, assuranceModeOptions } from '../config/transactionAssuranceConfig';
@@ -11,7 +12,7 @@ export default class Wallet {
   address: string = '';
   currency: string = '';
   @observable name: string = '';
-  @observable amount: number;
+  @observable amount: BigNumber;
   @observable assurance: AssuranceMode;
   @observable transactions: Array<WalletTransaction> = [];
 
@@ -21,7 +22,7 @@ export default class Wallet {
     name: string,
     address: string,
     currency: string,
-    amount: number,
+    amount: BigNumber,
     assuranceMode: AssuranceMode,
   }) {
     Object.assign(this, data);

--- a/app/domain/WalletTransaction.js
+++ b/app/domain/WalletTransaction.js
@@ -1,5 +1,6 @@
 // @flow
 import { observable } from 'mobx';
+import BigNumber from 'bignumber.js';
 import type { AssuranceMode, AssuranceLevel } from '../types/transactionAssuranceTypes';
 import { assuranceLevels } from '../config/transactionAssuranceConfig';
 
@@ -11,7 +12,7 @@ export default class WalletTransaction {
   @observable type: TransactionType;
   @observable title: string = '';
   @observable currency: string = '';
-  @observable amount: number;
+  @observable amount: BigNumber;
   @observable date: Date;
   @observable description: string = '';
   @observable numberOfConfirmations: number = 0;
@@ -21,7 +22,7 @@ export default class WalletTransaction {
     type: TransactionType,
     title: string,
     currency: string,
-    amount: number,
+    amount: BigNumber,
     date: Date,
     description: string,
     numberOfConfirmations: number

--- a/app/stores/SettingsStore.js
+++ b/app/stores/SettingsStore.js
@@ -1,5 +1,6 @@
 // @flow
 import { observable, computed } from 'mobx';
+import BigNumber from 'bignumber.js';
 import Store from './lib/Store';
 import CachedRequest from './lib/CachedRequest';
 
@@ -7,7 +8,26 @@ export default class SettingsStore extends Store {
 
   @observable termsOfUseRequest = new CachedRequest(this.api, 'getTermsOfUse');
 
+  @observable bigNumberDecimalFormat = {
+    decimalSeparator: ',',
+    groupSeparator: '.',
+    groupSize: 3,
+    secondaryGroupSize: 0,
+    fractionGroupSeparator: ' ',
+    fractionGroupSize: 0
+  };
+
+  setup() {
+    this.registerReactions([
+      this._setBigNumberFormat,
+    ]);
+  }
+
   @computed get termsOfUse(): string {
     return this.termsOfUseRequest.execute().result;
+  }
+
+  _setBigNumberFormat = () => {
+    BigNumber.config({ FORMAT: this.bigNumberDecimalFormat });
   }
 }

--- a/app/stores/SidebarStore.js
+++ b/app/stores/SidebarStore.js
@@ -37,7 +37,7 @@ export default class SidebarStore extends Store {
     return wallets.all.map(w => ({
       id: w.id,
       title: w.name,
-      info: `${w.amount} ${w.currency}`,
+      info: `${w.amount.toFormat()} ${w.currency}`,
       isConnected: networkStatus.isConnected,
     }));
   }

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   },
   "dependencies": {
     "aes-js": "^2.1.0",
+    "bignumber.js": "^4.0.0",
     "bip39": "^2.2.0",
     "blakejs": "^1.0.1",
     "classnames": "^2.2.5",


### PR DESCRIPTION
This PR fixes the current bug that we treat the lovelace amounts from backend like ADA in the frontend. It introduces the [bignumber.js](https://github.com/MikeMcl/bignumber.js/) package to work with arbitrary numbers and formatting.

<img width="902" alt="screenshot 2017-04-04 um 14 23 22" src="https://cloud.githubusercontent.com/assets/172414/24656317/4ed38456-1942-11e7-971e-0bba4f99d94a.png">
