### PR TITLE
Fix/daef 288 fix delete wallet dialog closing logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Changelog
 - Apply grammatical fixes to redemption instructions
 - Prevent sidebar visual glitch on sidebar open
 - Added missing "Add wallet" button label translation key
+- Prevent "Delete wallet" dialog from closing until deletion is over
 
 ### Chores
 

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
+import classnames from 'classnames';
 import Dialog from 'react-toolbox/lib/dialog/Dialog';
 import Input from 'react-toolbox/lib/input/Input';
 import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
@@ -50,6 +51,7 @@ export default class DeleteWalletConfirmationDialog extends Component {
     onContinue: Function,
     onCancel: Function,
     onConfirmationValueChange: Function,
+    isSubmitting: boolean,
   };
 
   static defaultProps = {
@@ -71,13 +73,19 @@ export default class DeleteWalletConfirmationDialog extends Component {
       onContinue,
       walletName,
       confirmationValue,
-      onConfirmationValueChange
+      onConfirmationValueChange,
+      isSubmitting,
     } = this.props;
 
     const countdownRemaining = countdownFn(environment.isTest() ? 0 : 10);
     const countdownDisplay = countdownRemaining > 0 ? ` (${countdownRemaining})` : '';
     const isCountdownFinished = countdownRemaining <= 0;
     const isWalletNameConfirmationCorrect = confirmationValue === walletName;
+
+    const dialogClasses = classnames([
+      styles.dialog,
+      isSubmitting ? styles.isSubmitting : null
+    ]);
 
     const actions = [
       {
@@ -99,7 +107,8 @@ export default class DeleteWalletConfirmationDialog extends Component {
         title={intl.formatMessage(messages.dialogTitle)}
         actions={actions}
         active
-        className={styles.dialog}
+        onOverlayClick={onCancel}
+        className={dialogClasses}
       >
         <FormattedHTMLMessage
           {...messages.wantToDeleteWalletQuestion}

--- a/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
+++ b/app/components/wallet/settings/DeleteWalletConfirmationDialog.scss
@@ -1,3 +1,5 @@
+@import '../../../themes/mixins/loading-spinner';
+
 .dialog {
   font-family: $font-light;
 
@@ -31,4 +33,10 @@
 
 .confirmationInput {
   margin-top: 30px;
+}
+
+.isSubmitting {
+  :global button.button_primary {
+    @include loading-spinner("../../../assets/images/spinner-light.svg");
+  }
 }

--- a/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
+++ b/app/containers/wallet/dialogs/DeleteWalletDialogContainer.js
@@ -16,6 +16,7 @@ export default class DeleteWalletDialogContainer extends Component {
     const dialogData = uiDialogs.dataForActiveDialog;
     const { updateDataForActiveDialog } = actions.dialogs;
     const activeWallet = wallets.active;
+    const { deleteWalletRequest } = wallets;
 
     // Guard against potential null values
     if (!activeWallet) throw new Error('Active wallet required for DeleteWalletDialogContainer.');
@@ -31,13 +32,16 @@ export default class DeleteWalletDialogContainer extends Component {
         })}
         onContinue={() => {
           actions.wallets.deleteWallet.trigger({ walletId: activeWallet.id });
-          actions.dialogs.resetActiveDialog.trigger();
         }}
-        onCancel={actions.dialogs.closeActiveDialog.trigger}
+        onCancel={() => {
+          actions.dialogs.closeActiveDialog.trigger();
+          deleteWalletRequest.reset();
+        }}
         confirmationValue={dialogData.confirmationValue}
         onConfirmationValueChange={confirmationValue => updateDataForActiveDialog.trigger({
           data: { confirmationValue }
         })}
+        isSubmitting={deleteWalletRequest.isExecuting}
       />
     );
   }

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -94,12 +94,14 @@ export default class WalletsStore extends Store {
       if (this.hasAnyWallets) {
         const nextIndexInList = Math.max(indexOfWalletToDelete - 1, 0);
         const nextWalletInList = this.all[nextIndexInList];
+        this.actions.dialogs.closeActiveDialog.trigger();
         this.goToWalletRoute(nextWalletInList.id);
       } else {
         this.active = null;
         this.actions.router.goToRoute.trigger({ route: ROUTES.NO_WALLETS });
       }
     });
+    this.deleteWalletRequest.reset();
     this.refreshWalletsData();
   };
 
@@ -129,7 +131,7 @@ export default class WalletsStore extends Store {
       ...transactionDetails,
       walletId: wallet.id,
       amount: transactionDetails.amount,
-      sender: accountId, // wallet.address,
+      sender: accountId,
     });
     this.refreshWalletsData();
     this.goToWalletRoute(wallet.id);
@@ -255,7 +257,6 @@ export default class WalletsStore extends Store {
   _updateActiveWalletOnRouteChanges = () => {
     const currentRoute = this.stores.app.currentRoute;
     const hasAnyWalletsLoaded = this.hasAnyLoaded;
-
     runInAction('WalletsStore::_updateActiveWalletOnRouteChanges', () => {
       // There are not wallets loaded (yet) -> unset active and return
       if (!hasAnyWalletsLoaded) return this._unsetActiveWallet();


### PR DESCRIPTION
This PR prevents "Delete wallet" dialog from closing until wallet deletion is finished and introduces "is-submitting" state in form of "spinner" submit button.

![delete-wallet-dialog](https://user-images.githubusercontent.com/376611/27326282-574d6fca-55ab-11e7-87d1-171736e63a7c.png)
