### PR TITLE
[DEVOPS-223] AppVeyor: stack 1.5.0 upgrade

### DIFF
--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -53,7 +53,7 @@ pushd installers
     @if %errorlevel% neq 0 (@echo powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
 	popd & exit /b 1)
     del /f stack.exe
-    7z x stack.zip stack.exe
+    7z x stack.zip stack.exe\stack.exe
     @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe
 	exit /b 1)
     del stack.zip

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -54,8 +54,11 @@ pushd installers
 	popd & exit /b 1)
     del /f stack.exe
     7z x stack.zip stack.exe\stack.exe
-    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe
+    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe\stack.exe
 	exit /b 1)
+    move stack.exe tmp
+    move tmp\stack.exe .
+    rmdir tmp
     del stack.zip
 
     @echo Copying DLLs


### PR DESCRIPTION
In stack v1.4.0 the stack executable was in the root of the downloaded
zip, but now in stack v1.5.0 it's under the stack.exe directory. The
link we're using now resolves to stack v1.5.0.