### PR TITLE
Fix/daef 148 add wallet dialog does not disappear immediately after wallet creation

### DIFF
--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -96,12 +96,14 @@ export default class WalletsStore extends Store {
   };
 
   _finishWalletCreation = async () => {
+    runInAction(() => { this.isAddWalletDialogOpen = false; });
     this._newWalletDetails.mnemonic = this.stores.walletBackup.recoveryPhrase.join(' ');
     const wallet = await this.createWalletRequest.execute(this._newWalletDetails).promise;
     if (wallet) {
       await this.walletsRequest.patch(result => { result.push(wallet); });
       this.goToWalletRoute(wallet.id);
-      runInAction(() => { this.isAddWalletDialogOpen = false; });
+    } else {
+      runInAction(() => { this.isAddWalletDialogOpen = true; });
     }
   };
 


### PR DESCRIPTION
This PR introduces a fix which prevents "Add wallet" dialog from showing up immediately after wallet creation.