### PR TITLE
Fix builds on branches that have `/` in their name

### DIFF
--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -59,7 +59,7 @@ upload_s3=
 test_install=
 
 daedalus_version="$1"; argnz "product version"; shift
-cardano_branch="$1";   argnz "Cardano SL branch to build Daedalus with"; shift
+cardano_branch="$(printf '%s' "$1" | tr '/' '-')"; argnz "Cardano SL branch to build Daedalus with"; shift
 
 case "$(uname -s)" in
         Darwin ) os=osx;   key=macos-2.p12;;


### PR DESCRIPTION
Fixes the URL for downloading daedalus bridge assets from S3 when
branch name has a / in it. Already tested in branch
nh2/csl-1004-node-catchup-improvements.