### PR TITLE
Fix/daef 308 fix active wallet refresh after wallet update actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changelog
 - Prevent "Delete wallet" dialog from closing until deletion is over
 - Improved error handling on "Set/Change wallet password" dialog
 - Improved API response errors handling
+- Update active wallet after wallet update actions
 
 ### Chores
 

--- a/app/stores/WalletSettingsStore.js
+++ b/app/stores/WalletSettingsStore.js
@@ -45,6 +45,7 @@ export default class WalletSettingsStore extends Store {
       const walletIndex = _.findIndex(result, { id: walletId });
       result[walletIndex] = wallet;
     });
+    this.stores.wallets._setActiveWallet({ walletId });
   };
 
   @action _updateWalletPassword = async ({ walletId, oldPassword, newPassword }: {
@@ -53,7 +54,8 @@ export default class WalletSettingsStore extends Store {
     await this.updateWalletPasswordRequest.execute({ walletId, oldPassword, newPassword });
     this.actions.dialogs.closeActiveDialog.trigger();
     this.updateWalletPasswordRequest.reset();
-    this.stores.wallets.refreshWalletsData();
+    await this.stores.wallets.refreshWalletsData();
+    this.stores.wallets._setActiveWallet({ walletId });
   };
 
   @action _updateWalletField = async ({ field, value }: { field: string, value: string }) => {
@@ -68,6 +70,7 @@ export default class WalletSettingsStore extends Store {
       const walletIndex = _.findIndex(result, { id: walletId });
       result[walletIndex] = wallet;
     });
+    this.stores.wallets._setActiveWallet({ walletId });
   };
 
   @action _startEditingWalletField = ({ field }: { field: string }) => {


### PR DESCRIPTION
This PR introduces a fix for issues with wallet data refresh on wallet settings page after wallet update actions (wallet-rename, wallet-assurance-change, wallet-password-update).