### PR TITLE
[DAEF-350] Accepting terms of use in English for Japanese locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Changelog
 - Use markdown for "Terms of use" content
 - Added manually written Flow types for API responses
 - Testnet version on the testnet label bumped from 0.3 to 0.5
+- Temporary workaround for missing Japanese translations for Terms of Use that allows users to accept them in English
 
 
 ## 0.6.2

--- a/app/i18n/locales/ja-JP.json
+++ b/app/i18n/locales/ja-JP.json
@@ -58,7 +58,7 @@
   "paper.wallet.export.dialog.printerCheck.headline": "印刷を確認",
   "profile.languageSelect.form.languageSelectLabel": "使用する言語を選択してください",
   "profile.languageSelect.form.submitLabel": "次",
-  "profile.termsOfUse.checkboxLabel": "利用規約に同意する",
+  "profile.termsOfUse.checkboxLabel": "利用規約が英語でのみ利用可能であることを理解し、利用規約に同意します。",
   "profile.termsOfUse.submitLabel": "次",
   "settings.general.languageSelect.label": "言語",
   "settings.menu.general.link.label": "一般",

--- a/app/i18n/locales/terms-of-use/ja-JP.md
+++ b/app/i18n/locales/terms-of-use/ja-JP.md
@@ -1,4 +1,4 @@
-# !!!Terms of Service Agreement
+# Terms of Service Agreement
 
 THIS TERMS OF SERVICE AGREEMENT (&quot;Agreement&quot;) is made between Input Output HK Limited (&quot;Company&quot;) and any person (&quot;User&quot;) who completes the process to download, utilize, or operate any software, data processing service, application, communication service, or other content created or offered by Company, including, but not limited to, the Daedalus Cryptocurrency Wallet application (&quot;Software&quot;). Company and User are collectively referred to as the &quot;parties.&quot;
 


### PR DESCRIPTION
This PR updates label for accepting terms of use for Japanese locale to: "I understand that Terms of User are available in English only and I agree with Terms of Use.", translated into Japanese. This will be removed tomorrow but in case Japanese translations are not delivered this will serve as a workaround.

![screen shot 2017-07-05 at 16 29 52](https://user-images.githubusercontent.com/4280521/27869267-abb051b8-619f-11e7-981c-4a88ff9b7cc1.png)
