### PR TITLE
fix/daef-160 Save users locale to local storage

### DIFF
--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -50,13 +50,15 @@ export default class Loading extends Component {
     hasBlockSyncingStarted: PropTypes.bool.isRequired,
     isLoadingWallets: PropTypes.bool.isRequired,
     syncPercentage: PropTypes.number.isRequired,
+    hasLoadedCurrentLocale: PropTypes.bool.isRequired,
   };
 
   render() {
     const { intl } = this.context;
     const {
       isConnecting, isSyncing, syncPercentage, isLoadingWallets,
-      hasBeenConnected, hasBlockSyncingStarted
+      hasBeenConnected, hasBlockSyncingStarted,
+      hasLoadedCurrentLocale,
     } = this.props;
     const componentStyles = classNames([
       styles.component,
@@ -68,28 +70,37 @@ export default class Loading extends Component {
     return (
       <div className={componentStyles}>
         <img className={styles.logo} src={logo} role="presentation" />
-        {isConnecting && !hasBlockSyncingStarted && (
-          <div className={styles.connecting}>
-            <h1 className={styles.headline}>{intl.formatMessage(connectingMessage)}</h1>
-          </div>
-        )}
-        {isConnecting && hasBlockSyncingStarted && (
-          <div className={styles.connecting}>
-            <h1 className={styles.headline}>
-              {intl.formatMessage(messages.waitingForSyncToStart)}
-            </h1>
-          </div>
-        )}
-        {isSyncing && (
-          <div className={styles.syncing}>
-            <h1 className={styles.headline}>
-              {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(2)}%
-            </h1>
-          </div>
-        )}{!isSyncing && !isConnecting && isLoadingWallets && (
-          <div className={styles.syncing}>
-            <h1 className={styles.headline}>Loading wallet data</h1>
-            <LoadingSpinner />
+        {hasLoadedCurrentLocale && (
+          <div>
+            {isConnecting && !hasBlockSyncingStarted && (
+              <div className={styles.connecting}>
+                <h1 className={styles.headline}>
+                  {intl.formatMessage(connectingMessage)}
+                </h1>
+              </div>
+            )}
+            {isConnecting && hasBlockSyncingStarted && (
+              <div className={styles.connecting}>
+                <h1 className={styles.headline}>
+                  {intl.formatMessage(messages.waitingForSyncToStart)}
+                </h1>
+              </div>
+            )}
+            {isSyncing && (
+              <div className={styles.syncing}>
+                <h1 className={styles.headline}>
+                  {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(2)}%
+                </h1>
+              </div>
+            )}
+            {!isSyncing && !isConnecting && isLoadingWallets && (
+              <div className={styles.syncing}>
+                <h1 className={styles.headline}>
+                  {intl.formatMessage(messages.loadingWalletData)}
+                </h1>
+                <LoadingSpinner />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/app/containers/LoadingPage.js
+++ b/app/containers/LoadingPage.js
@@ -17,18 +17,23 @@ export default class LoadingPage extends Component {
         hasBeenConnected: PropTypes.bool.isRequired,
         syncPercentage: PropTypes.number.isRequired,
       }).isRequired,
+      app: PropTypes.shape({
+        hasLoadedCurrentLocale: PropTypes.bool.isRequired,
+      }).isRequired,
     }).isRequired,
   };
 
   render() {
+    const { stores } = this.props;
     const {
       isConnecting,
       isSyncing,
       syncPercentage,
       isLoadingWallets,
       hasBeenConnected,
-      hasBlockSyncingStarted
-    } = this.props.stores.networkStatus;
+      hasBlockSyncingStarted,
+    } = stores.networkStatus;
+    const { hasLoadedCurrentLocale } = stores.app;
     return (
       <CenteredLayout>
         <Loading
@@ -38,6 +43,7 @@ export default class LoadingPage extends Component {
           isLoadingWallets={isLoadingWallets}
           hasBeenConnected={hasBeenConnected}
           hasBlockSyncingStarted={hasBlockSyncingStarted}
+          hasLoadedCurrentLocale={hasLoadedCurrentLocale}
         />
       </CenteredLayout>
     );

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "classnames": "2.2.5",
     "css-modules-require-hook": "4.0.6",
     "electron-debug": "1.1.0",
+    "electron-json-storage": "3.0.4",
     "electron-log": "2.0.2",
     "es6-error": "4.0.2",
     "faker": "3.1.0",


### PR DESCRIPTION
This PR replaces API storing loading and saving users locale from the backend with local storage. This is temporary workaround before we implement `BackendReady` notification. 