### PR TITLE
Fix - [DAEF-337] Disable polling for system update while connecting and syncing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Changelog
 - Improved API nextUpdate response errors handling
 - Improved active wallet data refresh after wallet balance/settings change
 - Fixed failing wallet add/restore/import acceptance tests
-- Polling for wallet data and system update should be disable while node is syncing with the blockchain
+- Polling for wallet data and system update should be disabled while node is syncing with the blockchain
 - Prevent syncing icon from being always stuck in syncing state by refactoring in-sync state calculation
 - Acceptance test for "Sending money" feature should check receiver wallet's balance
 - Improved spending password validation rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Changelog
 - Improved API nextUpdate response errors handling
 - Improved active wallet data refresh after wallet balance/settings change
 - Fixed failing wallet add/restore/import acceptance tests
-- Polling should be disable while node is syncing with the blockchain
+- Polling for wallet data and system update should be disable while node is syncing with the blockchain
 - Prevent syncing icon from being always stuck in syncing state by refactoring in-sync state calculation
 - Acceptance test for "Sending money" feature should check receiver wallet's balance
 - Improved spending password validation rules

--- a/app/stores/NodeUpdateStore.js
+++ b/app/stores/NodeUpdateStore.js
@@ -29,7 +29,7 @@ export default class NodeUpdateStore extends Store {
   }
 
   @action refreshNextUpdate = () => {
-    if (this.stores.networkStatus.isConnected) {
+    if (this.stores.networkStatus.isSynced) {
       this.nextUpdateRequest.execute();
       if (this.nextUpdateRequest.result && !this.isUpdatePostponed && !this.isUpdateInstalled) {
         this.isUpdateAvailable = true;


### PR DESCRIPTION
We have disabled polling for wallet data while the node is syncing to reduce the load on the wallet node. This PR does the same for polling for the system update.