### PR TITLE
Fix/daef 317 Improve nextUpdate error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Changelog
 - Acceptance test for "Send money from a wallet with spending password" feature
 - Acceptance test for "Generate wallet address" feature
 - Final version of Daedalus logo added on the loading screen
-- Final version of Daedalus logo added in the top-bar 
+- Final version of Daedalus logo added in the top-bar
 
 ### Fixes
 
@@ -50,6 +50,7 @@ Changelog
 - Improved error handling on "Set/Change wallet password" dialog
 - Improved API response errors handling
 - Update active wallet after wallet update actions
+- Improved API nextUpdate response errors handling
 
 ### Chores
 

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -401,8 +401,11 @@ export default class CardanoClientApi {
       nextUpdate = JSON.parse(await ClientApi.nextUpdate());
       Log.debug('CardanoClientApi::nextUpdate success: ', stringifyData(nextUpdate));
     } catch (error) {
-      Log.debug('CardanoClientApi::nextUpdate error: ' + stringifyError(error));
-      // TODO: Api is trowing an error when update is not available, handle other errors
+      if (error.message.includes('No updates available')) {
+        Log.debug('CardanoClientApi::nextUpdate success: No updates available');
+      } else {
+        Log.error('CardanoClientApi::nextUpdate error: ' + stringifyError(error));
+      }
     }
     return nextUpdate;
     // TODO: remove hardcoded response after node update is tested
@@ -577,7 +580,7 @@ export default class CardanoClientApi {
 // ========== LOGGING =========
 
 const stringifyData = (data) => JSON.stringify(data, null, 2);
-const stringifyError = (error) => JSON.stringify(error, Object.getOwnPropertyNames(error));
+const stringifyError = (error) => JSON.stringify(error, Object.getOwnPropertyNames(error), 2);
 
 // ========== TRANSFORM SERVER DATA INTO FRONTEND MODELS =========
 


### PR DESCRIPTION
This PR introduces improved API nextUpdate response errors handling by no longer logging "No updates available" response as an error (default success logger is used instead).