### PR TITLE
[CSL-1054] Enable --web when running the node (needed for utxo api)

### DIFF
--- a/installers/Launcher.hs
+++ b/installers/Launcher.hs
@@ -35,6 +35,7 @@ launcherArgs launcher = unwords $
         "--peers-file", "ip-dht-mappings",
         "--system-start", "1492428658",
         "--wallet",
+        "--web", "--web-port", "12300",
         "--explicit-initial"
         ]
 


### PR DESCRIPTION
`--web` flag enables some web endpoints which are mostly needed for debugging. It shouldn't add overhead or vulnerabilities.