### PR TITLE
[DEVOPS-10]  OS X local build automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
 install:
 - true
 script:
-- scripts/build-installer-unix.sh "$VERSION" "$CARDANO_SL_BRANCH" "$TRAVIS_OS_NAME"
+- scripts/build-installer-unix.sh "$VERSION" "$CARDANO_SL_BRANCH"
      --build-id       "$TRAVIS_BUILD_NUMBER"
      --travis-pr      "$TRAVIS_PULL_REQUEST"
      --nix-path       "$NIX_PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 install:
 - true
 script:
+- sudo mount -o remount,exec,size=4G,mode=755 /run/user || true    ## Travis-specific hack.
 - scripts/build-installer-unix.sh "$VERSION" "$CARDANO_SL_BRANCH"
      --build-id       "$TRAVIS_BUILD_NUMBER"
      --travis-pr      "$TRAVIS_PULL_REQUEST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,34 +18,12 @@ env:
     # p12 certs
     - secure: "y/kRyNtg7fnK8lGMT7h1WL4UPjSNOOt5T92fqetuRXLh7OxqJdcUPL2tT162gktTC/vs8k0jxM1fWiDtkyCAVQAMvoGwjbJXRdHMA+dyYmqcqWPmbEtDHPKhv5L+sM++RwQRg7Kct2g62y3EjxepT8r52+1OsWaSS893Z8GPvIaIq0K8oaOWGE4+q5+bO+scVEU+mAqjwavTOySauBCfX78ZJETAT/v0lhZNj20yTnitQce/gpt70c0UYm8Nzdk0mWrq2BQxCjTBOOHWcdUQNzmrX0jS3YyMKRWBBS4mgjQ98TKgCP6EPuZGfUdzDUiFQymmacprGdT5rdXRB2ZGxNwAGqf+nVrToLKefkqdYK6pmXBbZtk3wMlWvdzLpRWJMeDZGjAOSvq1JtFvNrAHGeGfeWgcFpDQhQ27foN5+g71/qCC01CWYRQWPLjThBLzW6ZhanyzbM77RQBw0MQpoOoHakyVCXupe/Z3PuvzT7yN8EaJWOM3sGZfiEKmwbpJdRfzbX3fStaqI2qFEC47AzBpoZYo1efe65ivpUrN282Cxz14b1Ds+/ycDjQw9JIJ9WIwfHwUFyqy4Q7/8uQQr1PZSuJHe9ojpka6aXuehVMq+0MA8G/iFYddcajH9mZ6uQjg0/ZeN1M/2kFuuq3/h7esgw1Npb/k9Kw0eADHL8k="
 install:
-- mkdir -p ~/.local/bin
-- export PATH=$HOME/.local/bin:$PATH
-- sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
-- travis_retry curl -L https://www.stackage.org/stack/$TRAVIS_OS_NAME-x86_64 | tar
-  xz --strip-components=1 -C ~/.local/bin
-- travis_retry curl -o daedalus-bridge.tar.xz https://s3.eu-central-1.amazonaws.com/cardano-sl-travis/daedalus-bridge-$TRAVIS_OS_NAME-$CARDANO_SL_BRANCH.tar.xz
-- mkdir -p node_modules/daedalus-client-api/
-- du -sh daedalus-bridge.tar.xz
-- tar xJf daedalus-bridge.tar.xz --strip-components=1 -C node_modules/daedalus-client-api/
-- rm daedalus-bridge.tar.xz
-- echo "cardano-sl build id is $(cat node_modules/daedalus-client-api/build-id)"
-- nix-shell --run "npm install"
+- true
 script:
