### PR TITLE
Feature/daef 278 add wallet restore feature acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 - Spending password on wallet receive page
 - Prepared UI dialogs for exporting paper wallets
 - Prepared UI dialogs for importing paper wallets
+- Acceptance test for "Restore wallet with and without spending password" feature
 
 ### Fixes
 

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -236,8 +236,14 @@ export default class WalletRestoreDialog extends Component {
           </div>
 
           <div className={walletPasswordFieldsClasses}>
-            <Input {...form.$('walletPassword').bind()} />
-            <Input {...form.$('repeatPassword').bind()} />
+            <Input
+              className="walletPassword"
+              {...form.$('walletPassword').bind()}
+            />
+            <Input
+              className="repeatedPassword"
+              {...form.$('repeatPassword').bind()}
+            />
           </div>
         </div>
 

--- a/features/restore-wallet-via-sidebar.feature
+++ b/features/restore-wallet-via-sidebar.feature
@@ -1,0 +1,33 @@
+Feature: Add Wallet via Sidebar
+
+  Background:
+    Given I have selected English language
+    And I have accepted "Terms of use"
+    And I have a wallet with funds
+
+  Scenario: Successfully Restoring a Wallet
+    Given The sidebar shows the "wallets" category
+    When I click on the add wallet button in the sidebar
+    And I see the add wallet dialog
+    And I click on the restore wallet button in add wallet dialog
+    And I see the restore wallet dialog
+    And I submit the restore wallet dialog with the following inputs:
+    | walletName      | recoveryPhrase                                                            |
+    | Restored wallet | marriage glide need gold actress grant judge eager spawn plug sister whip |
+    Then I should not see the restore wallet dialog anymore
+    And I should have newly created "Restored wallet" wallet loaded
+    And I should be on the "Restored wallet" wallet "summary" screen
+
+  Scenario: Successfully Restoring a Wallet with spending password
+    Given The sidebar shows the "wallets" category
+    When I click on the add wallet button in the sidebar
+    And I see the add wallet dialog
+    And I click on the restore wallet button in add wallet dialog
+    And I see the restore wallet dialog
+    And I toggle "Activate to create password" switch on the restore wallet dialog
+    And I submit the restore wallet with spending password dialog with the following inputs:
+    | walletName      | password | repeatedPassword | recoveryPhrase                                                            |
+    | Restored wallet | secret   | secret           | marriage glide need gold actress grant judge eager spawn plug sister whip |
+    Then I should not see the restore wallet dialog anymore
+    And I should have newly created "Restored wallet" wallet loaded
+    And I should be on the "Restored wallet" wallet "summary" screen

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -61,6 +61,10 @@ export default function () {
     return this.client.waitForVisible('.WalletCreateDialog');
   });
 
+  this.Given(/^I see the restore wallet dialog$/, function () {
+    return this.client.waitForVisible('.WalletRestoreDialog');
+  });
+
   this.Given(/^I dont see the create wallet dialog(?: anymore)?$/, function () {
     return this.client.waitForVisible('.WalletCreateDialog', null, true);
   });
@@ -74,6 +78,10 @@ export default function () {
 
   this.When(/^I click on the create wallet button in add wallet dialog$/, function () {
     return this.waitAndClick('.WalletAddDialog .createWalletButton');
+  });
+
+  this.When(/^I click on the restore wallet button in add wallet dialog$/, function () {
+    return this.waitAndClick('.WalletAddDialog .restoreWalletButton');
   });
 
   this.When(/^I click the wallet (.*) button$/, async function (buttonName) {
@@ -105,10 +113,30 @@ export default function () {
     return this.client.click(submitButton);
   });
 
+  this.When(/^I toggle "Activate to create password" switch on the restore wallet dialog$/, function () {
+    return this.waitAndClick('.WalletRestoreDialog .switch_field');
+  });
+
   this.When(/^I submit the create wallet dialog with the following inputs:$/, async function (table) {
     const fields = table.hashes()[0];
     await this.client.setValue('.WalletCreateDialog .walletName input', fields.walletName);
     return this.client.click('.WalletCreateDialog .dialog_button');
+  });
+
+  this.When(/^I submit the restore wallet dialog with the following inputs:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.WalletRestoreDialog .walletName input', fields.walletName);
+    await this.client.setValue('.WalletRestoreDialog .recoveryPhrase textarea', fields.recoveryPhrase);
+    return this.client.click('.WalletRestoreDialog .dialog_button');
+  });
+
+  this.When(/^I submit the restore wallet with spending password dialog with the following inputs:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.WalletRestoreDialog .walletName input', fields.walletName);
+    await this.client.setValue('.WalletRestoreDialog .recoveryPhrase textarea', fields.recoveryPhrase);
+    await this.client.setValue('.WalletRestoreDialog .walletPassword input', fields.password);
+    await this.client.setValue('.WalletRestoreDialog .repeatedPassword input', fields.repeatedPassword);
+    return this.client.click('.WalletRestoreDialog .dialog_button');
   });
 
   this.When(/^I see the create wallet privacy dialog$/, function () {
@@ -183,7 +211,11 @@ export default function () {
     return this.client.waitForVisible('.DeleteWalletConfirmationDialog_dialog', null, true);
   });
 
-  this.Then(/^I should have newly created "Test" wallet loaded$/, async function () {
+  this.Then(/^I should not see the restore wallet dialog anymore$/, function () {
+    return this.client.waitForVisible('.WalletRestoreDialog', null, true);
+  });
+
+  this.Then(/^I should have newly created "([^"]*)" wallet loaded$/, async function (walletName) {
     const result = await this.client.executeAsync(function(done) {
       daedalus.stores.wallets.walletsRequest.execute().then(done);
     });
@@ -193,6 +225,8 @@ export default function () {
     } else {
       this.wallets = result.value;
     }
+    const wallet = getWalletByName.call(this, walletName);
+    expect(wallet).to.be.an('object');
   });
 
   this.Then(/^I should be on some wallet page$/, async function () {


### PR DESCRIPTION
This PR introduces acceptance tests for wallet restore feature.
Tests include two scenarios:
- Wallet restore WITHOUT spending password
- Wallet restore WITH spending password