### PR TITLE
[DEVOPS-118] Windows installer: escalate to admin exec level

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -107,7 +107,7 @@ writeInstallerNSIS fullVersion = do
     injectGlobalLiteral $ "VIAddVersionKey \"ProductVersion\" " <> fullVersion
     injectGlobalLiteral "Unicode true"
     installDir "$PROGRAMFILES64\\Daedalus"   -- The default installation directory
-    requestExecutionLevel Highest
+    requestExecutionLevel Admin
     injectGlobalLiteral "!addplugindir \"nsis_plugins\\liteFirewall\\bin\""
 
     page Directory                   -- Pick where to install


### PR DESCRIPTION
Installer currently fails to run for non-admin users without explicitly running it as an admin. To avoid the error we should preemptively request admin permission.

Manually verified using a local build on Windows Server 2012 r2.