### PR TITLE
Windows tls security credentials

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -126,8 +126,11 @@ writeInstallerNSIS fullVersion = do
         file [] "log-config-prod.yaml"
         file [] "data\\ip-dht-mappings"
         file [] "version.txt"
+        file [] "build-certificates-win64.bat"
         writeFileLines "$INSTDIR\\daedalus.bat" (map str launcherScript)
         file [Recursive] "dlls\\"
+        file [Recursive] "libressl\\"
+        file [Recursive] "tls\\"
         file [Recursive] "..\\release\\win32-x64\\Daedalus-win32-x64\\"
 
         mapM_ injectLiteral
@@ -135,6 +138,8 @@ writeInstallerNSIS fullVersion = do
           , "Pop $0"
           , "DetailPrint \"liteFirewall::AddRule: $0\""
           ]
+
+        exec "build-certificates-win64.bat >build-certificates.log 2>&1"
 
         -- Uninstaller
         writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "InstallLocation" "$INSTDIR\\Daedalus"

--- a/installers/build-certificates-win64.bat
+++ b/installers/build-certificates-win64.bat
@@ -1,0 +1,68 @@
+@rem Source: https://pki-tutorial.readthedocs.io/en/latest/simple/index.html
+@echo Generating certificates.
+@x64\openssl version
+
+@echo .
+@echo ============================================================================
+@echo [1/6] Creating database
+rmdir /s/q tls\ca tls\certs 2>nul
+
+mkdir tls\ca\private tls\ca\db tls\certs
+copy nul  tls\ca\db\ca.db
+copy nul  tls\ca\db\ca.db.attr
+echo 01 > tls\ca\db\ca.crt.srl
+@echo ============================================================================
+
+@echo [2/6] Generating password
+@echo %RANDOM%  > tls\secret  & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret
+@echo %RANDOM% >> tls\secret  & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret
+@echo %RANDOM% >> tls\secret  & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret & echo %RANDOM% >> tls\secret
+@echo ============================================================================
+
+@echo [3/6] CA self-sign request
+x64\openssl req -new ^
+            -config     ca.conf                ^
+            -out        tls\ca\ca.csr          ^
+            -passout    file:tls\secret        ^
+            -keyout     tls\ca\private\ca.key
+@if %errorlevel% neq 0 (@echo . & echo "FAILED: CA self-sign request" & exit /b 1)
+@echo .
+@echo ============================================================================
+
+@echo [4/6] CA certificate
+x64\openssl ca  -selfsign -batch ^
+            -config     ca.conf                ^
+            -in         tls\ca\ca.csr          ^
+            -out        tls\ca\ca.crt          ^
+            -passin     file:tls\secret        ^
+            -extensions ca_ext
+@if %errorlevel% neq 0 (@echo . & echo "FAILED: CA self-signed certificate generation" & exit /b 1)
+@echo .
+@echo ============================================================================
+
+@echo [5/6] Server certificate signing request
+x64\openssl req -new ^
+            -config     server.conf            ^
+            -out        tls\certs\server.csr   ^
+            -keyout     tls\certs\server.key
+@if %errorlevel% neq 0 (@echo . & echo "FAILED: server certificate signing request" & exit /b 1)
+@echo .
+@echo ============================================================================
+
+@echo [6/6] Server certificate
+x64\openssl ca -batch ^
+            -config     ca.conf               ^
+            -in         tls\certs\server.csr  ^
+            -out        tls\certs\server.crt  ^
+            -passin     file:tls\secret       ^
+            -extensions server_ext
+@if %errorlevel% neq 0 (@echo . & echo "FAILED: server certificate signing" & exit /b 1)
+@echo .
+@echo ============================================================================
+
+@echo [7/6] Cleanup
+del tls\secret ca.conf server.conf
+rmdir /s/q tls\ca\private x86 x64
+
+@echo ============================================================================
+@echo Oll Korrect

