### PR TITLE
Fix/daef 374 Numeric input component caret position bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Changelog
 - Use correct styling for used addresses marking on wallet receive screen
 - Implement MomentJs internationalization
 - Also quit whole app when last window is closed on osx
-- Fixed Numeric component caret position bug on wallet send screen
+- Fixed Numeric component caret position bug on wallet send screen ([PR 394](https://github.com/input-output-hk/daedalus/pull/394))
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Changelog
 - Use correct styling for used addresses marking on wallet receive screen
 - Implement MomentJs internationalization
 - Also quit whole app when last window is closed on osx
+- Fixed Numeric component caret position bug on wallet send screen
 
 ### Chores
 

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "react-intl": "2.2.3",
     "react-markdown": "2.5.0",
     "react-number-format": "1.1.2",
-    "react-polymorph": "0.3.0",
+    "react-polymorph": "0.3.1",
     "react-router": "3.0.3",
     "recharts": "0.19.1",
     "route-parser": "0.0.5",


### PR DESCRIPTION
This PR updates react-polymorph plugin to latest release which contains Numeric input component fix for caret positioning bug.