### PR TITLE
[DAEF-158] Update to renamed endpoints for ada redemption

### DIFF
--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -135,11 +135,11 @@ export default class CardanoClientApi {
   }
 
   isValidRedemptionKey(mnemonic: string): Promise<bool> {
-    return ClientApi.isValidRedeemCode(mnemonic);
+    return ClientApi.isValidRedemptionKey(mnemonic);
   }
 
-  isValidPostVendRedeemCode(redeemCode: string): Promise<bool> {
-    return ClientApi.isValidPostVendRedeemCode(redeemCode);
+  isValidPaperVendRedemptionKey(redeemCode: string): Promise<bool> {
+    return ClientApi.isValidPaperVendRedemptionKey(redeemCode);
   }
 
   isValidRedemptionMnemonic(mnemonic: string): Promise<bool> {
@@ -189,7 +189,7 @@ export default class CardanoClientApi {
     const { redemptionCode, walletId } = request;
     Log.debug('CardanoClientApi::redeemAda called with', request);
     try {
-      const response: ServerWalletStruct = await ClientApi.redeemADA(redemptionCode, walletId);
+      const response: ServerWalletStruct = await ClientApi.redeemAda(redemptionCode, walletId);
       return _createTransactionFromServerData(response);
     } catch (error) {
       console.error(error);
@@ -203,7 +203,7 @@ export default class CardanoClientApi {
     Log.debug('CardanoClientApi::redeemPaperVendedAda called with', request);
     try {
       const response: ServerWalletStruct =
-        await ClientApi.postVendRedeemADA(shieldedRedemptionKey, mnemonics, walletId);
+        await ClientApi.redeemAdaPaperVend(shieldedRedemptionKey, mnemonics, walletId);
       console.log('RESPONSE', response);
       return _createTransactionFromServerData(response);
     } catch (error) {

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -327,7 +327,11 @@ export default class AdaRedemptionForm extends Component {
     let canSubmit = false;
     if (redemptionType === 'regular' && redemptionCode !== '') canSubmit = true;
     if (redemptionType === 'forceVended' && redemptionCode !== '') canSubmit = true;
-    if (redemptionType === 'paperVended' && shieldedRedemptionKeyField.isValid && passPhrase.isValid) canSubmit = true;
+    if (
+      redemptionType === 'paperVended' &&
+      shieldedRedemptionKeyField.isValid && shieldedRedemptionKeyField.isDirty &&
+      passPhrase.isValid && passPhrase.isDirty
+    ) canSubmit = true;
 
     let instructionMessage = '';
     switch (redemptionType) {

--- a/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
@@ -23,7 +23,7 @@ export default class AdaRedemptionSuccessOverlay extends Component {
   };
 
   static propTypes = {
-    amount: PropTypes.number.isRequired,
+    amount: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
   };
 

--- a/app/containers/wallet/AdaRedemptionPage.js
+++ b/app/containers/wallet/AdaRedemptionPage.js
@@ -37,7 +37,7 @@ export default class AdaRedemptionPage extends Component {
         isCertificateEncrypted: PropTypes.bool.isRequired,
         isValidRedemptionKey: PropTypes.func.isRequired,
         isValidRedemptionMnemonic: PropTypes.func.isRequired,
-        isValidPostVendRedeemCode: PropTypes.func.isRequired,
+        isValidPaperVendRedemptionKey: PropTypes.func.isRequired,
         redemptionType: PropTypes.string.isRequired,
         error: PropTypes.instanceOf(Error),
       }).isRequired,
@@ -56,7 +56,7 @@ export default class AdaRedemptionPage extends Component {
     const { wallets, adaRedemption } = this.props.stores;
     const {
       redeemAdaRequest, redeemPaperVendedAdaRequest, isCertificateEncrypted, isValidRedemptionKey,
-      redemptionType, isValidRedemptionMnemonic, isValidPostVendRedeemCode, error
+      redemptionType, isValidRedemptionMnemonic, isValidPaperVendRedemptionKey, error
     } = adaRedemption;
     const {
       chooseRedemptionType, setCertificate, setPassPhrase, setRedemptionCode, removeCertificate,
@@ -95,7 +95,7 @@ export default class AdaRedemptionPage extends Component {
           onRemoveCertificate={removeCertificate}
           mnemonicValidator={isValidRedemptionMnemonic}
           redemptionCodeValidator={isValidRedemptionKey}
-          postVendRedemptionCodeValidator={isValidPostVendRedeemCode}
+          postVendRedemptionCodeValidator={isValidPaperVendRedemptionKey}
           redemptionType={redemptionType}
           showInputsForDecryptingForceVendedCertificate={
             showInputsForDecryptingForceVendedCertificate

--- a/app/stores/AdaRedemptionStore.js
+++ b/app/stores/AdaRedemptionStore.js
@@ -57,7 +57,7 @@ export default class AdaRedemptionStore extends Store {
 
   isValidRedemptionKey = (redemptionKey: string) => this.api.isValidRedemptionKey(redemptionKey);
   isValidRedemptionMnemonic = (mnemonic: string) => this.api.isValidRedemptionMnemonic(mnemonic);
-  isValidPostVendRedeemCode = (mnemonic: string) => this.api.isValidPostVendRedeemCode(mnemonic);
+  isValidPaperVendRedemptionKey = (mnemonic: string) => this.api.isValidPaperVendRedemptionKey(mnemonic);
 
   @action _chooseRedemptionType = (params: {
     redemptionType: redemptionTypeChoices,
@@ -135,7 +135,7 @@ export default class AdaRedemptionStore extends Store {
     const errorMessage = isString(error) ? error : error.message;
     if (errorMessage.includes('Invalid mnemonic')) {
       this.error = new InvalidMnemonicError();
-    } else {
+    } else if (this.redemptionType === 'regular') {
       this.error = new AdaRedemptionCertificateParseError();
     }
     this.redemptionCode = '';


### PR DESCRIPTION
This PR updates API calls to renamed Ada redemption endpoints. It also fixes two smaller issues: Backend now returns a string in the transaction with redeemed Ada, not number. And parsing error specific to regular vending is now only displayed when the user is doing the redemption for regular vended Ada. 