### PR TITLE
[DAEF-328] Reset last generated address after switching wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Changelog
 - Improved error handling on "Set/Change wallet password" dialog
 - Improved API response errors handling
 - Update active wallet after wallet update actions
+- Last generated address was not being reset when switching wallets and it was shown on the receive screen for the wrong wallet
 
 ### Chores
 

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -233,6 +233,7 @@ export default class WalletsStore extends Store {
   @action _setActiveWallet = ({ walletId }: { walletId: string }) => {
     if (this.hasAnyWallets) {
       this.active = this.all.find(wallet => wallet.id === walletId);
+      this.stores.addresses.lastGeneratedAddress = null;
     }
   };
 


### PR DESCRIPTION
This PR resets last generated address and fixes the bug with showing the address of the different wallet on the receive page