### PR TITLE
Fix/daef-132 button on the wallet send screen is too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 ### Fixes
 
 - Wallet name on the send screen was hardcoded in Japanese translation
+- Button on the wallet send screen is too large
 
 ### Chores
 
@@ -95,9 +96,9 @@ Changelog
 ### Features
 
 - Added wallet creation screen that appears when there is no wallet yet
-- Updated to the latest design specs and refactor to 
+- Updated to the latest design specs and refactor to
 [react-toolbox](http://react-toolbox.com/) instead of
-material-ui for the UI components. This gives us much better style 
+material-ui for the UI components. This gives us much better style
 customization and theming options.
 - Cleaned up the boilerplate app menus
 - Added basic form validations using [mobx-react-form](https://github.com/foxhound87/mobx-react-form)
@@ -105,7 +106,7 @@ customization and theming options.
 - Added wallet send / receive / transactions screens
 - Form submitting UX updated to the design specifications with introduction of button loading spinners
 and support for submitting the form with enter key
-- Added cut, copy & paste application menu items and keyboard shortcuts 
+- Added cut, copy & paste application menu items and keyboard shortcuts
 
 ### Fixes
 

--- a/app/components/wallet/WalletSendForm.scss
+++ b/app/components/wallet/WalletSendForm.scss
@@ -5,15 +5,14 @@
   padding: 20px;
 }
 
-.submitButtonSpinning {
-  width: 100%;
-  @include loading-spinner("../../assets/images/spinner-light.svg");
+.submitButtonSpinning, .submitButton {
+  display: block !important;
+  margin: 0 auto;
+  width: 360px;
 }
 
-.submitButton {
-  width: 65%;
-  margin: 0 auto;
-  display: block !important;
+.submitButtonSpinning {
+  @include loading-spinner("../../assets/images/spinner-light.svg");
 }
 
 .error {


### PR DESCRIPTION
This PR introduces a fix for too large button on wallet send screen.
![wallet send screen button submitting](https://cloud.githubusercontent.com/assets/18653950/25178298/964dbf12-2505-11e7-9933-8adb8b932757.png)
![wallet send screen button](https://cloud.githubusercontent.com/assets/18653950/25178299/964f6ad8-2505-11e7-9e23-967cf0cd3530.png)
