### PR TITLE
[DAEF-202] properly shutdown app when closing window on osx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Changelog
 - Fixed sending amount maximum value validation
 - Use correct styling for used addresses marking on wallet receive screen
 - Implement MomentJs internationalization
+- Also quit whole app when last window is closed on osx
 
 ### Chores
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -62,9 +62,7 @@ if (isDev) {
   require('electron-debug')(); // eslint-disable-line global-require
 }
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit();
-});
+app.on('window-all-closed', () => app.quit());
 
 const installExtensions = async () => {
   if (isDev) {


### PR DESCRIPTION
This PR fixes the behavior on osx to close the whole Daedalus app when the last window is closed.