-- export DAEDALUS_VERSION=$VERSION.$TRAVIS_BUILD_NUMBER
-- export SSL_CERT_FILE=$NIX_SSL_CERT_FILE
-- mv node_modules/daedalus-client-api/{log-config-prod.yaml,cardano-node,cardano-launcher}
-  installers/
-- strip installers/cardano-node
-- strip installers/cardano-launcher
-- rm node_modules/daedalus-client-api/cardano-*
-- nix-shell --run "npm run package -- --icon installers/icons/256x256"
-- echo "Size of Electron app is $(du -sh release)"
-- pushd installers
-- if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then travis_retry nix-shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/macos.p12 macos.p12"; fi
-- stack --no-terminal --nix build --exec make-installer --jobs 2
-- mkdir -p dist
-- popd
-- echo "Size of Electron app after bundling $(du -sh release)"
+- scripts/build-installer-unix.sh "$VERSION" "$CARDANO_SL_BRANCH" "$TRAVIS_OS_NAME"
+     --build-id       "$TRAVIS_BUILD_NUMBER"
+     --travis-pr      "$TRAVIS_PULL_REQUEST"
+     --nix-path       "$NIX_PATH"
 notifications:
   slack:
     secure: hfzreJ033RxFI2UYtcGJ+MFgQX08UyUnQwhb8X8CuVuIZXDWhxz9JLMEUuL6QqogtffbiqfqIhyDwZ0PsE3aEJaHQAQ7lxJkMjZFU/o+CYvHBQy+WYCa/sFM0C8cEXn3Wb/LmhjvtKAgF302tnD5PAPglZTGtCJHpihKG/Wc+YwF2aFSon0DqoMtVmwVPvhD/WlAHyszARsE9C7jH7jN43gwupAmwj7QLH+kd96HKrrc2ItgMS0f5ucFnpM900c9LwhE5StxVdgTXLnogWQKcd1f4DwTNoXfS3Dy6VJkKj049VScvavcFcVPBL9xU62SMMy/eS/yRcHZkxJehUi16aoir2GXNZOKjQVQ85zEQofQgkR+b4roJJmtWJuCoyE0nptoHgDi4BlLwFuC1g7pkngtLvo3BrG3IjhV+s7QuhxFA9aA8MBQDTRBQNeZdU2I/iwJaYsggGQ2JYA/B2AE4C0sentbegGumsY4fah6HVQGOOZoCl3k9fmMDS42/D55kdteRAQBZBlixLHMXTsMf90jcJJGi/vkzVEnhby63RdTRNDW6MBA6RgvUIpI0VQgAIEM8LFHMNeHMYLoj++NnSI3gCrX8zi8nrnCUJmpCQ89WLDRbVy3rFltgcd7ds8SlRxMtSXCO9lulq/Q6Gk65mRhuq/My0FqBbT+DQUBg04=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Daedalus - cryptocurrency wallet
 Platform-specific build scripts facilitate building Daedalus the way it is built
 by the IOHK CI:
 
-   - `scripts/build-installer-unix.sh    <DAEDALUS-VERSION> <CARDANO-BRANCH> <OS> [OPTIONS..]`
+   - `scripts/build-installer-unix.sh    <DAEDALUS-VERSION> <CARDANO-BRANCH> [OPTIONS..]`
       - where OS is either `linux` or `osx`
       - facilitates installer upload to S3 via `--upload-s3`
    - `scripts/build-installer-windows.sh <DAEDALUS-VERSION> <CARDANO-BRANCH>`

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Daedalus - cryptocurrency wallet
 Platform-specific build scripts facilitate building Daedalus the way it is built
 by the IOHK CI:
 
-   - `scripts/build-installer-unix.sh    <DAEDALUS-VERSION> <CARDANO-BRANCH> [OPTIONS..]`
+   - `scripts/build-installer-unix.sh     <DAEDALUS-VERSION> <CARDANO-BRANCH> [OPTIONS..]`
       - where OS is either `linux` or `osx`
       - facilitates installer upload to S3 via `--upload-s3`
