### PR TITLE
[DAEF-170] Fix wallet name hardcoded in japanese translation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changelog
 
 ### Fixes
 
-- Hamburger button" and wallet's name are present on the "Ada redemption" and "Settings" screens
+- Wallet name on the send screen was hardcoded in Japanese translation
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 Changelog
 =========
 
+## vNEXT
+
+### Features
+
+### Fixes
+
+- Hamburger button" and wallet's name are present on the "Ada redemption" and "Settings" screens
+
+### Chores
+
+## 0.6.0
+
+### Features
+
+- Ada redemption with certificate decryption and parsing to extract the redemption key
+- Transaction assurance level with color coding for transactions and settings for a normal or strict mode
+- Wallet settings page with wallet deletion and transaction assurance level settings
+- User interface language option on application start and in settings with English and Japanese translations
+- Ada amounts formatting with thousands separator for displaying and entering amounts
+- Application header updated to show wallet name and amount of money in the wallet
+- Copy wallet address to the clipboard with UI notification
+- Testnet label
+- Application level settings page with language choice option
+- Wallet summary page
+- Showing absolute percentage with two decimals on the blockchain sync page
+- File logging and sending logs to Papertrail logging service without sensitive user data
+
+### Fixes
+
+- Toggling the application bar not working properly
+- UI glitch when quickly typing in Ada amounts on the send money form
+- “Add wallet” dialog does not disappear immediately after wallet creation
+- Clearing correctly entered backup recovery phrase should not be possible
+- Sidebar “randomly” closes/opens when navigating
+- Ada redemption overlay should also cover the wallet navigation
+- No transactions message is not vertically centered on Transactions page
+- Transactions ordering
+- Smaller UI improvements and fixes
+
+
 ## 0.5.0
 
 ![Main Wallet screenshot in 0.5.0](screenshots/2016-11-24 release 0.5.0 main-wallet.png)

--- a/app/i18n/locales/ja-JP.json
+++ b/app/i18n/locales/ja-JP.json
@@ -79,7 +79,7 @@
   "wallet.navigation.transactions": "トランズアクション",
   "wallet.receive.page.addressCopyNotificationMessage": "ウォレットアドレスのコピーに成功しました",
   "wallet.receive.page.instructions": "ウォレット受け取り手順",
-  "wallet.receive.page.title": "ショッピングウォレットアドレス",
+  "wallet.receive.page.title": "<strong>{walletName}</strong>のアドレス",
   "wallet.recovery.phrase.show.entry.dialog.button.labelClear": "取消",
   "wallet.recovery.phrase.show.entry.dialog.button.labelConfirm": "確認",
   "wallet.redeem.choices.tab.title.forceVended": "強制ヴェンド",


### PR DESCRIPTION
Wallet name was hardcoded to "Shopping" in Japanese translation. This PR fixes that.

![screen shot 2017-04-19 at 12 51 13](https://cloud.githubusercontent.com/assets/4280521/25176590/e29f03d2-24fe-11e7-8541-edb21481ec8d.png)
