### PR TITLE
Fix/daef 357 Prevent selected wallet reset on "Ada redemption" screen on tab or certificate change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Changelog
 - Prevent React key duplicates in transaction from/to addresses lists
 - Show more specific error messages on "Change password" dialog
 - Update password fields placeholders to match latest designs
+- Prevent selected wallet reset on "Ada redemption" screen on tab or certificate change
 
 ### Chores
 

--- a/app/components/wallet/ada-redemption/AdaRedemptionForm.js
+++ b/app/components/wallet/ada-redemption/AdaRedemptionForm.js
@@ -336,7 +336,19 @@ export default class AdaRedemptionForm extends Component {
     // We need to disable on-change validation before reseting the form in order to
     // avoid debounced validation being called straight after the form is reset
     form.state.options.set({ validateOnChange: false });
-    form.reset();
+
+    // We can not user form.reset() call here as it would reset selected walletId
+    // which is a bad UX since we are calling resetForm on certificate add/remove
+    form.$('walletPassword').reset();
+    form.$('adaAmount').reset();
+    form.$('adaPasscode').reset();
+    form.$('certificate').reset();
+    form.$('email').reset();
+    form.$('passPhrase').reset();
+    form.$('redemptionKey').reset();
+    form.$('shieldedRedemptionKey').reset();
+    form.$('walletPassword').reset();
+
     form.showErrors(false);
     form.state.options.set({ validateOnChange: true });
   };


### PR DESCRIPTION
This PR introduces a fix which prevents selected wallet reset on Ada redemption screen on tab change and certificate add/remove events.