-   - `scripts/build-installer-windows.sh <DAEDALUS-VERSION> <CARDANO-BRANCH>`
+   - `scripts/build-installer-windows.bat <DAEDALUS-VERSION> <CARDANO-BRANCH>`
 
 The result can be found at:
    - on OS X:    `${BUILD}/installers/dist/Daedalus-installer-*.pkg`

--- a/README.md
+++ b/README.md
@@ -1,24 +1,55 @@
 # daedalus
 Daedalus - cryptocurrency wallet
 
-## Quick all-in-one installer build script (Windows-only, for the time)
+## Automated build
 
-0. Dependencies: `Node.js`, `7zip`, `git`
-1. Obtain https://github.com/input-output-hk/daedalus/blob/master/scripts/windows-build-fresh-daedalus.bat
-2. Run it:
-   ```cmd
-   C:\windows-build-fresh-daedalus.bat [BRANCH] [GITHUB-USER]
+### CI/dev build scripts
+
+Platform-specific build scripts facilitate building Daedalus the way it is built
+by the IOHK CI:
+
+   - `scripts/build-installer-unix.sh    <DAEDALUS-VERSION> <CARDANO-BRANCH> <OS> [OPTIONS..]`
+      - where OS is either `linux` or `osx`
+      - facilitates installer upload to S3 via `--upload-s3`
+   - `scripts/build-installer-windows.sh <DAEDALUS-VERSION> <CARDANO-BRANCH>`
+
+The result can be found at:
+   - on OS X:    `${BUILD}/installers/dist/Daedalus-installer-*.pkg`
+   - on WIndows: `${BUILD}/installers/daedalus-*-installer.exe`
+
+### One-click build-fresh-daedalus scripts
+
+These rely on the scripts from the previous section, but also go to a certain
+trouble to ensure that dependencies are installed, and even check out a fresh
+version of Daedalus from the specifid branch.
+
+These are intended to be used by developers in a "clean rebuild" scenario, to
+facilitate validation.
+
+Dependencies:
+   - on OS X:    `git`
+   - on Windows: `Node.js`, `7zip`
+
+Location:
+   - on OS X:    https://github.com/input-output-hk/daedalus/blob/master/scripts/osx-build-fresh-daedalus.sh
+   - on Windows: https://github.com/input-output-hk/daedalus/blob/master/scripts/windows-build-fresh-daedalus.bat
+
+Invocation:
+   ```shell
+   {osx,windows}-build-fresh-daedalus.{sh,bat} [BRANCH] [GITHUB-USER] [OPTIONS...]
    ```
    ..where `BRANCH` defaults to the current release branch, and `GITHUB-USER`
    defaults to `input-output-hk`.
+   
+   The remaining `OPTIONS` are passed as-is to the respective build scripts.
 
+## Stepwise build
 
-## Install Dependencies.
+### Install Node.js dependencies.
 
 ```bash
 $ npm install
 ```
-
 
 ## Development
 
@@ -38,7 +69,7 @@ $ npm run start-hot
 *Note: requires a node version >= 4 and an npm version >= 3. This project
 defaults to 6.x*
 
-## Development - with Cardano Wallet (daedalus-bridge)
+### Development - with Cardano Wallet (daedalus-bridge)
 
 Build and run daedalus-bridge [using instructions in the repo](https://github.com/input-output-hk/pos-haskell-prototype/tree/master/daedalus)
 
@@ -48,7 +79,7 @@ Symlink the npm package in the subfolder `pos-haskell-prototype/daedalus`:
 
 Run with `npm run dev`
 
-## Testing
+### Testing
 
 You can run the test suite in two different modes during development
 (Currently you always need to run `npm run dev` before that)
@@ -63,7 +94,7 @@ $ npm run test
 $ npm run test-watch
 ```
 
