### PR TITLE
Fix/daef 348 Remove create-account API call from wallet restore handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Changelog
 - Acceptance test for "Sending money" feature should check receiver wallet's balance
 - Improved spending password validation rules
 - Improved acceptance tests for generating new addresses
+- Removed temporary workaround for creating new accounts during wallet create and wallet restore
 
 ### Chores
 

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -182,15 +182,10 @@ export default class CardanoClientApi {
     const assurance = 'CWANormal';
     const unit = 0;
     try {
-      // 1. create wallet
       const wallet: ApiWallet = await ClientApi.newWallet(
         name, assurance, unit, mnemonic, password
       );
-      Log.debug('CardanoClientApi::createWallet success: ', stringifyData(wallet));
-
-      // 2. create account
-      await ClientApi.newAccount(wallet.cwId, name, password);
-
+      Log.debug('CardanoClientApi::createWallet success');
       return _createWalletFromServerData(wallet);
     } catch (error) {
       Log.error('CardanoClientApi::createWallet error: ' + stringifyError(error));
@@ -288,15 +283,10 @@ export default class CardanoClientApi {
     const assurance = 'CWANormal';
     const unit = 0;
     try {
-      // 1. restore wallet
       const wallet: ApiWallet = await ClientApi.restoreWallet(
         walletName, assurance, unit, recoveryPhrase, walletPassword
       );
       Log.debug('CardanoClientApi::restoreWallet success');
-
-      // 2. create account
-      await ClientApi.newAccount(wallet.cwId, walletName, walletPassword);
-
       return _createWalletFromServerData(wallet);
     } catch (error) {
       Log.error('CardanoClientApi::restoreWallet error: ' + stringifyError(error));


### PR DESCRIPTION
This PR removes temporary workaround for creating accounts during wallet create or wallet restore features.