### PR TITLE
Fix/daef 165 hamburger button and wallets name are present on the Ada redemption and Settings screens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 ### Fixes
 
 - Wallet name on the send screen was hardcoded in Japanese translation
+- Hamburger button" and wallet's name are present on the "Ada redemption" and "Settings" screens
 
 ### Chores
 
@@ -95,9 +96,9 @@ Changelog
 ### Features
 
 - Added wallet creation screen that appears when there is no wallet yet
-- Updated to the latest design specs and refactor to 
+- Updated to the latest design specs and refactor to
 [react-toolbox](http://react-toolbox.com/) instead of
-material-ui for the UI components. This gives us much better style 
+material-ui for the UI components. This gives us much better style
 customization and theming options.
 - Cleaned up the boilerplate app menus
 - Added basic form validations using [mobx-react-form](https://github.com/foxhound87/mobx-react-form)
@@ -105,7 +106,7 @@ customization and theming options.
 - Added wallet send / receive / transactions screens
 - Form submitting UX updated to the design specifications with introduction of button loading spinners
 and support for submitting the form with enter key
-- Added cut, copy & paste application menu items and keyboard shortcuts 
+- Added cut, copy & paste application menu items and keyboard shortcuts
 
 ### Fixes
 

--- a/app/components/layout/TopBar.js
+++ b/app/components/layout/TopBar.js
@@ -8,6 +8,8 @@ import Wallet from '../../domain/Wallet';
 import menuIcon from '../../assets/images/menu-ic.svg';
 import { oneOrManyChildElements } from '../../propTypes';
 import styles from './TopBar.scss';
+import { matchRoute } from '../../lib/routing-helpers';
+import { ROUTES } from '../../Routes';
 
 @observer
 export default class TopBar extends Component {
@@ -16,16 +18,19 @@ export default class TopBar extends Component {
     onToggleSidebar: PropTypes.func,
     children: oneOrManyChildElements,
     activeWallet: PropTypes.instanceOf(Wallet),
+    currentRoute: PropTypes.string.isRequired,
   };
 
   render() {
-    const { onToggleSidebar, activeWallet } = this.props;
+    const { onToggleSidebar, activeWallet, currentRoute } = this.props;
+    const walletRoutesMatch = matchRoute(`${ROUTES.WALLETS.ROOT}/:id(*page)`, currentRoute);
     const sidebarToggleIcon = onToggleSidebar && <img className={styles.sidebarIcon} src={menuIcon} role="presentation" />;
+    const showWalletInfo = activeWallet && walletRoutesMatch;
     const topBarStyles = classNames([
-      !activeWallet ? styles.noWallet : null,
+      showWalletInfo ? styles.withWallet : styles.withoutWallet,
     ]);
 
-    const topBarTitle = activeWallet ? (
+    const topBarTitle = showWalletInfo ? (
       <div className={styles.walletInfo}>
         <div className={styles.walletName}>{activeWallet.name}</div>
         <div className={styles.walletAmount}>
@@ -37,8 +42,8 @@ export default class TopBar extends Component {
     return (
       <RTAppBar
         className={topBarStyles}
-        leftIcon={sidebarToggleIcon}
-        onLeftIconClick={onToggleSidebar}
+        leftIcon={walletRoutesMatch ? sidebarToggleIcon : null}
+        onLeftIconClick={walletRoutesMatch ? onToggleSidebar : null}
       >
         <div className={styles.topBarTitle}>{topBarTitle}</div>
         {this.props.children}

--- a/app/components/layout/TopBar.scss
+++ b/app/components/layout/TopBar.scss
@@ -3,31 +3,33 @@
   height: 100%;
 }
 
-.noWallet {
+.withoutWallet {
   background: $color-primary-dark url("../../assets/images/daedalus-logo-header-nologo.svg") no-repeat center !important;
   background-size: 220px !important;
   box-shadow: 0 5px 20px 0 rgba(0, 0, 0, 0.25) !important;
 }
 
-.topBarTitle {
-  flex-grow: 1;
+.withWallet {
+  .walletInfo {
+    color: $color-lighter-grey;
+    font-family: $font-regular;
+    text-align: center;
+    text-shadow: 0 2.5px 10px rgba(0, 0, 0, 0.25);
+
+    .walletName {
+      font-size: 21px;
+    }
+
+    .walletAmount {
+      font-size: 14px;
+      font-weight: 300;
+      letter-spacing: 0.5px;
+      line-height: 1.36;
+      opacity: 0.7;
+    }
+  }
 }
 
-.walletInfo {
-  color: $color-lighter-grey;
-  font-family: $font-regular;
-  text-align: center;
-  text-shadow: 0 2.5px 10px rgba(0, 0, 0, 0.25);
-
-  .walletName {
-    font-size: 21px;
-  }
-
-  .walletAmount {
-    font-size: 14px;
-    font-weight: 300;
-    letter-spacing: 0.5px;
-    line-height: 1.36;
-    opacity: 0.7;
-  }
+.topBarTitle {
+  flex-grow: 1;
 }

--- a/app/containers/MainLayout.js
+++ b/app/containers/MainLayout.js
@@ -53,6 +53,9 @@ export default class MainLayout extends Component {
         }).isRequired,
         activeSidebarCategory: PropTypes.string,
       }).isRequired,
+      app: PropTypes.shape({
+        currentRoute: PropTypes.string.isRequired,
+      }).isRequired,
     }).isRequired,
     actions: PropTypes.shape({
       router: PropTypes.shape({
@@ -81,7 +84,7 @@ export default class MainLayout extends Component {
 
   render() {
     const { actions, stores } = this.props;
-    const { sidebar, wallets, networkStatus } = stores;
+    const { sidebar, wallets, networkStatus, app } = stores;
     const { restoreRequest, isWalletKeyImportDialogOpen } = wallets;
     const {
       toggleAddWallet, toggleCreateWalletDialog, toggleWalletRestore
@@ -124,7 +127,11 @@ export default class MainLayout extends Component {
     );
 
     const topbar = (
-      <TopBar onToggleSidebar={actions.sidebar.toggleSubMenus} activeWallet={activeWallet}>
+      <TopBar
+        onToggleSidebar={actions.sidebar.toggleSubMenus}
+        activeWallet={activeWallet}
+        currentRoute={app.currentRoute}
+      >
         {testEnvironmentLabel}
         <NodeSyncStatusIcon
           isSynced={isSynced}

--- a/app/containers/profile/LanguageSelectionPage.js
+++ b/app/containers/profile/LanguageSelectionPage.js
@@ -19,6 +19,7 @@ export default class LanguageSelectionPage extends Component {
       app: PropTypes.shape({
         setProfileLocaleRequest: PropTypes.instanceOf(Request).isRequired,
         LANGUAGE_OPTIONS: PropTypes.array.isRequired,
+        currentRoute: PropTypes.string.isRequired,
       }).isRequired,
     }).isRequired,
   };
@@ -28,9 +29,9 @@ export default class LanguageSelectionPage extends Component {
   };
 
   render() {
-    const { setProfileLocaleRequest, LANGUAGE_OPTIONS } = this.props.stores.app;
+    const { setProfileLocaleRequest, LANGUAGE_OPTIONS, currentRoute } = this.props.stores.app;
     const isSubmitting = setProfileLocaleRequest.isExecuting;
-    const topbar = <TopBar />;
+    const topbar = <TopBar currentRoute={currentRoute} />;
     return (
       <TopBarLayout
         topbar={topbar}


### PR DESCRIPTION
This PR Introduces a fix for displaying hamburger button and wallet name in header only on wallet pages.
![wallets page header](https://cloud.githubusercontent.com/assets/18653950/25177333/c5b4922a-2501-11e7-8618-7ba8469fe3b4.png)
![ada redemption page header](https://cloud.githubusercontent.com/assets/18653950/25177334/c5b6f3d0-2501-11e7-9a06-240afed81eac.png)
![settings page header](https://cloud.githubusercontent.com/assets/18653950/25177335/c5bbc41e-2501-11e7-813e-0339302d06f0.png)
