### PR TITLE
[DAEF-146] Add linux support for logger

### DIFF
--- a/electron/lib/getLogsFolderPath.js
+++ b/electron/lib/getLogsFolderPath.js
@@ -8,5 +8,12 @@ export default (platform, env, appName) => {
     case 'win32': {
       return path.join(env['APPDATA'], appName, 'Logs');
     }
+    case 'linux': {
+      return path.join(env['HOME'], '.config', appName, 'Logs');
+    }
+    default: {
+      console.log('Unsupported platform');
+      process.exit(1);
+    }
   }
 };


### PR DESCRIPTION
This PR introduces Linux configuration for the logger and fixes Daedalus not working on Linux issue.