### PR TITLE
[DEVOPS-64] dont sign macos installer for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 - nix-shell --run "npm run package -- --icon installers/icons/256x256"
 - echo "Size of Electron app is $(du -sh release)"
 - pushd installers
-- nix-shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then nix-shell -p awscli --run "travis_retry aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; done
 - stack --no-terminal --nix build --exec make-installer --jobs 2
 - mkdir -p dist
 - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 - nix-shell --run "npm run package -- --icon installers/icons/256x256"
 - echo "Size of Electron app is $(du -sh release)"
 - pushd installers
-- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then nix-shell -p awscli --run "travis_retry aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; done
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then nix-shell -p awscli --run "travis_retry aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; fi
 - stack --no-terminal --nix build --exec make-installer --jobs 2
 - mkdir -p dist
 - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 - nix-shell --run "npm run package -- --icon installers/icons/256x256"
 - echo "Size of Electron app is $(du -sh release)"
 - pushd installers
-- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then nix-shell -p awscli --run "travis_retry aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; fi
+- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then travis_retry nix-shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; fi
 - stack --no-terminal --nix build --exec make-installer --jobs 2
 - mkdir -p dist
 - popd

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -72,13 +72,19 @@ main = do
        ]
   run "productbuild" productargs
 
-  -- Sign the installer with a special macOS dance
-  run "security" ["create-keychain", "-p", "travis", "macos-build.keychain"]
-  run "security" ["default-keychain", "-s", "macos-build.keychain"]
-  shells "security import macos.p12 -P $CERT_PASS -k macos-build.keychain -T `which productsign`" mempty
-  run "security" ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", "travis", "macos-build.keychain"]
-  run "security" ["unlock-keychain", "-p", "travis", "macos-build.keychain"]
-  shells ("productsign --sign \"Developer ID Installer: Nikolaos Bentenitis\" --keychain macos-build.keychain dist/temp2.pkg " <> T.pack pkg) mempty
+  isPullRequest <- fromMaybe "false" <$> lookupEnv "TRAVIS_PULL_REQUEST"
+  putStrLn isPullRequest
+  if isPullRequest == "false" then do
+    -- Sign the installer with a special macOS dance
+    run "security" ["create-keychain", "-p", "travis", "macos-build.keychain"]
+    run "security" ["default-keychain", "-s", "macos-build.keychain"]
+    shells "security import macos.p12 -P $CERT_PASS -k macos-build.keychain -T `which productsign`" mempty
+    run "security" ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", "travis", "macos-build.keychain"]
+    run "security" ["unlock-keychain", "-p", "travis", "macos-build.keychain"]
+    shells ("productsign --sign \"Developer ID Installer: Nikolaos Bentenitis\" --keychain macos-build.keychain dist/temp2.pkg " <> T.pack pkg) mempty
+  else do
+    echo "Pull request, not signing the installer."
+    run "cp" ["dist/temp2.pkg", T.pack pkg]
 
   run "rm" ["dist/temp.pkg"]
   run "rm" ["dist/temp2.pkg"]

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -72,8 +72,7 @@ main = do
        ]
   run "productbuild" productargs
 
-  isPullRequest <- fromMaybe "false" <$> lookupEnv "TRAVIS_PULL_REQUEST"
-  putStrLn isPullRequest
+  isPullRequest <- fromMaybe "true" <$> lookupEnv "TRAVIS_PULL_REQUEST"
   if isPullRequest == "false" then do
     -- Sign the installer with a special macOS dance
     run "security" ["create-keychain", "-p", "travis", "macos-build.keychain"]


### PR DESCRIPTION
If users don't have write access, CI will now fail since it won't be able to get the installer certificate.

Let's just sign for branch builds.