### PR TITLE
Fix/daef 360 Japanese translation bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Changelog
 - Fixed brittle acceptance test steps (wallet latest transaction amount check) ([PR 393](https://github.com/input-output-hk/daedalus/pull/393))
 - Fixed Numeric component caret position bug on wallet send screen ([PR 394](https://github.com/input-output-hk/daedalus/pull/394))
 - Fixed eslint syntax warnings ([PR 403](https://github.com/input-output-hk/daedalus/pull/403))
+- Fixed wallet spending password fields error messages positioning on wallet create/restore/import dialogs ([PR 407](https://github.com/input-output-hk/daedalus/pull/407))
 
 ### Chores
 

--- a/app/components/wallet/PaperWalletImportDialog.scss
+++ b/app/components/wallet/PaperWalletImportDialog.scss
@@ -42,6 +42,26 @@
       width: 275px;
     }
 
+    :global {
+      .SimpleFormField_root {
+        &.SimpleInput_errored {
+          margin-bottom: 21px;
+
+          .SimpleFormField_error {
+            left: 0;
+            margin: 4px 0 0 0;
+            overflow: hidden;
+            position: absolute;
+            right: 0;
+            text-align: right;
+            text-overflow: ellipsis;
+            top: 100%;
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
     .passwordInstructions {
       color: $text-color-accent;
       font-family: $font-light;

--- a/app/components/wallet/PaperWalletImportDialog.scss
+++ b/app/components/wallet/PaperWalletImportDialog.scss
@@ -1,5 +1,6 @@
 @import '../../themes/mixins/loading-spinner';
 @import '../../themes/mixins/error-message';
+@import '../../themes/mixins/place-form-field-error-below-input';
 
 .mnemonicPhrase {
   margin: 20px 0;
@@ -42,25 +43,7 @@
       width: 275px;
     }
 
-    :global {
-      .SimpleFormField_root {
-        &.SimpleInput_errored {
-          margin-bottom: 21px;
-
-          .SimpleFormField_error {
-            left: 0;
-            margin: 4px 0 0 0;
-            overflow: hidden;
-            position: absolute;
-            right: 0;
-            text-align: right;
-            text-overflow: ellipsis;
-            top: 100%;
-            white-space: nowrap;
-          }
-        }
-      }
-    }
+    @include place-form-field-error-below-input;
 
     .passwordInstructions {
       color: $text-color-accent;

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -1,4 +1,5 @@
 @import '../../themes/mixins/loading-spinner';
+@import '../../themes/mixins/place-form-field-error-below-input';
 
 .walletPassword {
   margin-bottom: -32px;
@@ -37,25 +38,7 @@
       width: 275px;
     }
 
-    :global {
-      .SimpleFormField_root {
-        &.SimpleInput_errored {
-          margin-bottom: 21px;
-
-          .SimpleFormField_error {
-            left: 0;
-            margin: 4px 0 0 0;
-            overflow: hidden;
-            position: absolute;
-            right: 0;
-            text-align: right;
-            text-overflow: ellipsis;
-            top: 100%;
-            white-space: nowrap;
-          }
-        }
-      }
-    }
+    @include place-form-field-error-below-input;
 
     .passwordInstructions {
       color: $text-color-accent;

--- a/app/components/wallet/WalletCreateDialog.scss
+++ b/app/components/wallet/WalletCreateDialog.scss
@@ -37,6 +37,26 @@
       width: 275px;
     }
 
+    :global {
+      .SimpleFormField_root {
+        &.SimpleInput_errored {
+          margin-bottom: 21px;
+
+          .SimpleFormField_error {
+            left: 0;
+            margin: 4px 0 0 0;
+            overflow: hidden;
+            position: absolute;
+            right: 0;
+            text-align: right;
+            text-overflow: ellipsis;
+            top: 100%;
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
     .passwordInstructions {
       color: $text-color-accent;
       font-family: $font-light;

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -42,6 +42,26 @@
       width: 275px;
     }
 
+    :global {
+      .SimpleFormField_root {
+        &.SimpleInput_errored {
+          margin-bottom: 21px;
+
+          .SimpleFormField_error {
+            left: 0;
+            margin: 4px 0 0 0;
+            overflow: hidden;
+            position: absolute;
+            right: 0;
+            text-align: right;
+            text-overflow: ellipsis;
+            top: 100%;
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
     .passwordInstructions {
       color: $text-color-accent;
       font-family: $font-light;

--- a/app/components/wallet/WalletRestoreDialog.scss
+++ b/app/components/wallet/WalletRestoreDialog.scss
@@ -1,5 +1,6 @@
 @import '../../themes/mixins/loading-spinner';
 @import '../../themes/mixins/error-message';
+@import '../../themes/mixins/place-form-field-error-below-input';
 
 .walletName {
   margin-bottom: 20px;
@@ -42,25 +43,7 @@
       width: 275px;
     }
 
-    :global {
-      .SimpleFormField_root {
-        &.SimpleInput_errored {
-          margin-bottom: 21px;
-
-          .SimpleFormField_error {
-            left: 0;
-            margin: 4px 0 0 0;
-            overflow: hidden;
-            position: absolute;
-            right: 0;
-            text-align: right;
-            text-overflow: ellipsis;
-            top: 100%;
-            white-space: nowrap;
-          }
-        }
-      }
-    }
+    @include place-form-field-error-below-input;
 
     .passwordInstructions {
       color: $text-color-accent;

--- a/app/components/wallet/key-import/WalletKeyImportDialog.scss
+++ b/app/components/wallet/key-import/WalletKeyImportDialog.scss
@@ -1,5 +1,6 @@
 @import '../../../themes/mixins/loading-spinner';
 @import '../../../themes/mixins/error-message';
+@import '../../../themes/mixins/place-form-field-error-below-input';
 
 .component {
   :global .dialog_body {
@@ -44,25 +45,7 @@
       width: 275px;
     }
 
-    :global {
-      .SimpleFormField_root {
-        &.SimpleInput_errored {
-          margin-bottom: 21px;
-
-          .SimpleFormField_error {
-            left: 0;
-            margin: 4px 0 0 0;
-            overflow: hidden;
-            position: absolute;
-            right: 0;
-            text-align: right;
-            text-overflow: ellipsis;
-            top: 100%;
-            white-space: nowrap;
-          }
-        }
-      }
-    }
+    @include place-form-field-error-below-input;
 
     .passwordInstructions {
       color: $text-color-accent;

--- a/app/components/wallet/key-import/WalletKeyImportDialog.scss
+++ b/app/components/wallet/key-import/WalletKeyImportDialog.scss
@@ -44,6 +44,26 @@
       width: 275px;
     }
 
+    :global {
+      .SimpleFormField_root {
+        &.SimpleInput_errored {
+          margin-bottom: 21px;
+
+          .SimpleFormField_error {
+            left: 0;
+            margin: 4px 0 0 0;
+            overflow: hidden;
+            position: absolute;
+            right: 0;
+            text-align: right;
+            text-overflow: ellipsis;
+            top: 100%;
+            white-space: nowrap;
+          }
+        }
+      }
+    }
+
     .passwordInstructions {
       color: $text-color-accent;
       font-family: $font-light;

--- a/app/components/widgets/forms/FileUploadWidget.scss
+++ b/app/components/widgets/forms/FileUploadWidget.scss
@@ -25,7 +25,8 @@
   margin-bottom: 10px;
 }
 
-.fileName {
+.fileName,
+.placeholder {
   overflow: hidden;
   padding-right: 50px;
   text-overflow: ellipsis;

--- a/app/themes/mixins/place-form-field-error-below-input.scss
+++ b/app/themes/mixins/place-form-field-error-below-input.scss
@@ -1,0 +1,21 @@
+@mixin place-form-field-error-below-input {
+  :global {
+    .SimpleFormField_root {
+      &.SimpleInput_errored {
+        margin-bottom: 21px;
+
+        .SimpleFormField_error {
+          left: 0;
+          margin: 4px 0 0 0;
+          overflow: hidden;
+          position: absolute;
+          right: 0;
+          text-align: right;
+          text-overflow: ellipsis;
+          top: 100%;
+          white-space: nowrap;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a fix for spending-password field error positioning in order to avoid label/error-message text overlapping in Japanese translations. The issue was solved by moving error messages below the input fields:

![screen shot 2017-07-26 at 09 37 43](https://user-images.githubusercontent.com/376611/28609895-b5f60e36-71e6-11e7-95b7-0c67fd0f5d0c.png)
![screen shot 2017-07-26 at 09 37 33](https://user-images.githubusercontent.com/376611/28609897-b611f4c0-71e6-11e7-91c2-afe4088d9e3c.png)
![screen shot 2017-07-26 at 09 37 20](https://user-images.githubusercontent.com/376611/28609898-b61566aa-71e6-11e7-91ec-e2b9ea9168f6.png)
