### PR TITLE
Fix/daef 351 Fix React key bug in transaction list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Changelog
 - Acceptance test for "Sending money" feature should check receiver wallet's balance
 - Improved spending password validation rules
 - Improved acceptance tests for generating new addresses
+- Prevent React key duplicates in transaction from/to addresses lists
 
 ### Chores
 

--- a/app/components/widgets/Transaction.js
+++ b/app/components/widgets/Transaction.js
@@ -171,12 +171,12 @@ export default class Transaction extends Component {
             )}
             <div>
               <h2>{intl.formatMessage(messages.fromAddresses)}</h2>
-              {data.addresses.from.map((address) => (
-                <span key={address} className={styles.address}>{address}</span>
+              {data.addresses.from.map((address, addressIndex) => (
+                <span key={`${data.id}-from-${address}-${addressIndex}`} className={styles.address}>{address}</span>
               ))}
               <h2>{intl.formatMessage(messages.toAddresses)}</h2>
-              {data.addresses.to.map((address) => (
-                <span key={address} className={styles.address}>{address}</span>
+              {data.addresses.to.map((address, addressIndex) => (
+                <span key={`${data.id}-to-${address}-${addressIndex}`} className={styles.address}>{address}</span>
               ))}
               <h2>{intl.formatMessage(messages.assuranceLevel)}</h2>
               <span>


### PR DESCRIPTION
This PR prevents React key duplicates in transaction from/to addresses lists.