### PR TITLE
Chore/daef 382 Write documentation for running Daedalus frontend acceptance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Changelog
 - Testnet version on the testnet label bumped from 0.3 to 0.5
 - Replaced all React-Toolbox components with React-Polymorph ones ([PR 361](https://github.com/input-output-hk/daedalus/pull/361))
 - Temporary workaround for missing Japanese translations for Terms of Use that allows users to accept them in English
+- Added readme file for running acceptance tests
 
 ## 0.6.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ Changelog
 - Testnet version on the testnet label bumped from 0.3 to 0.5
 - Replaced all React-Toolbox components with React-Polymorph ones ([PR 361](https://github.com/input-output-hk/daedalus/pull/361))
 - Temporary workaround for missing Japanese translations for Terms of Use that allows users to accept them in English
-- Added readme file for running acceptance tests
+- Added readme file for running acceptance tests ([PR 395](https://github.com/input-output-hk/daedalus/pull/395))
 
 ## 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Invocation:
    ```
    ..where `BRANCH` defaults to the current release branch, and `GITHUB-USER`
    defaults to `input-output-hk`.
-   
+
    The remaining `OPTIONS` are passed as-is to the respective build scripts.
 
 ## Stepwise build
@@ -93,6 +93,8 @@ $ npm run test
 ```bash
 $ npm run test-watch
 ```
+
+You can find more details regarding tests setup within [Running Deadalus acceptance tests](https://github.com/input-output-hk/daedalus/features/README.md) README file.
 
 ### CSS Modules
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ $ npm run test
 $ npm run test-watch
 ```
 
-You can find more details regarding tests setup within [Running Deadalus acceptance tests](https://github.com/input-output-hk/daedalus/features/README.md) README file.
+You can find more details regarding tests setup within [Running Deadalus acceptance tests](https://github.com/input-output-hk/daedalus/blob/master/features/README.md) README file.
 
 ### CSS Modules
 

--- a/features/README.md
+++ b/features/README.md
@@ -1,0 +1,35 @@
+# Running Deadalus acceptance tests
+
+
+1. Make sure you have correct node/npm versions installed on your machine (node v6.x and npm v3.x)
+2. Clone Deadalus repo to your machine (git@github.com:input-output-hk/daedalus.git - use **master** branch)
+3. Install npm dependencies from within Daedalus directory:
+```
+$ cd daedalus/
+$ npm install
+```
+4. Link your backend build with the Daedalus frontend (assumed that you have build the backend previously):
+```
+$ cd daedalus/node_modules/
+$ npm link daedalus-client-api
+```
+5. Launch the backend (cardano-sl) in production/staging mode:
+```
+$ cd cardano-sl/
+$ ./scripts/launch/staging.sh
+```
+6. Run Deadalus frontend in hot-server mode:
+```
+$ cd daedalus/
+$ npm run hot-server
+```
+7. Run Daedalus frontend tests in a separate Terminal window (leaving hot-server to run in the other):
+```
+$ cd daedalus/
+$ npm run test
+```
+
+There is a total of 46 different acceptance tests.
+Whole test suite takes around 5 minutes to finish.
+Once tests are complete you will get a summary of passed/failed tests in the Terminal window.
+Daedalus UI window will remain open - you are expected to close it manually before running tests again.


### PR DESCRIPTION
This PR introduced Daedalus frontend acceptance tests README file where it is documented how to run acceptance tests.