### PR TITLE
Feature/daef 279 add wallet settings acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changelog
 - Final version of Daedalus logo added on the loading screen
 - Final version of Daedalus logo added in the top-bar
 - Receive page design update
+- Acceptance test for wallet settings (Wallet password setting, Wallet setting invalid password, Wallet password update/change, Wallet password remove, Wallet rename, Wallet assurance level chage)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,10 @@ Changelog
 - Acceptance test for "Import wallet with/without spending password" feature
 - Acceptance test for "Send money from a wallet with spending password" feature
 - Acceptance test for "Generate wallet address" feature
+- Acceptance test for "Wallet settings management" features
 - Final version of Daedalus logo added on the loading screen
 - Final version of Daedalus logo added in the top-bar
 - Receive page design update
-- Acceptance test for wallet settings (Wallet password setting, Wallet setting invalid password, Wallet password update/change, Wallet password remove, Wallet rename, Wallet assurance level chage)
 
 ### Fixes
 

--- a/app/components/wallet/settings/ChangeWalletPasswordDialog.js
+++ b/app/components/wallet/settings/ChangeWalletPasswordDialog.js
@@ -186,6 +186,7 @@ export default class ChangeWalletPasswordDialog extends Component {
     const { removePassword } = this.state;
 
     const dialogClasses = classnames([
+      isWalletPasswordSet ? 'changePasswordDialog' : 'createPasswordDialog',
       styles.dialog,
       isSubmitting ? styles.isSubmitting : null
     ]);
@@ -195,12 +196,22 @@ export default class ChangeWalletPasswordDialog extends Component {
       removePassword ? styles.hidden : null
     ]);
 
+    const confirmButtonClasses = classnames([
+      'confirmButton',
+      removePassword ? styles.removeButton : null,
+    ]);
+
+    const newPasswordClasses = classnames([
+      'newPassword',
+      styles.newPassword,
+    ]);
+
     const actions = [
       {
         label: intl.formatMessage(globalMessages[removePassword ? 'remove' : 'save']),
         onClick: this.submit,
         primary: true,
-        className: removePassword ? styles.removeButton : null,
+        className: confirmButtonClasses,
       },
     ];
 