-## CSS Modules
+### CSS Modules
 
 This boilerplate out of the box is configured to use [css-modules](https://github.com/css-modules/css-modules).
 
@@ -72,8 +103,30 @@ All `.css` file extensions will use css-modules unless it has `.global.css`.
 If you need global styles, stylesheets with `.global.css` will not go through the
 css-modules loader. e.g. `app.global.css`
 
+### Externals
 
-## Package
+If you use any 3rd party libraries which can't or won't be built with webpack, you must list them in your `webpack.config.base.js`：
+
+```javascript
+externals: [
+  // put your node 3rd party libraries which can't be built with webpack here (mysql, mongodb, and so on..)
+]
+```
+
+For a common example, to install Bootstrap, `npm i --save bootstrap` and link them in the head of app.html
+
+```html
+<link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" />
+<link rel="image/svg+xml" href="../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.eot" />
+...
+```
+
+Make sure to list bootstrap in externals in `webpack.config.base.js` or the app won't include them in the package:
+```js
+externals: ['bootstrap']
+```
+
+## Packaging
 
 ```bash
 $ npm run package
@@ -100,27 +153,3 @@ $ npm run package -- --[option]
 - --all: pack for all platforms
 
 Use `electron-packager` to pack your app with `--all` options for darwin (osx), linux and win32 (windows) platform. After build, you will find them in `release` folder. Otherwise, you will only find one for your os.
-
-
-## Externals
-
-If you use any 3rd party libraries which can't or won't be built with webpack, you must list them in your `webpack.config.base.js`：
-
-```javascript
-externals: [
-  // put your node 3rd party libraries which can't be built with webpack here (mysql, mongodb, and so on..)
-]
-```
-
-For a common example, to install Bootstrap, `npm i --save bootstrap` and link them in the head of app.html
-
-```html
-<link rel="stylesheet" href="../node_modules/bootstrap/dist/css/bootstrap.css" />
-<link rel="image/svg+xml" href="../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.eot" />
-...
-```
-
-Make sure to list bootstrap in externals in `webpack.config.base.js` or the app won't include them in the package:
-```js
-externals: ['bootstrap']
-```

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -11,11 +11,9 @@ usage() {
     test -z "$1" || { echo "ERROR: $*" >&2; echo >&2; }
     cat >&2 <<EOF
   Usage:
-    $0 DAEDALUS-VERSION CARDANO-BRANCH OS OPTIONS*
+    $0 DAEDALUS-VERSION CARDANO-BRANCH OPTIONS*
 
   Build a Daedalus installer.
-
-  OS is either 'linux' or 'osx'.
 
   Options:
     --build-id BUILD-NO       Identifier of the build; defaults to '0'
@@ -58,12 +56,11 @@ upload_s3=
 
 daedalus_version="$1"; argnz "product version"; shift
 cardano_branch="$1";   argnz "Cardano SL branch to build Daedalus with"; shift
-os="$1";               argnz "OS to build for"; shift
 
-case "${os}" in
-        linux ) key=linux.p12;;
-        osx )   key=macos.p12;;
-        * )     usage "Unsupported OS provided: ${os}";;
+case "$(uname -s)" in
+        Darwin ) os=osx;   key=macos.p12;;
+        Linux )  os=linux; key=linux.p12;;
+        * )     usage "Unsupported OS: $(uname -s)";;
 esac
 
 set -u ## Undefined variable firewall enabled

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -23,6 +23,7 @@ usage() {
     --nix-path NIX-PATH       NIX_PATH value
 
     --upload-s3               Upload the installer to S3
+    --test-install            Test the installer for installability
 
     --verbose                 Verbose operation
     --quiet                   Disable verbose operation
@@ -55,6 +56,7 @@ verbose=true
 build_id=0
 travis_pr=true
 upload_s3=
+test_install=
 
 daedalus_version="$1"; argnz "product version"; shift
 cardano_branch="$1";   argnz "Cardano SL branch to build Daedalus with"; shift
@@ -75,6 +77,7 @@ do case "$1" in
            --nix-path )       arg2nz "NIX_PATH value";
                                                      export NIX_PATH="$2"; shift;;
            --upload-s3 )                                   upload_s3=t;;
+           --test-install )                             test_install=t;;
 
            ###
            --verbose )        echo "$0: --verbose passed, enabling verbose operation"
@@ -144,6 +147,11 @@ cd installers
             echo "$0: --upload-s3 passed, will upload the installer to S3";
             retry 5 nix-shell -p awscli --run "aws s3 cp 'dist/Daedalus-installer-${DAEDALUS_VERSION}.pkg' s3://daedalus-internal/ --acl public-read"
     fi
+    if test -n "${test_install}"
+    then echo "$0:  --test-install passed, will test the installer for installability";
+         case ${os} in
+                 osx )   sudo installer -dumplog -verbose -pkg "dist/Daedalus-installer-${DAEDALUS_VERSION}.pkg" -target /;;
+                 linux ) echo "WARNING: installation testing not implemented on Linux" >&2;; esac; fi
 cd ..
 
 ls -la installers/dist

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -100,15 +100,6 @@ export PATH=$HOME/.local/bin:$PATH
 export DAEDALUS_VERSION=${daedalus_version}.${build_id}
 export SSL_CERT_FILE=$NIX_SSL_CERT_FILE
 
-if test "${os}" = "linux"
-then
-        echo "INFO: running 'sudo mount -o remount,exec,size=4G,mode=755 /run/user'"
-        sudo mount -o remount,exec,size=4G,mode=755 /run/user ||
-                echo "WARNING:  Couldn't establish enough free space for the build process:  sudo failed" >&2
-else
-        echo "INFO:  not attempting to establish sufficient free space for the build process:  not supported on OS X"
-fi
-
 test -d node_modules/daedalus-client-api/ -a -n "${fast_impure}" || {
         retry 5 curl -o daedalus-bridge.tar.xz \
               https://s3.eu-central-1.amazonaws.com/cardano-sl-travis/daedalus-bridge-${os}-${cardano_branch}.tar.xz

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -56,9 +56,9 @@ build_id=0
 travis_pr=true
 upload_s3=
 
-daedalus_version="$1"; arg2nz "product version"; shift
-cardano_branch="$1";   arg2nz "Cardano SL branch to build Daedalus with"; shift
-os="$1";               arg2nz "OS to build for"; shift
+daedalus_version="$1"; argnz "product version"; shift
+cardano_branch="$1";   argnz "Cardano SL branch to build Daedalus with"; shift
+os="$1";               argnz "OS to build for"; shift
 
 case "${os}" in
         linux ) key=linux.p12;;

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# DEPENDENCIES (binaries should be in PATH):
+#   0. 'git'
+#   1. 'curl'
+#   2. 'nix-shell'
+#   3. 'stack'
+
+set -e
+
+usage() {
+    test -z "$1" || { echo "ERROR: $*" >&2; echo >&2; }
+    cat >&2 <<EOF
+  Usage:
+    $0 DAEDALUS-VERSION CARDANO-BRANCH OS OPTIONS*
+
+  Build a Daedalus installer.
+
+  OS is either 'linux' or 'osx'.
+
+  Options:
+    --build-id BUILD-NO       Identifier of the build; defaults to '0'
+
+    --travis-pr PR-ID         Travis pull request id we're building
+    --nix-path NIX-PATH       NIX_PATH value
+
+    --upload-s3               Upload the installer to S3
+
+    --verbose                 Verbose operation
+    --quiet                   Disable verbose operation
+    
+EOF
+    test -z "$1" || exit 1
+}
+alias   argnz='test $# -ge 1 -a ! -z "$1" || usage "empty value for"'
+alias  arg2nz='test $# -ge 2 -a ! -z "$2" || usage "empty value for"'
+alias  argnzf='test $# -ge 1 -a ! -z "$1" || fail "missing value for"'
+alias arg2nzf='test $# -ge 2 -a ! -z "$2" || fail "missing value for"'
+fail() { echo "ERROR: $*" >&2; exit 1;
+}
+retry() {
+        local tries=$1; argnzf "iteration count"; shift
+        for i in $(seq 1 ${tries})
+        do if "$@"
+           then return 0
+           fi
+           sleep 5s
+        done
+        fail "persistent failure to exec:  $*"
+}
+
+###
+### Argument processing
+###
+verbose=true
+build_id=0
+travis_pr=true
+upload_s3=
+
+daedalus_version="$1"; arg2nz "product version"; shift
+cardano_branch="$1";   arg2nz "Cardano SL branch to build Daedalus with"; shift
+os="$1";               arg2nz "OS to build for"; shift
+
+case "${os}" in
+        linux ) key=linux.p12;;
+        osx )   key=macos.p12;;
+        * )     usage "Unsupported OS provided: ${os}";;
+esac
+
+set -u ## Undefined variable firewall enabled
+while test $# -ge 1
+do case "$1" in
+           --build-id )       arg2nz "build identifier";    build_id="$2"; shift;;
+           --travis-pr )      arg2nz "Travis pull request id";
+                                                           travis_pr="$2"; shift;;
+           --nix-path )       arg2nz "NIX_PATH value";
+                                                     export NIX_PATH="$2"; shift;;
+           --upload-s3 )                                   upload_s3=t;;
+
+           ###
+           --verbose )        echo "$0: --verbose passed, enabling verbose operation"
+                                                             verbose=t;;
+           --quiet )          echo "$0: --quiet passed, disabling verbose operation"
+                                                             verbose=;;
+           --help )           usage;;
+           "--"* )            usage "unknown option: '$1'";;
+           * )                break;; esac
+   shift; done
+
+set -e
+if test -n "${verbose}"
+then set -x
+fi
+
+mkdir -p ~/.local/bin
+export PATH=$HOME/.local/bin:$PATH
+
+if test "${os}" = "linux"
+then
+        echo "INFO: running 'sudo mount -o remount,exec,size=4G,mode=755 /run/user'"
+        sudo mount -o remount,exec,size=4G,mode=755 /run/user ||
+                echo "WARNING:  Couldn't establish enough free space for the build process:  sudo failed" >&2
+else
+        echo "INFO:  not attempting to establish sufficient free space for the build process:  not supported on OS X"
+fi
+
+retry 5 bash -c "curl -L https://www.stackage.org/stack/${os}-x86_64 | \
+      tar xz --strip-components=1 -C ~/.local/bin"
+retry 5 curl -o daedalus-bridge.tar.xz \
+      https://s3.eu-central-1.amazonaws.com/cardano-sl-travis/daedalus-bridge-${os}-${cardano_branch}.tar.xz
+
+mkdir -p node_modules/daedalus-client-api/
+du -sh  daedalus-bridge.tar.xz
+tar xJf daedalus-bridge.tar.xz --strip-components=1 -C node_modules/daedalus-client-api/
+rm      daedalus-bridge.tar.xz
+echo "cardano-sl build id is $(cat node_modules/daedalus-client-api/build-id)"
+
+nix-shell --run "npm install"
+
+cd node_modules/daedalus-client-api
+    mv log-config-prod.yaml cardano-node cardano-launcher ../../installers
+cd ../..
+
+export DAEDALUS_VERSION=${daedalus_version}.${build_id}
+export SSL_CERT_FILE=$NIX_SSL_CERT_FILE
+
+strip installers/cardano-node installers/cardano-launcher
+rm node_modules/daedalus-client-api/cardano-*
+nix-shell --run "npm run package -- --icon installers/icons/256x256"
+echo "Size of Electron app is $(du -sh release)"
+
+cd installers
+    if test "${travis_pr}" = "false" -a "${os}" != "linux" # No Linux keys yet.
+    then retry 5 nix-shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/${key} ${key}"
+    fi
+    stack --no-terminal --nix build --exec make-installer --jobs 2
+    mkdir -p dist
+    if test -n "${upload_s3}"
+    then
+            echo "$0: --upload-s3 passed, will upload the installer to S3";
+            retry 5 nix-shell -p awscli --run "aws s3 cp 'dist/Daedalus-installer-${DAEDALUS_VERSION}.pkg' s3://daedalus-internal/ --acl public-read"
+    fi
+cd ..
+
+ls -la installers/dist
+
+exit 0

--- a/scripts/osx-build-fresh-daedalus.sh
+++ b/scripts/osx-build-fresh-daedalus.sh
@@ -55,6 +55,5 @@ pushd daedalus
     scripts/build-installer-unix.sh \
             "${GITHUB_USER}-${DAEDALUS_BRANCH}-$(git show-ref --hash HEAD)" \
             "${DEFAULT_DAEDALUS_BRANCH}" \
-            osx \
             "$@"
 popd

--- a/scripts/osx-build-fresh-daedalus.sh
+++ b/scripts/osx-build-fresh-daedalus.sh
@@ -1,0 +1,60 @@
+# DEPENDENCIES (binaries should be in PATH):
+#   0. 'git'
+#   1. 'curl'
+#   2. 'nix-shell'
+#   3. 'stack'
+
+DEFAULT_DAEDALUS_BRANCH=cardano-sl-0.4
+
+DAEDALUS_BRANCH=${1:-${DEFAULT_DAEDALUS_BRANCH}}
+GITHUB_USER=${2:-input-output-hk}
+shift 2
+
+URL=https://github.com/${GITHUB_USER}/daedalus.git
+
+test ! -e daedalus.old ||
+        rm -rf daedalus.old
+mv daedalus daedalus.old 2>/dev/null
+
+set -e -u
+
+test -n "$(type -P nix-shell)" || {
+        cat <<EOF
+WARNING: 'nix-shell' is absent from PATH
+
+Installation can be performed by following instructions at:
+
+  https://nixos.org/nix/download.html
+
+..or, if you're willing to skip straight to action:
+
+  curl https://nixos.org/nix/install | sh
+
+..are you willing to perform the above command?
+
+EOF
+        echo -n "Confirm: Y / n? "
+        read ans
+        test "${ans}" = "Y" -o "${ans}" = "y" -o -z "${ans}" || {
+                echo "FATAL: 'nix-shell' unavailable and user declined to proceed with installation." >&2
+                exit 1
+        }
+        echo "INFO:  proceeding with Nix installation, hang on tight."
+        echo
+        curl https://nixos.org/nix/install | sh
+        echo '. ~/.nix-profile/etc/profile.d/nix.sh' >> ~/.profile
+        . ~/.profile
+}
+
+echo "Building Daedalus branch ${DAEDALUS_BRANCH} from ${URL}"
+git clone ${URL}
+
+pushd daedalus
+    git reset --hard origin/${DAEDALUS_BRANCH}
+
+    scripts/build-installer-unix.sh \
+            "${GITHUB_USER}-${DAEDALUS_BRANCH}-$(git show-ref --hash HEAD)" \
+            "${DEFAULT_DAEDALUS_BRANCH}" \
+            osx \
+            "$@"
+popd


### PR DESCRIPTION
This completes the Daedalus local build automation (the first half of the effort was on Windows):

1. The build sequence is extracted into a stand-alone script, that is both invoked by CI and available for developer use.
2. A convenience script that allows a single-launch build of a fresh Daedalus version on OS X, that checks out a fresh version from git in a clean directory, installs Nix and invokes the build.
3. The `README.md` is revised in an attempt to provide better structure.

Known issues:
- [ ] ~~The `--upload-s3` option to the build script doesn't work without pre-obtained Amazon credentials~~
- [x] ~~The Linux build on the CI currently bombs out due to a failure of deployment -- which shouldn't even happen, because there's no installer to deploy on Linux yet -- the build is just a stub.  Clearly, something started to trigger this unwanted deployment.. couldn't figure out what did, so far.~~