### PR TITLE
Windows build refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ main.js.map
 
 # Editors
 .idea
+*~
+\#*
+.\#*
+.~*
 
 # Generated translation files
 translations/messages

--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # daedalus
 Daedalus - cryptocurrency wallet
 
+## Quick all-in-one installer build script (Windows-only, for the time)
+
+0. Dependencies: `Node.js`, `7zip`, `git`
+1. Obtain https://github.com/input-output-hk/daedalus/blob/master/scripts/windows-build-fresh-daedalus.bat
+2. Run it:
+   ```cmd
+   C:\windows-build-fresh-daedalus.bat [BRANCH] [GITHUB-USER]
+   ```
+   ..where `BRANCH` defaults to the current release branch, and `GITHUB-USER`
+   defaults to `input-output-hk`.
+
+
 ## Install Dependencies.
 
 ```bash

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,37 +19,10 @@ cache:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - npm install
-  - mkdir node_modules\daedalus-client-api
-  - cd node_modules\daedalus-client-api
-  - ps: Start-FileDownload 'https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=cardano-sl-0.4' -FileName CardanoSL.zip
-  - 7z x CardanoSL.zip -y
-  - cd ..\..\
-  - move node_modules\daedalus-client-api\log-config-prod.yaml installers\log-config-prod.yaml
-  - move node_modules\daedalus-client-api\cardano-node.exe installers\
-  - move node_modules\daedalus-client-api\cardano-launcher.exe installers\
-  - del /f node_modules\daedalus-client-api\*.exe
+  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - SET DAEDALUS_VERSION=%APPVEYOR_BUILD_VERSION%
-  # Package frontend
-  - npm run package -- --icon installers/icons/64x64
-  - cd installers
-  # Install stack
-  - ps: Start-FileDownload http://www.stackage.org/stack/windows-x86_64 -FileName stack.zip
-  - 7z x stack.zip stack.exe
-  # Copy DLLs
-  # TODO: get rocksdb from rocksdb-haskell
-  - mkdir DLLs
-  - cd DLLs
-  - ps: Start-FileDownload 'https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip' -FileName DLLs.zip
-  - 7z x DLLs.zip
-  - del DLLs.zip
-  - cd ..
-  - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate.p12 C:/iohk-windows-certificate.p12
-  - stack setup --no-reinstall
-  - appveyor-retry call stack --no-terminal build -j 2 --exec make-installer
-  - cd ..
+  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION%
 
 artifacts:
   - path: release\win32-x64\Daedalus-win32-x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION%
+  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% cardano-sl-0.4
 
 artifacts:
   - path: release\win32-x64\Daedalus-win32-x64

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -1,0 +1,102 @@
+rem DEPENDENCIES:
+rem   1. Node.js ('npm' binary in PATH)
+rem   2. 7zip    ('7z'  binary in PATH)
+
+set DEFAULT_CARDANO_BRANCH=cardano-sl-0.4
+set MIN_CARDANO_BYTES=50000000
+set LIBRESSL_VERSION=2.5.3
+
+set DAEDALUS_VERSION=%1
+@if [%DAEDALUS_VERSION%]==[] (@echo FATAL: DAEDALUS_VERSION [argument #1] was not provided
+    exit /b 1);
+set CARDANO_BRANCH=%2
+@if [%CARDANO_BRANCH%]==[]   (@echo NOTE: CARDANO_BRANCH [argument #2] was not provided, defaulting to %DEFAULT_CARDANO_BRANCH%
+    set CARDANO_BRANCH=%DEFAULT_CARDANO_BRANCH%);
+
+@echo Building Daedalus version: %DAEDALUS_VERSION%
+@echo ..with Cardano branch:     %CARDANO_BRANCH%
+
+call npm install
+@if %errorlevel% neq 0 (@echo FAILED: npm install
+    exit /b 1)
+
+@echo Obtaining Cardano from branch %CARDANO_BRANCH%
+rmdir /s/q node_modules\daedalus-client-api 2>nul
+mkdir      node_modules\daedalus-client-api
+
+pushd node_modules\daedalus-client-api
+    powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%', 'CardanoSL.zip'); } catch { exit 1; }"
+    @if %errorlevel% neq 0 (@echo FAILED: powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%', 'CardanoSL.zip'); } catch { exit 1; }"
+	popd & exit /b 1)
+    @for /F "usebackq" %%A in ('CardanoSL.zip') do set size=%%~zA
+    if %size% lss %MIN_CARDANO_BYTES% (@echo FAILED: CardanoSL.zip is too small: threshold=%MIN_CARDANO_BYTES%, actual=%size% bytes
+        popd & exit /b 1)
+
+    7z x CardanoSL.zip -y
+    @if %errorlevel% neq 0 (@echo FAILED: 7z x CardanoSL.zip -y
+	popd & exit /b 1)
+    del CardanoSL.zip
+popd
+
+move   node_modules\daedalus-client-api\log-config-prod.yaml installers\log-config-prod.yaml
+move   node_modules\daedalus-client-api\cardano-node.exe     installers\
+move   node_modules\daedalus-client-api\cardano-launcher.exe installers\
+del /f node_modules\daedalus-client-api\*.exe
+
+rem @echo Obtaining LibreSSL %LIBRESSL_VERSION%
+rem https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
+
+@echo Packaging frontend
+call npm run package -- --icon installers/icons/64x64
+@if %errorlevel% neq 0 (@echo FAILED: npm run package -- --icon installers/icons/64x64
+	exit /b 1)
+
+pushd installers
+    @echo Installing stack
+    powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
+    @if %errorlevel% neq 0 (@echo powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
+	popd & exit /b 1)
+    del /f stack.exe
+    7z x stack.zip stack.exe
+    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe
+	exit /b 1)
+    del stack.zip
+
+    @echo Copying DLLs
+    @rem TODO: get rocksdb from rocksdb-haskell
+    rmdir /s/q DLLs 2>nul
+    mkdir      DLLs
+    pushd      DLLs
+        powershell -Command "try { wget 'https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip' -outfile DLLs.zip; } catch { exit 1; }"
+        @if %errorlevel% neq 0 (@echo FAILED: powershell -Command "try { wget 'https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip' -outfile DLLs.zip; } catch { exit 1; }"
+		exit /b 1)
+        7z x DLLs.zip
+        @if %errorlevel% neq 0 (@echo FAILED: 7z x DLLs.zip
+		popd & popd & exit /b 1)
+        del DLLs.zip
+    popd
+
+    @echo Building the installer
+    stack setup --no-reinstall
+    @if %errorlevel% neq 0 (@echo FAILED: stack setup --no-reinstall
+	exit /b 1)
+
+:build
+    stack --no-terminal build -j 2 --exec make-installer
+    @if %errorlevel% neq 0 (
+        @echo .
+        @echo .
+        @echo FAILED: stack --no-terminal build -j 2 --exec make-installer
+        @echo .
+        @timeout 7
+        @echo Retrying -- and also waiting for GHC 8.2.1 [see https://github.com/commercialhaskell/stack/issues/2617]
+        @echo .
+        @echo .
+	goto build
+        )
+popd
+
+@echo .
+@echo Successfully built Daedalus %DAEDALUS_VERSION%
+@echo .
+@dir /b/s installers\daedalus*

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -42,9 +42,6 @@ move   node_modules\daedalus-client-api\cardano-node.exe     installers\
 move   node_modules\daedalus-client-api\cardano-launcher.exe installers\
 del /f node_modules\daedalus-client-api\*.exe
 
-rem @echo Obtaining LibreSSL %LIBRESSL_VERSION%
-rem https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
-
 @echo Packaging frontend
 call npm run package -- --icon installers/icons/64x64
 @if %errorlevel% neq 0 (@echo FAILED: npm run package -- --icon installers/icons/64x64

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -2,7 +2,6 @@ rem DEPENDENCIES:
 rem   1. Node.js ('npm' binary in PATH)
 rem   2. 7zip    ('7z'  binary in PATH)
 
-set DEFAULT_CARDANO_BRANCH=cardano-sl-0.4
 set MIN_CARDANO_BYTES=50000000
 set LIBRESSL_VERSION=2.5.3
 
@@ -10,8 +9,8 @@ set DAEDALUS_VERSION=%1
 @if [%DAEDALUS_VERSION%]==[] (@echo FATAL: DAEDALUS_VERSION [argument #1] was not provided
     exit /b 1);
 set CARDANO_BRANCH=%2
-@if [%CARDANO_BRANCH%]==[]   (@echo NOTE: CARDANO_BRANCH [argument #2] was not provided, defaulting to %DEFAULT_CARDANO_BRANCH%
-    set CARDANO_BRANCH=%DEFAULT_CARDANO_BRANCH%);
+@if [%CARDANO_BRANCH%]==[]   (@echo NOTE: CARDANO_BRANCH [argument #2] was not provided
+    exit /b 1);
 
 @echo Building Daedalus version: %DAEDALUS_VERSION%
 @echo ..with Cardano branch:     %CARDANO_BRANCH%

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -81,8 +81,10 @@ pushd installers
 	exit /b 1)
 
 :build
-    stack --no-terminal build -j 2 --exec make-installer
-    @if %errorlevel% neq 0 (
+    for /l %%x in (1, 1, 5) do (
+        stack --no-terminal build -j 2 --exec make-installer
+        @if %errorlevel% equ 0 goto :built
+
         @echo .
         @echo .
         @echo FAILED: stack --no-terminal build -j 2 --exec make-installer
@@ -91,8 +93,10 @@ pushd installers
         @echo Retrying -- and also waiting for GHC 8.2.1 [see https://github.com/commercialhaskell/stack/issues/2617]
         @echo .
         @echo .
-	goto build
-        )
+    )
+    @echo FATAL: persistent failure while building installer with:  stack --no-terminal build -j 2 --exec make-installer
+    exit /b 1
+:built
 popd
 
 @echo .

--- a/scripts/windows-build-fresh-daedalus.bat
+++ b/scripts/windows-build-fresh-daedalus.bat
@@ -3,10 +3,10 @@ rem   1. Node.js ('npm' binary in PATH)
 rem   2. 7zip    ('7z'  binary in PATH)
 rem   3. Git     ('git' binary in PATH)
 
-@set DEFAULT_BRANCH=cardano-sl-0.4
+@set DEFAULT_DAEDALUS_BRANCH=cardano-sl-0.4
 
-set BRANCH=%1
-@if [%BRANCH%]==[] (set BRANCH=%DEFAULT_BRANCH%)
+set DAEDALUS_BRANCH=%1
+@if [%DAEDALUS_BRANCH%]==[] (set DAEDALUS_BRANCH=%DEFAULT_DAEDALUS_BRANCH%)
 set GITHUB_USER=%2
 @if [%GITHUB_USER%]==[] (set GITHUB_USER=input-output-hk)
 
@@ -14,16 +14,20 @@ set GITHUB_USER=%2
 
 move daedalus daedalus.old 2>nul
 
-@echo Building Daedalus branch %BRANCH% from %URL%
+@echo Building Daedalus branch %DAEDALUS_BRANCH% from %URL%
 git clone %URL%
 @if %errorlevel% neq 0 (@echo FAILED: git clone %URL%
 	exit /b 1)
 
 @pushd daedalus
-    git reset --hard origin/%BRANCH%
-    @if %errorlevel% neq 0 (@echo FAILED: git reset --hard origin/%BRANCH%
+    git reset --hard origin/%DAEDALUS_BRANCH%
+    @if %errorlevel% neq 0 (@echo FAILED: git reset --hard origin/%DAEDALUS_BRANCH%
 	exit /b 1)
     @for /f %%a in ('git show-ref --hash HEAD') do set version=%%a
     @call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
-    call scripts\build-installer-win64 %GITHUB_USER%-%BRANCH%-%version% %BRANCH%
+
+    @rem NOTE: we're setting the CARDANO_BRANCH to DEFAULT_DAEDALUS_BRANCH:
+    @rem       1. there's no obvious better choice
+    @rem       2. this is intended as a workflow script sitting outside the repository, anyway
+    call scripts\build-installer-win64 %GITHUB_USER%-%DAEDALUS_BRANCH%-%version% %DEFAULT_DAEDALUS_BRANCH%
 @popd

--- a/scripts/windows-build-fresh-daedalus.bat
+++ b/scripts/windows-build-fresh-daedalus.bat
@@ -25,5 +25,5 @@ git clone %URL%
 	exit /b 1)
     @for /f %%a in ('git show-ref --hash HEAD') do set version=%%a
     @call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
-    call scripts\build-installer-win64 %GITHUB_USER%-%BRANCH%-%version%
+    call scripts\build-installer-win64 %GITHUB_USER%-%BRANCH%-%version% %BRANCH%
 @popd

--- a/scripts/windows-build-fresh-daedalus.bat
+++ b/scripts/windows-build-fresh-daedalus.bat
@@ -1,0 +1,29 @@
+rem DEPENDENCIES:
+rem   1. Node.js ('npm' binary in PATH)
+rem   2. 7zip    ('7z'  binary in PATH)
+rem   3. Git     ('git' binary in PATH)
+
+@set DEFAULT_BRANCH=cardano-sl-0.4
+
+set BRANCH=%1
+@if [%BRANCH%]==[] (set BRANCH=%DEFAULT_BRANCH%)
+set GITHUB_USER=%2
+@if [%GITHUB_USER%]==[] (set GITHUB_USER=input-output-hk)
+
+@set URL=https://github.com/%GITHUB_USER%/daedalus.git
+
+move daedalus daedalus.old 2>nul
+
+@echo Building Daedalus branch %BRANCH% from %URL%
+git clone %URL%
+@if %errorlevel% neq 0 (@echo FAILED: git clone %URL%
+	exit /b 1)
+
+@pushd daedalus
+    git reset --hard origin/%BRANCH%
+    @if %errorlevel% neq 0 (@echo FAILED: git reset --hard origin/%BRANCH%
+	exit /b 1)
+    @for /f %%a in ('git show-ref --hash HEAD') do set version=%%a
+    @call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
+    call scripts\build-installer-win64 %GITHUB_USER%-%BRANCH%-%version%
+@popd


### PR DESCRIPTION
- move most contents of the `appveyor.yml` build script into `scripts/windows-build-fresh-daedalus.bat`, adding some sanity checks on the way
- scripts/windows-build-fresh-daedalus.bat, for a shortcuttable easy builds on Windows

cc @domenkozar, @jmitchell 