### PR TITLE
Fix/daef 354 Show more specific error messages on Change password dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Changelog
 - Improved acceptance tests for generating new addresses
 - Removed temporary workaround for creating new accounts during wallet create and wallet restore
 - Prevent React key duplicates in transaction from/to addresses lists
+- Show more specific error messages on "Change password" dialog
 
 ### Chores
 

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -531,6 +531,9 @@ export default class CardanoClientApi {
       return true;
     } catch (error) {
       Log.error('CardanoClientApi::updateWalletPassword error: ' + stringifyError(error));
+      if (error.message.includes('Invalid old passphrase given')) {
+        throw new IncorrectWalletPasswordError();
+      }
       throw new GenericApiError();
     }
   }


### PR DESCRIPTION
This PR introduces a fix which presents more specific error message on Change password dialog.
![change password dialog - more specific error message](https://user-images.githubusercontent.com/18653950/27901334-f688c4b2-6231-11e7-9413-b74ac72b52a3.png)
