### PR TITLE
Fix/daef 175 send form is reset after unsuccessful submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 ### Fixes
 
 - Verification of mnemonic recovery phrase during wallet backup is not working if it contains duplicate words.
+- Prevent wallet send form reset on submit
 
 ### Chores
 

--- a/app/components/wallet/WalletSendForm.js
+++ b/app/components/wallet/WalletSendForm.js
@@ -144,7 +144,6 @@ export default class WalletSendForm extends Component {
         const formValues = form.values();
         formValues.amount = this.adaToLovelaces(formValues.amount);
         this.props.onSubmit(formValues);
-        form.reset();
       },
       onError: () => {}
     });


### PR DESCRIPTION
This PR introduces a fix which prevents wallet send form reset on submit.