### PR TITLE
[DEVOPS-223] AppVeyor: revert stack.exe fix

### DIFF
--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -53,12 +53,9 @@ pushd installers
     @if %errorlevel% neq 0 (@echo powershell -Command "try { $wc = New-Object net.webclient; $wc.Downloadfile('http://www.stackage.org/stack/windows-x86_64', 'stack.zip'); } catch { exit 1; }"
 	popd & exit /b 1)
     del /f stack.exe
-    7z x stack.zip stack.exe\stack.exe
-    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe\stack.exe
+    7z x stack.zip stack.exe
+    @if %errorlevel% neq 0 (@echo FAILED: 7z x stack.zip stack.exe
 	exit /b 1)
-    move stack.exe tmp
-    move tmp\stack.exe .
-    rmdir tmp
     del stack.zip
 
     @echo Copying DLLs


### PR DESCRIPTION
When stack-1.5.0 was initially released the zip file for the Windows
build put stack.exe in a different place. They've since reverted that
change, so this reverts the now outdated fix as well.