### PR TITLE
Feature/daef 385 Implement CMD+H hotkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changelog
 - UI for displaying transaction fees on wallet send screen
 - Correct placeholder text for Ada redemption "Ada amount" input
 - Opt-in mode for sending logs to the remote server
+- Added support for Cmd+H hotkey shortcut for hiding application window on OSX ([PR 404](https://github.com/input-output-hk/daedalus/pull/404))
 
 ### Fixes
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, shell, ipcMain, dialog, crashReporter } from 'electron';
+import { app, BrowserWindow, Menu, shell, ipcMain, dialog, crashReporter, globalShortcut } from 'electron';
 import os from 'os';
 import path from 'path';
 import Log from 'electron-log';
@@ -150,4 +150,20 @@ app.on('ready', async () => {
     menu = Menu.buildFromTemplate(winLinuxMenu(mainWindow));
     mainWindow.setMenu(menu);
   }
+
+  // Hide application window on Cmd+H hotkey (OSX only!)
+  if (process.platform === 'darwin') {
+    app.on('activate', () => {
+      if (!mainWindow.isVisible()) app.show();
+    });
+
+    mainWindow.on('focus', () => {
+      globalShortcut.register('CommandOrControl+H', app.hide);
+    });
+
+    mainWindow.on('blur', () => {
+      globalShortcut.unregister('CommandOrControl+H');
+    });
+  }
+
 });


### PR DESCRIPTION
This PR introduces support for Cmd+H hotkey on OSX which hides the application window.