### PR TITLE
[DAEF-212] show upcoming currencies as disabled on create wallet dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog
 - “Terms of use” page in settings section
 - Change wallet password dialog UX improvements
 - Multiple input and output addresses in transaction details
+- Show BTC and ETC currencies as coming soon in create wallet dialog
 
 ### Fixes
 

--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -70,10 +70,17 @@ const messages = defineMessages({
     defaultMessage: '!!!Password',
     description: 'Placeholder for the "Password" inputs in the create wallet dialog.',
   },
+  currencyComingSoonLabel: {
+    id: 'wallet.create.dialog.currencyComingSoonLabel',
+    defaultMessage: '!!!Coming soon',
+    description: 'Label for currency options that are disabled but coming soon.',
+  }
 });
 
 const currencies = [
   { value: 'ada', label: 'ADA' },
+  { value: 'btc', label: 'BTC', isDisabled: true },
+  { value: 'etc', label: 'ETC', isDisabled: true },
 ];
 
 @observer
@@ -234,6 +241,16 @@ export default class WalletCreateDialog extends Component {
           className="currency"
           {...form.$('currency').bind()}
           options={currencies}
+          optionRenderer={option => (
+            <div className={styles.currencyOption}>
+              <span>{option.label}</span>
+              {option.isDisabled && (
+                <span className={styles.currencyOptionComingSoon}>
+                  {intl.formatMessage(messages.currencyComingSoonLabel)}
+                </span>
+              )}
+            </div>
+          )}
           skin={<SelectSkin />}
         />
 

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -1,11 +1,5 @@
 @import '../../themes/mixins/loading-spinner';
 
-.component {
-  :global .dialog_body {
-    overflow-y: hidden;
-  }
-}
-
 .isSubmitting {
   button {
     @include loading-spinner("../../assets/images/spinner-light.svg");
@@ -39,4 +33,9 @@
       width: 275px;
     }
   }
+}
+
+.currencyOptionComingSoon {
+  float: right;
+  font-size: 14px;
 }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -85,6 +85,7 @@
   "wallet.create.dialog.title": "Create wallet",
   "wallet.create.dialog.walletNameHint": "e.g: Shopping Wallet",
   "wallet.create.dialog.walletPasswordLabel": "Wallet password",
+  "wallet.create.dialog.currencyComingSoonLabel": "Coming soon",
   "wallet.key.import.dialog.headline": "Import Wallet",
   "wallet.key.import.dialog.keyFileHint": "Drop file here or click to choose",
   "wallet.key.import.dialog.keyFileLabel": "Upload your key file",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "react-intl": "2.2.3",
     "react-markdown": "2.5.0",
     "react-number-format": "1.1.2",
-    "react-polymorph": "git@github.com:CodeAdventure/react-polymorph.git#c54bfe35c2cb0971bc9631442cf3b4315e00c7b2",
+    "react-polymorph": "git@github.com:CodeAdventure/react-polymorph.git#eb62387fc516800155d1a9d41e7ced4f2f43fde5",
     "react-router": "3.0.3",
     "react-toolbox": "1.3.4",
     "recharts": "0.19.1",


### PR DESCRIPTION
This PR adds upcoming currencies to the create wallet dialog, as disabled options in the select component:

<img width="666" alt="screenshot 2017-05-29 um 12 37 49" src="https://cloud.githubusercontent.com/assets/172414/26549180/9b2dabc6-446f-11e7-897a-5b90f67954d4.png">
