### PR TITLE
Fix/daef 154 quickly chaning the amount value on the send form

### DIFF
--- a/app/components/wallet/WalletSendForm.js
+++ b/app/components/wallet/WalletSendForm.js
@@ -4,8 +4,8 @@ import { observer } from 'mobx-react';
 import Input from 'react-toolbox/lib/input/Input';
 import Button from 'react-toolbox/lib/button/Button';
 import { defineMessages, intlShape } from 'react-intl';
-import isInt from 'validator/lib/isInt';
 import BigNumber from 'bignumber.js';
+import { isValidAmountInLovlelaces } from '../../lib/validations';
 import { LOVELACES_PER_ADA, DECIMAL_PLACES_IN_ADA } from '../../config/numbersConfig';
 import ReactToolboxMobxForm from '../../lib/ReactToolboxMobxForm';
 import BorderedBox from '../widgets/BorderedBox';
@@ -117,11 +117,7 @@ export default class WalletSendForm extends Component {
         placeholder: this.context.intl.formatMessage(messages.amountHint),
         value: '',
         validate: ({ field }) => {
-          const isValid = isInt(field.value, {
-            allow_leading_zeroes: false,
-            min: 1,
-            max: 45000000000000000,
-          });
+          const isValid = isValidAmountInLovlelaces(field.value);
           return [isValid, this.context.intl.formatMessage(messages.invalidAmount)];
         },
         bindings: 'ReactToolbox',
@@ -152,7 +148,8 @@ export default class WalletSendForm extends Component {
     const { isSubmitting, error } = this.props;
 
     let adaAmount = '0';
-    if (form.$('amount').value !== '' && form.$('amount').isValid) {
+    const enteredAmount = form.$('amount').value;
+    if (enteredAmount !== '' && isValidAmountInLovlelaces(enteredAmount)) {
       const lovelaces = new BigNumber(form.$('amount').value);
       adaAmount = lovelaces.dividedBy(LOVELACES_PER_ADA).toFormat(DECIMAL_PLACES_IN_ADA);
     }

--- a/app/components/wallet/WalletSendForm.js
+++ b/app/components/wallet/WalletSendForm.js
@@ -5,7 +5,7 @@ import Input from 'react-toolbox/lib/input/Input';
 import Button from 'react-toolbox/lib/button/Button';
 import { defineMessages, intlShape } from 'react-intl';
 import BigNumber from 'bignumber.js';
-import { isValidAmountInLovlelaces } from '../../lib/validations';
+import { isValidAmountInLovelaces } from '../../lib/validations';
 import { LOVELACES_PER_ADA, DECIMAL_PLACES_IN_ADA } from '../../config/numbersConfig';
 import ReactToolboxMobxForm from '../../lib/ReactToolboxMobxForm';
 import BorderedBox from '../widgets/BorderedBox';
@@ -117,7 +117,7 @@ export default class WalletSendForm extends Component {
         placeholder: this.context.intl.formatMessage(messages.amountHint),
         value: '',
         validate: ({ field }) => {
-          const isValid = isValidAmountInLovlelaces(field.value);
+          const isValid = isValidAmountInLovelaces(field.value);
           return [isValid, this.context.intl.formatMessage(messages.invalidAmount)];
         },
         bindings: 'ReactToolbox',
@@ -149,7 +149,7 @@ export default class WalletSendForm extends Component {
 
     let adaAmount = '0';
     const enteredAmount = form.$('amount').value;
-    if (enteredAmount !== '' && isValidAmountInLovlelaces(enteredAmount)) {
+    if (enteredAmount !== '' && isValidAmountInLovelaces(enteredAmount)) {
       const lovelaces = new BigNumber(form.$('amount').value);
       adaAmount = lovelaces.dividedBy(LOVELACES_PER_ADA).toFormat(DECIMAL_PLACES_IN_ADA);
     }

--- a/app/lib/validations.js
+++ b/app/lib/validations.js
@@ -1,5 +1,15 @@
+import isInt from 'validator/lib/isInt';
+
 export const isValidWalletName = (walletName) => walletName.length >= 3;
 
 export const isNotEmptyString = (value) => value !== '';
 
 export const isValidCurrency = (value) => value === 'ada';
+
+export const isValidAmountInLovlelaces = (value: string) => (
+  isInt(value, {
+    allow_leading_zeroes: false,
+    min: 1,
+    max: 45000000000000000,
+  })
+);

--- a/app/lib/validations.js
+++ b/app/lib/validations.js
@@ -6,7 +6,7 @@ export const isNotEmptyString = (value) => value !== '';
 
 export const isValidCurrency = (value) => value === 'ada';
 
-export const isValidAmountInLovlelaces = (value: string) => (
+export const isValidAmountInLovelaces = (value: string) => (
   isInt(value, {
     allow_leading_zeroes: false,
     min: 1,

--- a/features/send-money-to-receiver.feature
+++ b/features/send-money-to-receiver.feature
@@ -15,8 +15,8 @@ Feature: Send Money to Receiver
     And I submit the wallet send form
     Then I should be on the "Personal Wallet" wallet "summary" screen
     And the latest transaction should show:
-      | title    | amount    |
-      | Ada Sent | -0,000010 |
+      | title                      | amount    |
+      | wallet.transaction.adaSent | -0.000010 |
 
   Scenario: User Submits Empty Form
     Given I am on the "Personal Wallet" wallet "send" screen

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -116,7 +116,8 @@ export default function () {
     const expectedData = table.hashes()[0];
     await this.client.waitForVisible('.Transaction_title');
     const transactionTitle = await this.client.getText('.Transaction_title');
-    expect(transactionTitle[0]).to.equal(expectedData.title);
+    const expectedTransactionTitle = await this.intl(expectedData.title);
+    expect(expectedTransactionTitle).to.equal(transactionTitle[0]);
     const transactionAmount = await this.client.getText('.Transaction_amount');
     expect(transactionAmount[0]).to.include(expectedData.amount);
   });

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -115,11 +115,13 @@ export default function () {
   this.Then(/^the latest transaction should show:$/, async function (table) {
     const expectedData = table.hashes()[0];
     await this.client.waitForVisible('.Transaction_title');
-    const transactionTitle = await this.client.getText('.Transaction_title');
+    let transactionTitles = await this.client.getText('.Transaction_title');
+    transactionTitles = [].concat(transactionTitles);
     const expectedTransactionTitle = await this.intl(expectedData.title);
-    expect(expectedTransactionTitle).to.equal(transactionTitle[0]);
-    const transactionAmount = await this.client.getText('.Transaction_amount');
-    expect(transactionAmount[0]).to.include(expectedData.amount);
+    expect(expectedTransactionTitle).to.equal(transactionTitles[0]);
+    let transactionAmounts = await this.client.getText('.Transaction_amount');
+    transactionAmounts = [].concat(transactionAmounts);
+    expect(expectedData.amount).to.include(transactionAmounts[0]);
   });
 
 };


### PR DESCRIPTION
This PR fixes issue with quickly typing invalid number with a comma in the wallet send form. It also fixes one acceptance test introduced by new translation.

![screen shot 2017-04-12 at 16 41 08](https://cloud.githubusercontent.com/assets/4280521/24964742/6544d8e6-1fa2-11e7-9031-707961c2908b.png)
