### PR TITLE
Fix/daef 173 fix right click context menu

### DIFF
--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -116,14 +116,22 @@ app.on('ready', async () => {
   if (isDev) mainWindow.openDevTools();
 
   mainWindow.webContents.on('context-menu', (e, props) => {
-    const { x, y } = props;
+    const contextMenuOptions = [
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
+      { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+    ];
 
-    Menu.buildFromTemplate([{
-      label: 'Inspect element',
-      click() {
-        mainWindow.inspectElement(x, y);
-      }
-    }]).popup(mainWindow);
+    if (isDev) {
+      const { x, y } = props;
+      contextMenuOptions.push({
+        label: 'Inspect element',
+        click() {
+          mainWindow.inspectElement(x, y);
+        }
+      });
+    }
+
+    Menu.buildFromTemplate(contextMenuOptions).popup(mainWindow);
   });
 
   if (process.platform === 'darwin') {


### PR DESCRIPTION
This PR introduces copy&paste options on application right-click context menu (plus "Inspect element" in development mode).

<img width="1151" alt="production" src="https://cloud.githubusercontent.com/assets/376611/25353662/5d65a9a6-2930-11e7-8a74-53c3247531c8.png">
