### PR TITLE
[CSL-1303] Include `updater-windows-runner` into Daedalus launcher for Windows 

### DIFF
--- a/installers/Launcher.hs
+++ b/installers/Launcher.hs
@@ -6,15 +6,17 @@ import           System.FilePath (pathSeparator)
 
 -- OS dependent configuration
 data Launcher = Launcher
-    { nodePath      :: String
-    , nodeLogPath   :: String
-    , walletPath    :: String
-    , installerPath :: String
-    , runtimePath   :: String
+    { nodePath             :: String
+    , nodeLogPath          :: String
+    , walletPath           :: String
+    , installerPath        :: String
+    , windowsInstallerPath :: Maybe String
+    , runtimePath          :: String
     }
 
 launcherArgs :: Launcher -> String
 launcherArgs launcher = unwords $
+    maybe [] (("--windows-updater-runner":) . (:[])) (windowsInstallerPath launcher) ++
   [ "--node", quote (nodePath launcher)
   , "--node-log-path", quote (nodeLogPath launcher)
   , "--wallet", quote (walletPath launcher)

--- a/installers/Launcher.hs
+++ b/installers/Launcher.hs
@@ -16,7 +16,7 @@ data Launcher = Launcher
 
 launcherArgs :: Launcher -> String
 launcherArgs launcher = unwords $
-    maybe [] (("--windows-updater-runner":) . (:[])) (windowsInstallerPath launcher) ++
+    maybe [] (("--updater-windows-runner":) . (:[]) . quote) (windowsInstallerPath launcher) ++
   [ "--node", quote (nodePath launcher)
   , "--node-log-path", quote (nodeLogPath launcher)
   , "--wallet", quote (walletPath launcher)

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -1,19 +1,19 @@
 module MacInstaller where
 
 import           Control.Monad        (unless)
-import qualified Data.Text            as T
 import           Data.Foldable        (for_)
 import           Data.Maybe           (fromMaybe)
 import           Data.Monoid          ((<>))
+import qualified Data.Text            as T
+import           System.Directory
 import           System.Environment   (lookupEnv)
 import           System.FilePath      (replaceExtension)
-import           System.FilePath.Glob (globDir1, compile)
-import           System.Directory
-import           Turtle               (procs, echo, shells, shell, ExitCode(..))
+import           System.FilePath.Glob (compile, globDir1)
+import           Turtle               (ExitCode (..), echo, procs, shell, shells)
 import           Turtle.Line          (unsafeTextToLine)
 
-import RewriteLibs                    (chain)
-import Launcher
+import           Launcher
+import           RewriteLibs          (chain)
 
 
 main :: IO ()
@@ -97,6 +97,7 @@ doLauncher = "./cardano-launcher " <> (launcherArgs $ Launcher
   , walletPath = "./Frontend"
   , nodeLogPath = appdata <> "Logs/cardano-node.log"
   , installerPath = appdata <> "installer.pkg"
+  , windowsInstallerPath = Nothing
   , runtimePath = appdata
   })
     where

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -8,8 +8,8 @@ import           Data.Text          (pack, split, unpack)
 import           Development.NSIS
 import           System.Directory   (doesFileExist)
 import           System.Environment (lookupEnv)
-import           Turtle             (echo, proc, procs, ExitCode(..))
-import           Turtle.Line          (unsafeTextToLine)
+import           Turtle             (ExitCode (..), echo, proc, procs)
+import           Turtle.Line        (unsafeTextToLine)
 
 import           Launcher
 
@@ -25,6 +25,7 @@ launcherScript =
       , nodeLogPath = "%APPDATA%\\Daedalus\\Logs\\cardano-node.log"
       , walletPath = "%DAEDALUS_DIR%\\Daedalus.exe"
       , installerPath = "%APPDATA%\\Daedalus\\Installer.exe"
+      , windowsInstallerPath = Just "%APPDATA%\\Daedalus\\Installer.bat"
       , runtimePath = "%APPDATA%\\Daedalus\\"
       }
 


### PR DESCRIPTION
Appveyor build tested on Win64, Travis Mac build verified (by looking at the launcher script) but not tested.