### PR TITLE
Feature/daef 179 show terms of use screen on first application start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - Sidebar is no longer auto-hiding if application window is width is greater than 1150px.
 - When user opens or closes the sidebar using the hamburger icon it stays open or closed.
+- "Terms of use" screen on first application start
 
 ### Fixes
 

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -16,6 +16,7 @@ import NoWalletsPage from './containers/wallet/NoWalletsPage';
 import LanguageSelectionPage from './containers/profile/LanguageSelectionPage';
 import Settings from './containers/settings/Settings';
 import GeneralSettingsPage from './containers/settings/categories/GeneralSettingsPage';
+import TermsOfUsePage from './containers/profile/TermsOfUsePage';
 
 export const ROUTES = {
   ROOT: '/',
@@ -24,6 +25,7 @@ export const ROUTES = {
   NO_WALLETS: '/no-wallets',
   PROFILE: {
     LANGUAGE_SELECTION: '/profile/language-selection',
+    TERMS_OF_USE: '/profile/terms-of-use',
   },
   WALLETS: {
     ROOT: '/wallets',
@@ -44,6 +46,7 @@ export default (
   <div>
     <Route path={ROUTES.ROOT} component={LoadingPage} />
     <Route path={ROUTES.PROFILE.LANGUAGE_SELECTION} component={LanguageSelectionPage} />
+    <Route path={ROUTES.PROFILE.TERMS_OF_USE} component={TermsOfUsePage} />
     <Route path={ROUTES.STAKING} component={StakingPage} />
     <Route path={ROUTES.ADA_REDEMPTION} component={AdaRedemptionPage} />
     <Route path={ROUTES.NO_WALLETS} component={NoWalletsPage} />

--- a/app/actions/profile-actions.js
+++ b/app/actions/profile-actions.js
@@ -4,5 +4,6 @@ import Action from './lib/Action';
 // ======= PROFILE ACTIONS =======
 
 export default class ProfileActions {
+  acceptTermsOfUse: Action<any> = new Action();
   updateLocale: Action<{ locale: string }> = new Action();
 }

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -64,8 +64,29 @@ const setUserLocaleInLocalStorage = (locale) => new Promise((resolve, reject) =>
   });
 });
 
-const unsetUserLocaleInLocalStorage = () => new Promise((resolve) => {
+const unsetUserLocaleFromLocalStorage = () => new Promise((resolve) => {
   localStorage.remove('userLocale', () => {
+    resolve();
+  });
+});
+
+const getTermsOfUseAcceptanceFromLocalStorage = () => new Promise((resolve, reject) => {
+  localStorage.get('termsOfUseAcceptance', (error, response) => {
+    if (error) return reject(error);
+    if (!response.accepted) return resolve(false);
+    resolve(response.accepted);
+  });
+});
+
+const setTermsOfUseAcceptanceInLocalStorage = () => new Promise((resolve, reject) => {
+  localStorage.set('termsOfUseAcceptance', { accepted: true }, (error) => {
+    if (error) return reject(error);
+    resolve();
+  });
+});
+
+const unsetTermsOfUseAcceptanceFromLocalStorage = () => new Promise((resolve) => {
+  localStorage.remove('termsOfUseAcceptance', () => {
     resolve();
   });
 });
@@ -378,6 +399,30 @@ export default class CardanoClientApi {
     }
   }
 
+  async setTermsOfUseAcceptance() {
+    Log.debug('CardanoClientApi::setTermsOfUseAcceptance called');
+    try {
+      await setTermsOfUseAcceptanceInLocalStorage();
+      Log.debug('CardanoClientApi::setTermsOfUseAcceptance success');
+      return true;
+    } catch (error) {
+      Log.error('CardanoClientApi::setTermsOfUseAcceptance error: ', error);
+      throw new GenericApiError();
+    }
+  }
+
+  async getTermsOfUseAcceptance() {
+    Log.debug('CardanoClientApi::getTermsOfUseAcceptance called');
+    try {
+      const acceptance = await getTermsOfUseAcceptanceFromLocalStorage();
+      Log.debug('CardanoClientApi::getTermsOfUseAcceptance success: ', acceptance);
+      return acceptance;
+    } catch (error) {
+      Log.error('CardanoClientApi::getTermsOfUseAcceptance error: ', error);
+      throw new GenericApiError();
+    }
+  }
+
   async updateWallet(request: UpdateWalletRequest) {
     Log.debug('CardanoClientApi::updateWallet called: ', JSON.stringify(request, null, 2));
     const { walletId, type, currency, name, assurance } = request;
@@ -409,7 +454,8 @@ export default class CardanoClientApi {
 
   async testReset() {
     Log.debug('CardanoClientApi::testReset called');
-    await unsetUserLocaleInLocalStorage(); // TODO: remove after saving locale to API is restored
+    await unsetUserLocaleFromLocalStorage(); // TODO: remove after saving locale to API is restored
+    await unsetTermsOfUseAcceptanceFromLocalStorage();
     try {
       const response = await ClientApi.testReset();
       Log.debug('CardanoClientApi::testReset success: ', JSON.stringify(response, null, 2));

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -140,6 +140,8 @@ export type Api = {
   getSyncProgress(): Promise<GetSyncProgressResponse>,
   setUserLocale(locale: string): Promise<string>,
   getUserLocale(): Promise<string>,
+  setTermsOfUseAcceptance(): Promise<boolean>,
+  getTermsOfUseAcceptance(): Promise<boolean>,
   updateWallet(request: UpdateWalletRequest): Promise<UpdateWalletResponse>,
   testReset(): void,
   changeWalletPassword(request: ChangeWalletPasswordRequest): Promise<ChangeWalletPasswordResponse>,

--- a/app/components/layout/TopBarLayout.scss
+++ b/app/components/layout/TopBarLayout.scss
@@ -17,4 +17,5 @@ $topBarHeight: 84px;
 
 .content {
   height: calc(100% - #{$topBarHeight});
+  overflow: auto;
 }

--- a/app/components/layout/TopBarLayout.scss
+++ b/app/components/layout/TopBarLayout.scss
@@ -17,5 +17,4 @@ $topBarHeight: 84px;
 
 .content {
   height: calc(100% - #{$topBarHeight});
-  overflow: auto;
 }

--- a/app/components/profile/terms-of-use/TermsOfUseForm.js
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.js
@@ -1,0 +1,138 @@
+// @flow
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import Button from 'react-toolbox/lib/button/Button';
+import { defineMessages, intlShape } from 'react-intl';
+import CheckboxWithLongLabel from '../../widgets/forms/CheckboxWithLongLabel';
+import LocalizableError from '../../../i18n/LocalizableError';
+import styles from './TermsOfUseForm.scss';
+
+const messages = defineMessages({
+  checkboxLabel: {
+    id: 'profile.termsOfUse.checkboxLabel',
+    defaultMessage: '!!!I agree with terms of use',
+    description: 'Label for the "I agree with terms of use" checkbox.'
+  },
+  submitLabel: {
+    id: 'profile.termsOfUse.submitLabel',
+    defaultMessage: '!!!Continue',
+    description: 'Label for the "Terms of use" form submit button.'
+  },
+});
+
+@observer
+export default class TermsOfUseForm extends Component {
+
+  props: {
+    onSubmit: Function,
+    isSubmitting: boolean,
+    error?: ?LocalizableError,
+  };
+
+  static contextTypes = {
+    intl: intlShape.isRequired,
+  };
+
+  state = {
+    areTermsOfUseAccepted: false,
+  };
+
+  toggleAcceptance() {
+    this.setState({ areTermsOfUseAccepted: !this.state.areTermsOfUseAccepted });
+  }
+
+  submit = () => {
+    this.props.onSubmit();
+  };
+
+  render() {
+    const { intl } = this.context;
+    const { isSubmitting, error } = this.props;
+    const { areTermsOfUseAccepted } = this.state;
+
+    return (
+      <div className={styles.component}>
+        <div className={styles.centeredBox}>
+
+          <div className={styles.terms}>
+            <h1>Terms of use</h1>
+
+            <p>
+              First paragraph quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+              adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+              some link aliquam quaerat voluptatem.
+            </p>
+
+            <p>
+              Second paragraph ad minima veniam, quis nostrum exercitationem ullam corporis
+              suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum
+              iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur,
+              vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?
+            </p>
+
+            <ol>
+              <li>
+                <h2>1. Numbered title</h2>
+                <ul>
+                  <li>
+                    <strong>1.1 Sub-title name.</strong>
+                    At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+                    praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias
+                    excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui
+                    officia deserunt mollitia animi, id est laborum et dolorum fuga.
+                  </li>
+                  <li>
+                    <strong>1.2 Sub-title name.</strong>
+                    Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore,
+                    cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod
+                    maxime placeat facere possimus, omnis voluptas assumenda est,
+                    omnis dolor repellendus.
+                  </li>
+                </ul>
+              </li>
+
+              <li>
+                <h2>2. Numbered title</h2>
+                <ul>
+                  <li>
+                    <strong>2.1 Sub-title name.</strong>
+                    At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis
+                    praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias
+                    excepturi sint occaecati cupiditate non provident, similique sunt in culpa...
+                    and so on...
+                  </li>
+                </ul>
+              </li>
+            </ol>
+
+            <p>
+              Last paragraph quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur,
+              adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore
+              some link aliquam quaerat voluptatem.
+            </p>
+
+            <CheckboxWithLongLabel
+              className={styles.checkbox}
+              label={intl.formatMessage(messages.checkboxLabel)}
+              onChange={this.toggleAcceptance.bind(this)}
+              checked={areTermsOfUseAccepted}
+            />
+
+          </div>
+
+          {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
+
+          <Button
+            className={isSubmitting ? styles.submitButtonSpinning : styles.submitButton}
+            label={intl.formatMessage(messages.submitLabel)}
+            onMouseUp={this.submit}
+            primary
+            disabled={!areTermsOfUseAccepted}
+          />
+
+        </div>
+      </div>
+    );
+  }
+
+}

--- a/app/components/profile/terms-of-use/TermsOfUseForm.scss
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.scss
@@ -2,20 +2,20 @@
 @import '../../../themes/mixins/error-message';
 
 .component {
-  align-items: center;
-  display: flex;
+  padding: 20px;
   height: 100%;
-  justify-content: center;
+  overflow-y: overlay;
+  &::-webkit-scrollbar-button {
+    height: 7px;
+    display: block;
+  }
 }
 
 .centeredBox {
   background-color: $color-lighter-grey;
   border: solid 1px $color-light-grey;
   border-radius: 4px;
-  margin: 20px;
   padding: 30px 30px 20px;
-  overflow: visible;
-  width: 100%;
 }
 
 .submitButton,

--- a/app/components/profile/terms-of-use/TermsOfUseForm.scss
+++ b/app/components/profile/terms-of-use/TermsOfUseForm.scss
@@ -1,0 +1,80 @@
+@import '../../../themes/mixins/loading-spinner';
+@import '../../../themes/mixins/error-message';
+
+.component {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+}
+
+.centeredBox {
+  background-color: $color-lighter-grey;
+  border: solid 1px $color-light-grey;
+  border-radius: 4px;
+  margin: 20px;
+  padding: 30px 30px 20px;
+  overflow: visible;
+  width: 100%;
+}
+
+.submitButton,
+.submitButtonSpinning {
+  display: block !important;
+  height: 50px !important;
+  margin: 0 auto;
+  width: 360px;
+}
+
+.submitButton {
+  font-size: 14px !important;
+  line-height: 50px !important;
+}
+
+.submitButtonSpinning {
+  @include loading-spinner("../../../assets/images/spinner-light.svg");
+}
+
+.error {
+  @include error-message;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.terms {
+  color: $text-color-accent;
+  margin-bottom: 30px;
+
+  h1, h2 {
+    font-family: $font-medium;
+    font-size: 19px;
+    margin-bottom: 11px;
+  }
+
+  h2 {
+    margin-top: 22px;
+  }
+
+  ul {
+    list-style: disc;
+    margin-left: 20px;
+  }
+
+  p, li {
+    font-family: $font-regular;
+    line-height: 1.38;
+    margin-bottom: 11px;
+
+    strong {
+      font-weight: 500;
+    }
+  }
+
+  // checkbox component selector
+  & > div:last-child {
+    padding-top: 10px !important;
+    & > div:last-child {
+      font-family: $font-regular !important;
+    }
+  }
+}

--- a/app/containers/profile/TermsOfUsePage.js
+++ b/app/containers/profile/TermsOfUsePage.js
@@ -1,0 +1,35 @@
+// @flow
+import React, { Component } from 'react';
+import { inject, observer } from 'mobx-react';
+import TopBar from '../../components/layout/TopBar';
+import TopBarLayout from '../../components/layout/TopBarLayout';
+import TermsOfUseForm from '../../components/profile/terms-of-use/TermsOfUseForm';
+import type { InjectedProps } from '../../types/injectedPropsType';
+
+@inject('stores', 'actions') @observer
+export default class TermsOfUsePage extends Component {
+
+  static defaultProps = { actions: null, stores: null };
+  props: InjectedProps;
+
+  onSubmit = () => {
+    this.props.actions.profile.acceptTermsOfUse.trigger();
+  };
+
+  render() {
+    const { setTermsOfUseAcceptanceRequest, currentRoute } = this.props.stores.app;
+    const isSubmitting = setTermsOfUseAcceptanceRequest.isExecuting;
+    const topbar = <TopBar currentRoute={currentRoute} />;
+    return (
+      <TopBarLayout
+        topbar={topbar}
+      >
+        <TermsOfUseForm
+          onSubmit={this.onSubmit}
+          isSubmitting={isSubmitting}
+          error={setTermsOfUseAcceptanceRequest.error}
+        />
+      </TopBarLayout>
+    );
+  }
+}

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -40,6 +40,8 @@
   "profile.languageSelect.form.options.japanese": "Japanese / 日本語",
   "profile.languageSelect.form.options.korean": "Korean",
   "profile.languageSelect.form.submitLabel": "Continue",
+  "profile.termsOfUse.checkboxLabel": "I agree with terms of use",
+  "profile.termsOfUse.submitLabel": "Continue",
   "settings.general.languageSelect.label": "Language",
   "settings.menu.general.link.label": "General",
   "staking.chart.tooltip.commitments.label": "commitments",

--- a/features/accept-terms-of-use.feature
+++ b/features/accept-terms-of-use.feature
@@ -1,0 +1,12 @@
+Feature: Accept "Terms of use"
+
+  Background:
+    Given I didnt accept "Terms of use"
+    And I have selected English language
+
+  Scenario: User accepts "Terms of use"
+    Given I am on the "Terms of use" screen
+    And I click on "I agree with terms of use" checkbox
+    When I submit the "Terms of use" form
+    Then I should not see the "Terms of use" screen anymore
+    And I should have "Terms of use" accepted

--- a/features/add-wallet-via-sidebar.feature
+++ b/features/add-wallet-via-sidebar.feature
@@ -2,6 +2,7 @@ Feature: Add Wallet via Sidebar
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet with funds
 
   Scenario: Successfully Adding a Wallet

--- a/features/navigate-sidebar-categories.feature
+++ b/features/navigate-sidebar-categories.feature
@@ -2,6 +2,7 @@ Feature: Navigate Sidebar Categories
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet with funds
     And the active wallet is "Personal Wallet"
 

--- a/features/navigate-wallet-tabs.feature
+++ b/features/navigate-wallet-tabs.feature
@@ -2,6 +2,7 @@ Feature: Navigate Wallet Tabs
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet with funds
 
   Scenario Outline: Switching Between Wallet Tabs

--- a/features/send-money-to-receiver.feature
+++ b/features/send-money-to-receiver.feature
@@ -2,6 +2,7 @@ Feature: Send Money to Receiver
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet with funds
     And I have the following wallets:
       | name   |

--- a/features/step_definitions/accept-terms-of-use-steps.js
+++ b/features/step_definitions/accept-terms-of-use-steps.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+
+export default function () {
+  this.Given(/^I have accepted "Terms of use"$/, async function () {
+    await this.client.execute(() => {
+      daedalus.actions.profile.acceptTermsOfUse.trigger();
+    });
+  });
+
+  this.Given(/^I didnt accept "Terms of use"$/, async function () {
+    await this.client.execute(() => {
+      daedalus.reset();
+    });
+  });
+
+  this.Given(/^I am on the "Terms of use" screen$/, function () {
+    return this.client.waitForVisible('.TermsOfUseForm_component');
+  });
+
+  this.When(/^I click on "I agree with terms of use" checkbox$/, function () {
+    return this.waitAndClick('.TermsOfUseForm_component .CheckboxWithLongLabel_checkbox');
+  });
+
+  this.When(/^I submit the "Terms of use" form$/, function () {
+    return this.waitAndClick('.TermsOfUseForm_submitButton');
+  });
+
+  this.Then(/^I should not see the "Terms of use" screen anymore$/, function () {
+    return this.client.waitForVisible('.TermsOfUseForm_component', null, true);
+  });
+
+  this.Then(/^I should have "Terms of use" accepted$/, async function () {
+    const result = await this.client.executeAsync(function(done) {
+      daedalus.stores.app.getTermsOfUseAcceptanceRequest.execute().then(done);
+    });
+    expect(result.value).to.equal(true);
+  });
+
+};

--- a/features/switching-between-wallets.feature
+++ b/features/switching-between-wallets.feature
@@ -2,6 +2,7 @@ Feature: Switching Between Wallets
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
 
   Scenario Outline: Using the Sidebar to Switch Wallets
     Given I have the following wallets:

--- a/features/toggle-sidebar-submenus.feature
+++ b/features/toggle-sidebar-submenus.feature
@@ -2,6 +2,7 @@ Feature: Toggle Sidebar Submenus
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet with funds
     And I am on the "Personal Wallet" wallet "summary" screen
 

--- a/features/transaction-search.feature
+++ b/features/transaction-search.feature
@@ -6,6 +6,7 @@ Feature: Transaction Search
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet
     And I made the following transactions with my wallet:
       | title  |

--- a/features/transactions-grouping.feature
+++ b/features/transactions-grouping.feature
@@ -6,6 +6,7 @@ Feature: Transactions Grouping
 
   Background:
     Given I have selected English language
+    And I have accepted "Terms of use"
     And I have a wallet
 
   Scenario: Transactions are Grouped by Date


### PR DESCRIPTION
This PR introduces "Terms of use" screen which is shown to the user on first application start and user must accept terms in order to use the application.
As a part of this PR "Terms of use" screen was implemented along with the UI logic and acceptance test for this feature.

![terms-of-use-not-accepted](https://cloud.githubusercontent.com/assets/376611/25334262/3541a87c-28ee-11e7-8815-5e5f99f4907d.png)
![terms-of-use-accepted](https://cloud.githubusercontent.com/assets/376611/25334266/36f95da4-28ee-11e7-8eb6-8635de1a59c0.png)

## TODO:
- [ ] Add real "Terms of use" text