### PR TITLE
Fix/daef 286 Add error message handling on change password dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changelog
 - Apply grammatical fixes to redemption instructions
 - Prevent sidebar visual glitch on sidebar open
 - Added missing "Add wallet" button label translation key
+- Improved error handling on "Set/Change wallet password" dialog
 
 ### Chores
 

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -10,8 +10,8 @@ import DialogCloseButton from '../../widgets/DialogCloseButton';
 import Switch from '../../widgets/Switch';
 import { isValidWalletPassword, isValidRepeatPassword } from '../../../lib/validations';
 import globalMessages from '../../../i18n/global-messages';
+import LocalizableError from '../../../i18n/LocalizableError';
 import styles from './ChangeWalletPasswordDialog.scss';
-
 
 const messages = defineMessages({
   dialogTitleSetPassword: {
@@ -72,6 +72,9 @@ export default class ChangeWalletPasswordDialog extends Component {
     onSave: Function,
     onCancel: Function,
     onDataChange: Function,
+    onPasswordSwitchToggle: Function,
+    isSubmitting: boolean,
+    error: ?LocalizableError,
   };
 
   static defaultProps = {
@@ -85,7 +88,6 @@ export default class ChangeWalletPasswordDialog extends Component {
   };
 
   state = {
-    isSubmitting: false,
     removePassword: false,
   };
 
@@ -99,7 +101,7 @@ export default class ChangeWalletPasswordDialog extends Component {
         validators: [({ field }) => {
           if (!this.props.isWalletPasswordSet) return [true];
           return [
-            isValidWalletPassword(field.value), // TODO: replace with real current password check
+            isValidWalletPassword(field.value),
             this.context.intl.formatMessage(globalMessages.invalidWalletPassword)
           ];
         }],
@@ -148,7 +150,6 @@ export default class ChangeWalletPasswordDialog extends Component {
   submit = () => {
     this.form.submit({
       onSuccess: (form) => {
-        this.setState({ isSubmitting: true });
         const { removePassword } = this.state;
         const { currentPassword, walletPassword } = form.values();
         const passwordData = {
@@ -157,14 +158,13 @@ export default class ChangeWalletPasswordDialog extends Component {
         };
         this.props.onSave(passwordData);
       },
-      onError: () => {
-        this.setState({ isSubmitting: false });
-      },
+      onError: () => {},
     });
   };
 
   handlePasswordSwitchToggle = (value: boolean) => {
     this.setState({ removePassword: value });
+    this.props.onPasswordSwitchToggle();
   };
 
   handleDataChange = (key: string, value: string) => {
@@ -180,8 +180,15 @@ export default class ChangeWalletPasswordDialog extends Component {
       currentPasswordValue,
       newPasswordValue,
       repeatedPasswordValue,
+      isSubmitting,
+      error,
     } = this.props;
     const { removePassword } = this.state;
+
+    const dialogClasses = classnames([
+      styles.dialog,
+      isSubmitting ? styles.isSubmitting : null
+    ]);
 
     const walletPasswordFieldsClasses = classnames([
       styles.walletPasswordFields,
@@ -204,7 +211,8 @@ export default class ChangeWalletPasswordDialog extends Component {
         )}
         actions={actions}
         active
-        className={styles.dialog}
+        onOverlayClick={onCancel}
+        className={dialogClasses}
       >
 
         {isWalletPasswordSet ? (
@@ -243,6 +251,8 @@ export default class ChangeWalletPasswordDialog extends Component {
             {...form.$('repeatPassword').bind()}
           />
         </div>
+
+        {error ? <p className={styles.error}>{intl.formatMessage(error)}</p> : null}
 
         <DialogCloseButton onClose={onCancel} />
 

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.scss
@@ -1,3 +1,6 @@
+@import '../../../themes/mixins/loading-spinner';
+@import '../../../themes/mixins/error-message';
+
 .dialog {
   font-family: $font-light;
 
@@ -43,5 +46,17 @@
     &:active {
       background: $color-dark-red !important;
     }
+  }
+
+  .error {
+    @include error-message;
+    text-align: center;
+    margin-top: 27px;
+  }
+}
+
+.isSubmitting {
+  button {
+    @include loading-spinner("../../../assets/images/spinner-light.svg");
   }
 }

--- a/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
+++ b/app/containers/wallet/dialogs/ChangeWalletPasswordDialogContainer.js
@@ -11,12 +11,25 @@ export default class ChangeWalletPasswordDialogContainer extends Component {
 
   props: InjectedProps;
 
+  resetErrors = () => {
+    const {
+      changeWalletPasswordRequest,
+      setWalletPasswordRequest,
+    } = this.props.stores.walletSettings;
+    changeWalletPasswordRequest.reset();
+    setWalletPasswordRequest.reset();
+  };
+
   render() {
     const { actions } = this.props;
-    const { wallets, uiDialogs } = this.props.stores;
+    const { wallets, walletSettings, uiDialogs } = this.props.stores;
     const dialogData = uiDialogs.dataForActiveDialog;
     const { updateDataForActiveDialog } = actions.dialogs;
     const activeWallet = wallets.active;
+    const {
+      changeWalletPasswordRequest,
+      setWalletPasswordRequest,
+    } = walletSettings;
 
     if (!activeWallet) throw new Error('Active wallet required for ChangeWalletPasswordDialogContainer.');
 
@@ -37,12 +50,21 @@ export default class ChangeWalletPasswordDialogContainer extends Component {
               walletId, oldPassword: values.oldPassword, newPassword: values.newPassword
             });
           }
-          actions.dialogs.resetActiveDialog.trigger();
         }}
-        onCancel={actions.dialogs.closeActiveDialog.trigger}
+        onCancel={() => {
+          actions.dialogs.closeActiveDialog.trigger();
+          this.resetErrors();
+        }}
+        onPasswordSwitchToggle={this.resetErrors}
         onDataChange={data => {
           updateDataForActiveDialog.trigger({ data });
         }}
+        isSubmitting={
+          changeWalletPasswordRequest.isExecuting || setWalletPasswordRequest.isExecuting
+        }
+        error={
+          changeWalletPasswordRequest.error || setWalletPasswordRequest.error
+        }
       />
     );
   }

--- a/app/stores/WalletSettingsStore.js
+++ b/app/stores/WalletSettingsStore.js
@@ -53,6 +53,8 @@ export default class WalletSettingsStore extends Store {
     walletId: string, oldPassword: string, newPassword: string,
   }) => {
     await this.changeWalletPasswordRequest.execute({ walletId, oldPassword, newPassword });
+    this.actions.dialogs.closeActiveDialog.trigger();
+    this.changeWalletPasswordRequest.reset();
     this.stores.wallets.refreshWalletsData();
   };
 
@@ -60,6 +62,8 @@ export default class WalletSettingsStore extends Store {
     walletId: string, password: string,
   }) => {
     await this.setWalletPasswordRequest.execute({ walletId, password });
+    this.actions.dialogs.closeActiveDialog.trigger();
+    this.setWalletPasswordRequest.reset();
     this.stores.wallets.refreshWalletsData();
   };
 


### PR DESCRIPTION
This PR introduces improved error handling on "Set / Change / Remove wallet password" dialogs.

![remove-password-dialog](https://user-images.githubusercontent.com/376611/27302539-be7a0b14-5537-11e7-88b4-532f55c76795.png)