### PR TITLE
Fix/daef 362 Update used addresses styling on wallet receive screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Changelog
 - Show more specific error messages on "Change password" dialog
 - Update password fields placeholders to match latest designs
 - Prevent selected wallet reset on "Ada redemption" screen on tab or certificate change
+- Use correct styling for used addresses marking on wallet receive screen
 
 ### Chores
 

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -207,9 +207,15 @@
     }
   }
 
-  .usedWalletAddress .addressId {
-    color: #aeaeb3;
-    text-decoration: line-through;
+  .usedWalletAddress {
+    .addressId,
+    .addressActions .copyAddress img {
+      opacity: 0.4;
+    }
+
+    .addressActions .copyAddress span {
+      opacity: 0.2;
+    }
   }
 }
 


### PR DESCRIPTION
This PR introduces updated "used" address styling on Wallet's receive screen.

![result](https://user-images.githubusercontent.com/376611/28016626-84fae522-6575-11e7-8787-2518cec5618b.png)
