### PR TITLE
[DAEF-325] Disable polling for wallet data while syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Changelog
 - Improved error handling on "Set/Change wallet password" dialog
 - Improved API response errors handling
 - Update active wallet after wallet update actions
+- Polling should be disable while node is syncing with the blockchain
 
 ### Chores
 

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -61,7 +61,7 @@ export default class WalletsStore extends Store {
       this._toggleAddWalletDialogOnWalletsLoaded,
     ]);
     if (environment.CARDANO_API) {
-      setInterval(this.refreshWalletsData, this.WALLET_REFRESH_INTERVAL);
+      setInterval(this.pollRefresh, this.WALLET_REFRESH_INTERVAL);
     }
   }
 
@@ -180,7 +180,7 @@ export default class WalletsStore extends Store {
   isValidPrivateKey = () => { return true; }; // eslint-disable-line
 
   @action refreshWalletsData = async () => {
-    if (this.stores.networkStatus.isSynced) {
+    if (this.stores.networkStatus.isConnected) {
       const result = await this.walletsRequest.execute().promise;
       if (!result) return;
       runInAction('refresh active wallet', () => {
@@ -205,6 +205,12 @@ export default class WalletsStore extends Store {
         }));
         this.stores.transactions._refreshTransactionData();
       });
+    }
+  };
+
+  pollRefresh = async () => {
+    if (this.stores.networkStatus.isSynced) {
+      await this.refreshWalletsData();
     }
   };
 

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -180,7 +180,7 @@ export default class WalletsStore extends Store {
   isValidPrivateKey = () => { return true; }; // eslint-disable-line
 
   @action refreshWalletsData = async () => {
-    if (this.stores.networkStatus.isConnected) {
+    if (this.stores.networkStatus.isConnected && this.stores.networkStatus.isSynced) {
       const result = await this.walletsRequest.execute().promise;
       if (!result) return;
       runInAction('refresh address data', () => {

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -180,7 +180,7 @@ export default class WalletsStore extends Store {
   isValidPrivateKey = () => { return true; }; // eslint-disable-line
 
   @action refreshWalletsData = async () => {
-    if (this.stores.networkStatus.isConnected && this.stores.networkStatus.isSynced) {
+    if (this.stores.networkStatus.isSynced) {
       const result = await this.walletsRequest.execute().promise;
       if (!result) return;
       runInAction('refresh active wallet', () => {


### PR DESCRIPTION
This PR disables polling for wallet data while the wallet node is syncing. Polling while syncing is slowing dow the node.

To do:
- [x] Verify that tests are green
- [x] Crate a card for changing the logic for `isSynced`, with 15-second slots sync is jumping from 99% to 100% constantly since new blocks are received very often.