--- a/installers/tls/ca.conf
+++ b/installers/tls/ca.conf
@@ -1,0 +1,103 @@
+# Simple Root CA
+
+# The [default] section contains global constants that can be referred to from
+# the entire configuration file. It may also hold settings pertaining to more
+# than one openssl command.
+
+[ default ]
+ca                      = daedssrca             # CA name
+dir                     = tls                   # Top dir
+
+# The next part of the configuration file is used by the openssl req command.
+# It defines the CA's key pair, its DN, and the desired extensions for the CA
+# certificate.
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha1                  # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+0.domainComponent       = "io"
+1.domainComponent       = "iohk"
+organizationName        = "Input Output HK"
+organizationalUnitName  = "Daedalus Self-Signed Root CA"
+commonName              = "Daedalus Self-Signed Root CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+
+# The remainder of the configuration file is used by the openssl ca command.
+# The CA section defines the locations of CA assets, as well as the policies
+# applying to the CA.
+
+[ ca ]
+default_ca              = daedssrca             # The default CA section
+
+[ daedssrca ]
+certificate             = $dir/ca/ca.crt        # The CA cert
+private_key             = $dir/ca/private/ca.key # CA private key
+new_certs_dir           = $dir/ca               # Certificate archive
+serial                  = $dir/ca/db/ca.crt.srl # Serial number file
+crlnumber               = $dir/ca/db/ca.crl.srl # CRL number file
+database                = $dir/ca/db/ca.db      # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 3652                  # How long to certify for
+default_md              = sha256                # MD to use
+policy                  = match_pol             # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = ca_default            # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = none                  # Copy extensions from CSR
+x509_extensions         = server_ext            # Default cert extensions
+default_crl_days        = 3652                  # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+# Naming policies control which parts of a DN end up in the certificate and
+# under what circumstances certification should be denied.
+
+[ match_pol ]
+domainComponent         = match                 # Must match 'simple.org'
+organizationName        = match                 # Must match 'Simple Inc'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Certificate extensions define what types of certificates the CA is able to
+# create.
+
+[ ca_ext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+[ server_ext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+basicConstraints        = CA:false
+extendedKeyUsage        = serverAuth # ,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+# CRL extensions exist solely to point to the CA certificate that has issued
+# the CRL.
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always

--- a/installers/tls/server.conf
+++ b/installers/tls/server.conf
@@ -1,0 +1,30 @@
+# TLS server certificate request
+
+# This file is used by the openssl req command. The subjectAltName cannot be
+# prompted for and must be specified in the SAN environment variable.
+
+[ default ]
+SAN                     = DNS:localhost.localdomain # Default value
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = no                    # Protect private key
+default_md              = sha256                # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Prompt for DN
+distinguished_name      = server_dn             # DN template
+req_extensions          = server_reqext         # Desired extensions
+
+[ server_dn ]
+0.domainComponent       = "io"
+1.domainComponent       = "iohk"
+organizationName        = "Input Output HK"
+organizationalUnitName  = "Cardano Settlement Layer Server Node"
+commonName              = "Cardano Settlement Layer Server Node"
+
+[ server_reqext ]
+keyUsage                = critical,digitalSignature,keyEncipherment
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+subjectAltName          = $ENV::SAN

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -65,12 +65,25 @@ del /f node_modules\daedalus-client-api\*.exe
 call npm run package -- --icon installers/icons/64x64
 @if %errorlevel% neq 0 (@echo FAILED: Failed to package the frontend
 	exit /b 1)
+
 pushd installers
+    del /f LibreSSL.zip 2>nul
+    @echo Obtaining LibreSSL %LIBRESSL_VERSION%
+    ..\curl %LIBRESSL_URL% -o LibreSSL.zip
+    @if %errorlevel% neq 0 (@echo FAILED: LibreSSL couldn't be obtained
+	popd & exit /b 1)
+    7z x LibreSSL.zip
+    @if %errorlevel% neq 0 (@echo FAILED: LibreSSL couldn't be extracted from downloaded archive
+	popd & exit /b 1)
+    del LibreSSL.zip
+    rmdir /s/q libressl
+    move libressl-%LIBRESSL_VERSION%-windows libressl
+
     @echo Installing stack
-    ..\curl http://www.stackage.org/stack/windows-x86_64 -o stack.zip
+    ..\curl --location http://www.stackage.org/stack/windows-x86_64 -o stack.zip
     @if %errorlevel% neq 0 (@echo FAILED: stack couldn't be obtained
 	popd & exit /b 1)
-    del /f stack.exe
+    del /f stack.exe 2>nul
     7z x stack.zip stack.exe
     @if %errorlevel% neq 0 (@echo FAILED: couldn't extract stack from the distribution package
 	exit /b 1)
@@ -81,7 +94,7 @@ pushd installers
     rmdir /s/q DLLs 2>nul
     mkdir      DLLs
     pushd      DLLs
-        ..\..\curl %DLLS_URL% -o DLLs.zip
+        ..\..\curl --location %DLLS_URL% -o DLLs.zip
         @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain CardanoSL DLL package
 		exit /b 1)
         7z x DLLs.zip

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -4,6 +4,7 @@ rem   2. 7zip    ('7z'  binary in PATH)
 
 set MIN_CARDANO_BYTES=50000000
 set LIBRESSL_VERSION=2.5.3
+set CURL_VERSION=7.54.0
 
 set DAEDALUS_VERSION=%1
 @if [%DAEDALUS_VERSION%]==[] (@echo FATAL: DAEDALUS_VERSION [argument #1] was not provided
@@ -12,8 +13,25 @@ set CARDANO_BRANCH=%2
 @if [%CARDANO_BRANCH%]==[]   (@echo NOTE: CARDANO_BRANCH [argument #2] was not provided
     exit /b 1);
 
-@echo Building Daedalus version: %DAEDALUS_VERSION%
-@echo ..with Cardano branch:     %CARDANO_BRANCH%
+set CURL_URL=https://bintray.com/artifact/download/vszakats/generic/curl-%CURL_VERSION%-win64-mingw.7z
+set CURL_BIN=curl-%CURL_VERSION%-win64-mingw\bin
+set CARDANO_URL=https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%
+set LIBRESSL_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
+set DLLS_URL=https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip
+
+@echo Building Daedalus version:  %DAEDALUS_VERSION%
+@echo ..with Cardano branch:      %CARDANO_BRANCH%
+@echo ..with LibreSSL version:    %LIBRESSL_VERSION%
+@echo .
+
+@echo Obtaining curl
+powershell -Command "try { Import-Module BitsTransfer; Start-BitsTransfer -Source '%CURL_URL%' -Destination 'curl.7z'; } catch { exit 1; }"
+@if %errorlevel% neq 0 (@echo FAILED: couldn't obtain curl from %CURL_URL% using BITS
+	popd & exit /b 1)
+del /f curl.exe curl-ca-bundle.crt libcurl.dll
+7z e curl.7z %CURL_BIN%\curl.exe %CURL_BIN%\curl-ca-bundle.crt %CURL_BIN%\libcurl.dll
+@if %errorlevel% neq 0 (@echo FAILED: couldn't extract curl from downloaded archive
+	popd & exit /b 1)
 
 call npm install
 @if %errorlevel% neq 0 (@echo FAILED: npm install
@@ -24,8 +42,9 @@ rmdir /s/q node_modules\daedalus-client-api 2>nul
 mkdir      node_modules\daedalus-client-api
 
 pushd node_modules\daedalus-client-api
-    powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%', 'CardanoSL.zip'); } catch { exit 1; }"
-    @if %errorlevel% neq 0 (@echo FAILED: powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('https://ci.appveyor.com/api/projects/jagajaga/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%', 'CardanoSL.zip'); } catch { exit 1; }"
+    del /f CardanoSL.zip 2>nul
+    ..\..\curl --location %CARDANO_URL% -o CardanoSL.zip
+    @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain the cardano-sl package
 	popd & exit /b 1)
     @for /F "usebackq" %%A in ('CardanoSL.zip') do set size=%%~zA
     if %size% lss %MIN_CARDANO_BYTES% (@echo FAILED: CardanoSL.zip is too small: threshold=%MIN_CARDANO_BYTES%, actual=%size% bytes
@@ -44,17 +63,16 @@ del /f node_modules\daedalus-client-api\*.exe
 
 @echo Packaging frontend
 call npm run package -- --icon installers/icons/64x64
-@if %errorlevel% neq 0 (@echo FAILED: npm run package -- --icon installers/icons/64x64
+@if %errorlevel% neq 0 (@echo FAILED: Failed to package the frontend
 	exit /b 1)
-
 pushd installers
     @echo Installing stack
-    powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
-    @if %errorlevel% neq 0 (@echo powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
+    ..\curl http://www.stackage.org/stack/windows-x86_64 -o stack.zip
+    @if %errorlevel% neq 0 (@echo FAILED: stack couldn't be obtained
 	popd & exit /b 1)
     del /f stack.exe
     7z x stack.zip stack.exe
-    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe
+    @if %errorlevel% neq 0 (@echo FAILED: couldn't extract stack from the distribution package
 	exit /b 1)
     del stack.zip
 
@@ -63,8 +81,8 @@ pushd installers
     rmdir /s/q DLLs 2>nul
     mkdir      DLLs
     pushd      DLLs
-        powershell -Command "try { wget 'https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip' -outfile DLLs.zip; } catch { exit 1; }"
-        @if %errorlevel% neq 0 (@echo FAILED: powershell -Command "try { wget 'https://s3.eu-central-1.amazonaws.com/cardano-sl-testing/DLLs.zip' -outfile DLLs.zip; } catch { exit 1; }"
+        ..\..\curl %DLLS_URL% -o DLLs.zip
+        @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain CardanoSL DLL package
 		exit /b 1)
         7z x DLLs.zip
         @if %errorlevel% neq 0 (@echo FAILED: 7z x DLLs.zip


### PR DESCRIPTION
This does 1/2 of the work for DEVOPS-33 -- the windows part of TLS CA/server key/cert generation.

Since this is heavily reliant on the Daedalus-on-Windows part of DEVOPS-10, this is currently on-top of the as-yet unmerged PR https://github.com/input-output-hk/daedalus/pull/264.

However, most of the non-DEVOPS-10 parts (basically, everything under `installers/`) is meaningfully available for review,
and so -- cc @akegalj, @domenkozar, @jmitchell.

For details, please see: https://issues.serokell.io/issue/DEVOPS-33#comment=96-3065