### PR TITLE
[DEVOPS-102] Run cardano-launcher at highestAvailable level

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,8 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate.p12 C:/iohk-windows-certificate.p12
 
 test_script:
+  - dir "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\*.exe"
+  - set PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\8.1\bin\x64"
   - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% cardano-sl-0.4
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,6 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - dir "C:\Program Files (x86)\Windows Kits\8.1\bin\x64\*.exe"
-  - set PATH=%PATH%;"C:\Program Files (x86)\Windows Kits\8.1\bin\x64"
   - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% cardano-sl-0.4
 
 artifacts:

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -170,7 +170,7 @@ main = do
   signUninstaller
 
   echo "Adding permissions manifest to cardano-launcher.exe"
-  procs "mt.exe" ["-manifest", "cardano-launcher.exe.manifest", "-outputresource:cardano-launcher.exe;#1"] mempty
+  procs "C:\\Program Files (x86)\\Windows Kits\\8.1\\bin\\x64\\mt.exe" ["-manifest", "cardano-launcher.exe.manifest", "-outputresource:cardano-launcher.exe;#1"] mempty
 
   echo "Writing daedalus.nsi"
   writeInstallerNSIS fullVersion

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -116,8 +116,6 @@ writeInstallerNSIS fullVersion = do
     _ <- section "" [Required] $ do
         setOutPath "$INSTDIR"        -- Where to install files in this section
         writeRegStr HKLM "Software/Daedalus" "Install_Dir" "$INSTDIR" -- Used by launcher batch script
-        createDirectory "$APPDATA\\Daedalus\\DB-0.2"
-        createDirectory "$APPDATA\\Daedalus\\Wallet-0.2"
         createDirectory "$APPDATA\\Daedalus\\Logs"
         createDirectory "$APPDATA\\Daedalus\\Secrets"
         createShortcut "$DESKTOP\\Daedalus.lnk" daedalusShortcut

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -169,6 +169,9 @@ main = do
   writeUninstallerNSIS fullVersion
   signUninstaller
 
+  echo "Adding permissions manifest to cardano-launcher.exe"
+  procs "mt.exe" ["-manifest", "cardano-launcher.exe.manifest", "-outputresource:cardano-launcher.exe;#1"] mempty
+
   echo "Writing daedalus.nsi"
   writeInstallerNSIS fullVersion
 

--- a/installers/cardano-launcher.exe.manifest
+++ b/installers/cardano-launcher.exe.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="highestAvailable" uiAccess="false"/>
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+</assembly>


### PR DESCRIPTION
Necessary for getting an update Installer.exe to elevate to admin
execution level when run by an admin user.

DEVOPS-118 tried to address this by setting requestExecutionLevel
to admin, but it doesn't take take effect when executed by a
non-elevated exe (in this case cardano-launcher.exe).

This approach has been verified on a Windows 10 Pro VM.