### PR TITLE
[DEVOPS-38] Hide minimized CMD window

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -16,7 +16,7 @@ launcherScript :: [String]
 launcherScript =
   [ "@echo off"
   , "SET DAEDALUS_DIR=%~dp0"
-  , "\"%DAEDALUS_DIR%\\cardano-launcher.exe\" " <> args
+  , "start /D \"%DAEDALUS_DIR%\" cardano-launcher.exe " <> args
   ]
   where
     args = launcherArgs $ Launcher


### PR DESCRIPTION
The batch script shortcut target introduced in CSLA-62 causes a
minimized CMD window to spawn when opening the Daedalus shortcut.

This approach for suppressing it has been tested manually on Windows
Server 2012 r2.