### PR TITLE
Fix/daef 324 acceptance test for double money received bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Changelog
 - Improved active wallet data refresh after wallet balance/settings change
 - Fixed failing wallet add/restore/import acceptance tests
 - Polling should be disable while node is syncing with the blockchain
+- Acceptance test for "Sending money" feature should check receiver wallet's balance
 
 ### Chores
 

--- a/app/components/sidebar/wallets/SidebarWalletMenuItem.js
+++ b/app/components/sidebar/wallets/SidebarWalletMenuItem.js
@@ -12,12 +12,17 @@ export default class SidebarWalletMenuItem extends Component {
     title: string,
     info: string,
     active: boolean,
+    className: string,
     onClick: Function,
   };
 
   render() {
-    const { title, info, active, onClick } = this.props;
-    const componentStyles = classNames([styles.component, active ? styles.active : null]);
+    const { title, info, active, className, onClick } = this.props;
+    const componentStyles = classNames([
+      styles.component,
+      active ? styles.active : null,
+      className,
+    ]);
     return (
       <button className={componentStyles} onClick={onClick}>
         <span className={styles.meta}>

--- a/app/components/sidebar/wallets/SidebarWalletsMenu.js
+++ b/app/components/sidebar/wallets/SidebarWalletsMenu.js
@@ -44,6 +44,7 @@ export default class SidebarWalletsMenu extends Component {
               active={isActiveWallet(wallet.id)}
               onClick={() => onWalletItemClick(wallet.id)}
               key={wallet.id}
+              className={`Wallet_${wallet.id}`}
             />
           ))}
         </div>

--- a/features/send-money-to-receiver.feature
+++ b/features/send-money-to-receiver.feature
@@ -18,6 +18,9 @@ Feature: Send Money to Receiver
     And the latest transaction should show:
       | title                      | amount    |
       | wallet.transaction.adaSent | -0.000010 |
+    And the balance of "first" wallet should be:
+      | balance  |
+      | 0.000010 |
 
   Scenario: User Sends Money from wallet with spending password to Receiver
     Given I have a wallet with funds and password
@@ -30,6 +33,9 @@ Feature: Send Money to Receiver
     And the latest transaction should show:
       | title                      | amount    |
       | wallet.transaction.adaSent | -0.000010 |
+    And the balance of "first" wallet should be:
+      | balance  |
+      | 0.000010 |
 
   Scenario: User Submits Empty Form
     Given I have a wallet with funds

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -339,7 +339,14 @@ export default function () {
     expect(expectedTransactionTitle).to.equal(transactionTitles[0]);
     let transactionAmounts = await this.client.getText('.Transaction_amount');
     transactionAmounts = [].concat(transactionAmounts);
-    expect(expectedData.amount).to.include(transactionAmounts[0]);
+    expect(expectedData.amount).to.equal(transactionAmounts[0]);
+  });
+
+  this.Then(/^the balance of "([^"]*)" wallet should be:$/, async function (walletName, table) {
+    const expectedData = table.hashes()[0];
+    const receiverWallet = getWalletByName.call(this, walletName);
+    const receiverWalletBalance = await this.client.getText(`.SidebarWalletsMenu_wallets .Wallet_${receiverWallet.id} .SidebarWalletMenuItem_info`);
+    expect(receiverWalletBalance).to.equal(`${expectedData.balance} ADA`);
   });
 
   this.Then(/^I should see two wallet addresses$/, function () {


### PR DESCRIPTION
This PR extends acceptance test for "Sending money" feature by checking receiver's wallet balance after transaction is complete and by doing so exposes current API double-amount bug.