@@ -228,6 +239,7 @@ export default class ChangeWalletPasswordDialog extends Component {
 
             <Input
               type="password"
+              className="currentPassword"
               value={currentPasswordValue}
               onChange={(value) => this.handleDataChange('currentPasswordValue', value)}
               {...form.$('currentPassword').bind()}
@@ -238,7 +250,7 @@ export default class ChangeWalletPasswordDialog extends Component {
         <div className={walletPasswordFieldsClasses}>
           <Input
             type="password"
-            className={styles.newPassword}
+            className={newPasswordClasses}
             value={newPasswordValue}
             onChange={(value) => this.handleDataChange('newPasswordValue', value)}
             {...form.$('walletPassword').bind()}
@@ -246,6 +258,7 @@ export default class ChangeWalletPasswordDialog extends Component {
 
           <Input
             type="password"
+            className="repeatedPassword"
             value={repeatedPasswordValue}
             onChange={(value) => this.handleDataChange('repeatedPasswordValue', value)}
             {...form.$('repeatPassword').bind()}

--- a/app/components/widgets/forms/ReadOnlyInput.js
+++ b/app/components/widgets/forms/ReadOnlyInput.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
+import classnames from 'classnames';
 import { intlShape } from 'react-intl';
 import Input from 'react-toolbox/lib/input/Input';
 import globalMessages from '../../../i18n/global-messages';
@@ -29,8 +30,14 @@ export default class ReadOnlyInput extends Component {
     } = this.props;
     const { intl } = this.context;
     const buttonLabel = intl.formatMessage(globalMessages[isSet ? 'change' : 'create']);
+
+    const mainClasses = classnames([
+      styles.component,
+      isSet ? 'changeLabel' : 'createLabel',
+    ]);
+
     return (
-      <div className={styles.component}>
+      <div className={mainClasses}>
 
         <Input
           className={styles.input}

--- a/features/step_definitions/lib/wallets-helpers.js
+++ b/features/step_definitions/lib/wallets-helpers.js
@@ -22,3 +22,11 @@ export const fillOutWalletSendForm = async function(values) {
 export const getWalletByName = function(walletName) {
   return this.wallets.find((w) => w.name === walletName);
 };
+
+export const waitUntilWaletNamesEqual = function(walletName) {
+  const context = this;
+  return context.client.waitUntil(async function() {
+    const currentWalletName = await getNameOfActiveWalletInSidebar.call(context);
+    return currentWalletName === walletName;
+  });
+};

--- a/features/step_definitions/settings-steps.js
+++ b/features/step_definitions/settings-steps.js
@@ -16,7 +16,7 @@ export default function () {
     return this.client.click(selector);
   });
 
-  this.When(/^I set wallet password:$/, async function (table) {
+  this.When(/^I enter wallet password:$/, async function (table) {
     const fields = table.hashes()[0];
     await this.client.setValue('.createPasswordDialog .newPassword input', fields.password);
     await this.client.setValue('.createPasswordDialog .repeatedPassword input', fields.repeatedPassword);
@@ -55,11 +55,11 @@ export default function () {
     await this.client.setValue('.WalletSettings_component .InlineEditingInput_component input', fields.name);
   });
 
-  this.When(/^I click outside form input fields$/, function () {
+  this.When(/^I click outside "name" input field$/, function () {
     return this.client.click('.WalletSettings_component');
   });
 
-  this.When(/^I open Transaction assurance security level selection dropdown$/, function () {
+  this.When(/^I open "Transaction assurance security level" selection dropdown$/, function () {
     return this.waitAndClick('.WalletSettings_assuranceLevelSelect .SimpleInput_input');
   });
 
@@ -67,7 +67,7 @@ export default function () {
     return this.waitAndClick('//li[contains(text(), "Strict")]');
   });
 
-  this.Then(/^I should have wallet Strict assurance level$/, async function () {
+  this.Then(/^I should have wallet with "Strict" assurance level set$/, async function () {
     const activeWalletName = await getNameOfActiveWalletInSidebar.call(this);
     const wallets = await this.client.executeAsync(function(done) {
       daedalus.stores.wallets.walletsRequest.execute().then(done);

--- a/features/step_definitions/settings-steps.js
+++ b/features/step_definitions/settings-steps.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import {
+  waitUntilWaletNamesEqual,
+  getNameOfActiveWalletInSidebar
+} from './lib/wallets-helpers';
+
+export default function () {
+
+  this.Given(/^I should see the "([^"]*)" wallet password dialog$/, function (dialogType) {
+    const selector = '.' + dialogType + 'PasswordDialog';
+    return this.client.waitForVisible(selector);
+  });
+
+  this.When(/^I click on the "([^"]*)" password label$/, function (label) {
+    const selector = '.' + label + 'Label button';
+    return this.client.click(selector);
+  });
+
+  this.When(/^I set wallet password:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.createPasswordDialog .newPassword input', fields.password);
+    await this.client.setValue('.createPasswordDialog .repeatedPassword input', fields.repeatedPassword);
+  });
+
+  this.When(/^I click on the "([^"]*)" button in "([^"]*)" wallet password dialog$/, function (action, dialogType) {
+    return this.client.click('.confirmButton');
+  });
+
+  this.When(/^I change wallet password:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.changePasswordDialog .currentPassword input', fields.currentPassword);
+    await this.client.setValue('.changePasswordDialog .newPassword input', fields.password);
+    await this.client.setValue('.changePasswordDialog .repeatedPassword input', fields.repeatedPassword);
+  });
+
+  this.Then(/^I should not see the change password dialog anymore$/, function () {
+    return this.client.waitForVisible('.changePasswordDialog', null, true);
+  });
+
+  this.When(/^I toggle "Check to deactivate password" switch on the change wallet password dialog$/, function () {
+    return this.waitAndClick('.changePasswordDialog .switch_field');
+  });
+
+  this.When(/^I enter current wallet password:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.changePasswordDialog .currentPassword input', fields.currentPassword);
+  });
+
+  this.When(/^I click on "name" input field$/, function () {
+    return this.client.click('.WalletSettings_component .InlineEditingInput_component');
+  });
+
+  this.When(/^I enter new wallet name:$/, async function (table) {
+    const fields = table.hashes()[0];
+    await this.client.setValue('.WalletSettings_component .InlineEditingInput_component input', fields.name);
+  });
+
+  this.When(/^I click outside form input fields$/, function () {
+    return this.client.click('.WalletSettings_component');
+  });
+
+  this.When(/^I open Transaction assurance security level selection dropdown$/, function () {
+    return this.waitAndClick('.WalletSettings_assuranceLevelSelect .SimpleInput_input');
+  });
+
+  this.When(/^I select "Strict" assurance level$/, function () {
+    return this.waitAndClick('//li[contains(text(), "Strict")]');
+  });
+
+  this.Then(/^I should have wallet Strict assurance level$/, async function () {
+    const activeWalletName = await getNameOfActiveWalletInSidebar.call(this);
+    const wallets = await this.client.executeAsync(function(done) {
+      daedalus.stores.wallets.walletsRequest.execute().then(done);
+    });
+    const activeWallet = wallets.value.find((w) => w.name === activeWalletName);
+    expect(activeWallet.assurance).to.equal('CWAStrict');
+  });
+
+  this.Then(/^I should see new wallet name "([^"]*)"$/, async function (walletName) {
+    return waitUntilWaletNamesEqual.call(this, walletName);
+  });
+
+  this.Then(/^I should see "([^"]*)" label in password field$/, function (label) {
+    const selector = '.' + label + 'Label';
+    return this.client.waitForVisible(selector);
+  });
+
+  this.Then(/^I should see the following error messages:$/, async function (data) {
+    const error = data.hashes()[0];
+    const errorSelector = '.ChangeWalletPasswordDialog_newPassword .input_error';
+    await this.client.waitForText(errorSelector);
+    let errorsOnScreen = await this.client.getText(errorSelector);
+    const expectedError = await this.intl(error.message);
+    expect(errorsOnScreen).to.equal(expectedError);
+  });
+}

--- a/features/wallet-settings.feature
+++ b/features/wallet-settings.feature
@@ -8,21 +8,21 @@ Feature: Wallet Settings
     | first  |           |
     | second | Secret123 |
 
-  Scenario: Wallet password setting
+  Scenario: User sets Wallet password
     Given I am on the "first" wallet "settings" screen
     And I click on the "create" password label
     And I should see the "create" wallet password dialog
-    And I set wallet password:
-    | password | repeatedPassword |
-    | Secret123   | Secret123           |
+    And I enter wallet password:
+    | password  | repeatedPassword |
+    | Secret123 | Secret123        |
     And I click on the "save" button in "create" wallet password dialog
     Then I should see "change" label in password field
 
-  Scenario: Wallet setting invalid password
+  Scenario: User tries to set Wallet password with invalid password format
     Given I am on the "first" wallet "settings" screen
     And I click on the "create" password label
     And I should see the "create" wallet password dialog
-    And I set wallet password:
+    And I enter wallet password:
     | password | repeatedPassword |
     | secret   | secret           |
     And I click on the "save" button in "create" wallet password dialog
@@ -30,7 +30,7 @@ Feature: Wallet Settings
     | message                             |
     | global.errors.invalidWalletPassword |
 
-  Scenario: Wallet password update/change
+  Scenario: User changes Wallet password
     Given I am on the "second" wallet "settings" screen
     And I click on the "change" password label
     And I should see the "change" wallet password dialog
@@ -40,7 +40,7 @@ Feature: Wallet Settings
     And I click on the "save" button in "create" wallet password dialog
     Then I should not see the change password dialog anymore
 
-  Scenario: Wallet password remove
+  Scenario: User removes Wallet password
     Given I am on the "second" wallet "settings" screen
     And I click on the "change" password label
     And I should see the "change" wallet password dialog
@@ -51,18 +51,17 @@ Feature: Wallet Settings
     And I click on the "remove" button in "change" wallet password dialog
     Then I should see "create" label in password field
 
-  Scenario: Wallet rename
+  Scenario: User renames Wallet
     Given I am on the "first" wallet "settings" screen
     And I click on "name" input field
     And I enter new wallet name:
     | name         |
     | first Edited |
-    And I click outside form input fields
+    And I click outside "name" input field
     Then I should see new wallet name "first Edited"
 
-  Scenario: Wallet assurance level change
+  Scenario: User changes Wallet assurance level
     Given I am on the "first" wallet "settings" screen
-    And I open Transaction assurance security level selection dropdown
+    And I open "Transaction assurance security level" selection dropdown
     And I select "Strict" assurance level
-    And I click outside form input fields
-    Then I should have wallet Strict assurance level
+    Then I should have wallet with "Strict" assurance level set

--- a/features/wallet-settings.feature
+++ b/features/wallet-settings.feature
@@ -1,0 +1,75 @@
+Feature: Wallet Settings
+
+  Background:
+    Given I have selected English language
+    And I have accepted "Terms of use"
+    And I have the following wallets:
+    | name   | password  |
+    | first  |           |
+    | second | Secret123 |
+
+
+  @watch
+  Scenario: Wallet password setting
+    Given I am on the "first" wallet "settings" screen
+    And I click on the "create" password label
+    And I should see the "create" wallet password dialog
+    And I set wallet password:
+    | password | repeatedPassword |
+    | Secret123   | Secret123           |
+    And I click on the "save" button in "create" wallet password dialog
+    Then I should see "change" label in password field
+
+  @watch
+  Scenario: Wallet setting Invalid password
+    Given I am on the "first" wallet "settings" screen
+    And I click on the "create" password label
+    And I should see the "create" wallet password dialog
+    And I set wallet password:
+    | password | repeatedPassword |
+    | secret   | secret           |
+    And I click on the "save" button in "create" wallet password dialog
+    Then I should see the following error messages:
+    | message                             |
+    | global.errors.invalidWalletPassword |
+
+  @watch
+  Scenario: Wallet password update/change
+    Given I am on the "second" wallet "settings" screen
+    And I click on the "change" password label
+    And I should see the "change" wallet password dialog
+    And I change wallet password:
+    | currentPassword | password     | repeatedPassword |
+    | Secret123       | newSecret123 | newSecret123     |
+    And I click on the "save" button in "create" wallet password dialog
+    Then I should not see the change password dialog anymore
+
+  @watch
+  Scenario: Wallet password remove
+    Given I am on the "second" wallet "settings" screen
+    And I click on the "change" password label
+    And I should see the "change" wallet password dialog
+    And I toggle "Check to deactivate password" switch on the change wallet password dialog
+    And I enter current wallet password:
+    | currentPassword |
+    | Secret123       |
+    And I click on the "remove" button in "change" wallet password dialog
+    Then I should see "create" label in password field
+
+  @watch
+  Scenario: Wallet rename
+    Given I am on the "first" wallet "settings" screen
+    And I click on "name" input field
+    And I enter new wallet name:
+    | name         |
+    | first Edited |
+    And I click outside form input fields
+    Then I should see new wallet name "first Edited"
+
+  @watch
+  Scenario: Wallet assurance level change
+    Given I am on the "first" wallet "settings" screen
+    And I open Transaction assurance security level selection dropdown
+    And I select "Strict" assurance level
+    And I click outside form input fields
+    Then I should have wallet Strict assurance level

--- a/features/wallet-settings.feature
+++ b/features/wallet-settings.feature
@@ -8,8 +8,6 @@ Feature: Wallet Settings
     | first  |           |
     | second | Secret123 |
 
-
-  @watch
   Scenario: Wallet password setting
     Given I am on the "first" wallet "settings" screen
     And I click on the "create" password label
@@ -20,8 +18,7 @@ Feature: Wallet Settings
     And I click on the "save" button in "create" wallet password dialog
     Then I should see "change" label in password field
 
-  @watch
-  Scenario: Wallet setting Invalid password
+  Scenario: Wallet setting invalid password
     Given I am on the "first" wallet "settings" screen
     And I click on the "create" password label
     And I should see the "create" wallet password dialog
@@ -33,7 +30,6 @@ Feature: Wallet Settings
     | message                             |
     | global.errors.invalidWalletPassword |
 
-  @watch
   Scenario: Wallet password update/change
     Given I am on the "second" wallet "settings" screen
     And I click on the "change" password label
@@ -44,7 +40,6 @@ Feature: Wallet Settings
     And I click on the "save" button in "create" wallet password dialog
     Then I should not see the change password dialog anymore
 
-  @watch
   Scenario: Wallet password remove
     Given I am on the "second" wallet "settings" screen
     And I click on the "change" password label
@@ -56,7 +51,6 @@ Feature: Wallet Settings
     And I click on the "remove" button in "change" wallet password dialog
     Then I should see "create" label in password field
 
-  @watch
   Scenario: Wallet rename
     Given I am on the "first" wallet "settings" screen
     And I click on "name" input field
@@ -66,7 +60,6 @@ Feature: Wallet Settings
     And I click outside form input fields
     Then I should see new wallet name "first Edited"
 
-  @watch
   Scenario: Wallet assurance level change
     Given I am on the "first" wallet "settings" screen
     And I open Transaction assurance security level selection dropdown


### PR DESCRIPTION
This PR introduces wallet settings acceptance tests which cover: 
- Wallet password setting
- Wallet setting invalid password
- Wallet password update/change
- Wallet password remove
- Wallet rename
- Wallet assurance level chage

<img width="710" alt="wallet-settings acceptance 1 2" src="https://user-images.githubusercontent.com/18653950/27689331-248c24ca-5cde-11e7-812c-497d778b43c1.png">
<img width="558" alt="wallet-settings acceptance 2 2" src="https://user-images.githubusercontent.com/18653950/27689330-248a9722-5cde-11e7-85e6-a5da4090d1b2.png">

