### PR TITLE
Fix/daef 333 Settings page wallet name success message is shown on transaction assurance update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Changelog
 - Fixed Numeric component caret position bug on wallet send screen ([PR 394](https://github.com/input-output-hk/daedalus/pull/394))
 - Fixed all design implementation issues ([PR 397](https://github.com/input-output-hk/daedalus/pull/397))
 - Fixed eslint syntax warnings ([PR 403](https://github.com/input-output-hk/daedalus/pull/403))
+- Fixed inline-editing success-messages on wallet settings screen ([PR 408](https://github.com/input-output-hk/daedalus/pull/408))
 
 ### Chores
 

--- a/app/actions/wallet-settings-actions.js
+++ b/app/actions/wallet-settings-actions.js
@@ -1,12 +1,10 @@
 // @flow
 import Action from './lib/Action';
-import type { AssuranceMode } from '../types/transactionAssuranceTypes';
 
 export default class WalletSettingsActions {
   cancelEditingWalletField: Action<any> = new Action();
   startEditingWalletField: Action<{ field: string }> = new Action();
   stopEditingWalletField: Action<any> = new Action();
-  updateWalletAssuranceLevel: Action<{ assurance: AssuranceMode }> = new Action();
   updateWalletField: Action<{ field: string, value: string }> = new Action();
   // eslint-disable-next-line max-len
   updateWalletPassword: Action<{ walletId: string, oldPassword: ?string, newPassword: ?string }> = new Action();

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -3,11 +3,10 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import moment from 'moment';
-import Select from 'react-polymorph/lib/components/Select';
-import SelectSkin from 'react-polymorph/lib/skins/simple/SelectSkin';
 import LocalizableError from '../../i18n/LocalizableError';
 import BorderedBox from '../widgets/BorderedBox';
 import InlineEditingInput from '../widgets/forms/InlineEditingInput';
+import InlineEditingDropdown from '../widgets/forms/InlineEditingDropdown';
 import ReadOnlyInput from '../widgets/forms/ReadOnlyInput';
 import DeleteWalletButton from './settings/DeleteWalletButton';
 import DeleteWalletConfirmationDialog from './settings/DeleteWalletConfirmationDialog';
@@ -63,7 +62,6 @@ export default class WalletSettings extends Component {
     assuranceLevels: Array<{ value: string, label: ReactIntlMessage }>,
     walletName: string,
     walletAssurance: string,
-    onWalletAssuranceLevelUpdate: Function,
     isWalletPasswordSet: boolean,
     walletPasswordUpdateDate: ?Date,
     error?: ?LocalizableError,
@@ -84,11 +82,15 @@ export default class WalletSettings extends Component {
     intl: intlShape.isRequired,
   };
 
+  componentWillUnmount() {
+    // This call is used to prevent display of old successfully-updated messages
+    this.props.onCancelEditing();
+  }
+
   render() {
     const { intl } = this.context;
     const {
       assuranceLevels, walletAssurance,
-      onWalletAssuranceLevelUpdate,
       walletName, isWalletPasswordSet,
       walletPasswordUpdateDate, error,
       openDialogAction, isDialogOpen,
@@ -116,6 +118,7 @@ export default class WalletSettings extends Component {
         <BorderedBox>
 
           <InlineEditingInput
+            className="walletName"
             inputFieldLabel={intl.formatMessage(messages.name)}
             inputFieldValue={walletName}
             isActive={activeField === 'name'}
@@ -128,13 +131,16 @@ export default class WalletSettings extends Component {
             successfullyUpdated={!isSubmitting && lastUpdatedField === 'name' && !isInvalid}
           />
 
-          <Select
-            className={styles.assuranceLevelSelect}
+          <InlineEditingDropdown
+            className="walletAssuranceLevel"
             label={intl.formatMessage(messages.assuranceLevelLabel)}
             options={assuranceLevelOptions}
             value={walletAssurance}
-            onChange={(value) => onWalletAssuranceLevelUpdate({ assurance: value })}
-            skin={<SelectSkin />}
+            isActive={activeField === 'assurance'}
+            onStartEditing={() => onStartEditing('assurance')}
+            onStopEditing={onStopEditing}
+            onSubmit={(value) => onFieldValueChange('assurance', value)}
+            successfullyUpdated={!isSubmitting && lastUpdatedField === 'assurance'}
           />
 
           <ReadOnlyInput

--- a/app/components/wallet/WalletSettings.scss
+++ b/app/components/wallet/WalletSettings.scss
@@ -9,10 +9,6 @@
   padding: 20px 30px;
 }
 
-.assuranceLevelSelect {
-  margin-bottom: 20px;
-}
-
 .export {
   font-size: 16px;
   margin-bottom: 20px;

--- a/app/components/widgets/forms/InlineEditingDropdown.js
+++ b/app/components/widgets/forms/InlineEditingDropdown.js
@@ -19,11 +19,14 @@ const messages = defineMessages({
 export default class InlineEditingDropdown extends Component {
 
   props: {
+    className?: string,
     isActive: boolean,
     label: string,
     options: Array<{ value: (number | string), label: string }>,
     value: number | string,
-    onChange: Function,
+    onSubmit: Function,
+    onStartEditing: Function,
+    onStopEditing: Function,
     successfullyUpdated: boolean,
   };
 
@@ -31,28 +34,34 @@ export default class InlineEditingDropdown extends Component {
     intl: intlShape.isRequired,
   };
 
+  onChange = (value: number | string) => {
+    this.props.onStartEditing();
+    this.props.onSubmit(value);
+    this.props.onStopEditing();
+  };
+
   render() {
     const { intl } = this.context;
     const {
-      isActive,
-      label,
-      options,
-      value,
-      onChange,
-      successfullyUpdated,
+      className, isActive, label, options,
+      value, successfullyUpdated,
     } = this.props;
+    const componentClasses = classnames([
+      className,
+      styles.component,
+    ]);
     const dropdownStyles = classnames([
       successfullyUpdated ? 'dropdown_animateSuccess' : null,
     ]);
     return (
-      <div className={styles.component}>
+      <div className={componentClasses}>
 
         <Select
           className={dropdownStyles}
           label={label}
           options={options}
           value={value}
-          onChange={onChange}
+          onChange={this.onChange}
           disabled={!isActive}
           skin={<SelectSkin />}
         />

--- a/app/components/widgets/forms/InlineEditingDropdown.scss
+++ b/app/components/widgets/forms/InlineEditingDropdown.scss
@@ -1,4 +1,5 @@
 .component {
+  margin-bottom: 20px;
   position: relative;
 
   @keyframes animateSavingResultLabel {

--- a/app/components/widgets/forms/InlineEditingInput.js
+++ b/app/components/widgets/forms/InlineEditingInput.js
@@ -34,6 +34,7 @@ export default class InlineEditingInput extends Component {
   }
 
   props: {
+    className?: string,
     isActive: boolean,
     inputFieldLabel: string,
     inputFieldValue: string,
@@ -122,6 +123,7 @@ export default class InlineEditingInput extends Component {
   render() {
     const { validator } = this;
     const {
+      className,
       inputFieldLabel,
       isActive,
       inputFieldValue,
@@ -130,6 +132,7 @@ export default class InlineEditingInput extends Component {
     const { intl } = this.context;
     const inputField = validator.$('inputField');
     const componentStyles = classnames([
+      className,
       styles.component,
       isActive ? null : styles.inactive,
     ]);

--- a/app/components/widgets/forms/InlineEditingInput.scss
+++ b/app/components/widgets/forms/InlineEditingInput.scss
@@ -4,7 +4,7 @@
 
   :global {
     .SimpleFormField_label {
-      color: $theme-label-color;
+      color: $theme-label-color !important;
     }
 
     .SimpleInput_disabled {

--- a/app/components/widgets/forms/ReadOnlyInput.scss
+++ b/app/components/widgets/forms/ReadOnlyInput.scss
@@ -4,7 +4,7 @@
 
   :global {
     .SimpleFormField_label {
-      color: $theme-label-color;
+      color: $theme-label-color !important;
     }
 
     .SimpleInput_disabled {

--- a/app/containers/wallet/WalletSettingsPage.js
+++ b/app/containers/wallet/WalletSettingsPage.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer, inject } from 'mobx-react';
 import WalletSettings from '../../components/wallet/WalletSettings';
 import type { InjectedProps } from '../../types/injectedPropsType';
-import type { AssuranceMode } from '../../types/transactionAssuranceTypes';
 import { isValidWalletName } from '../../lib/validations';
 
 @inject('stores', 'actions') @observer
@@ -11,10 +10,6 @@ export default class WalletSettingsPage extends Component {
 
   static defaultProps = { actions: null, stores: null };
   props: InjectedProps;
-
-  handleWalletAssuranceLevelUpdate = (values: { assurance: AssuranceMode }) => {
-    this.props.actions.walletSettings.updateWalletAssuranceLevel.trigger(values);
-  };
 
   render() {
     const { wallets, walletSettings, uiDialogs } = this.props.stores;
@@ -39,7 +34,6 @@ export default class WalletSettingsPage extends Component {
       <WalletSettings
         assuranceLevels={walletSettings.WALLET_ASSURANCE_LEVEL_OPTIONS}
         walletAssurance={activeWallet.assurance}
-        onWalletAssuranceLevelUpdate={this.handleWalletAssuranceLevelUpdate}
         error={walletSettings.updateWalletRequest.error}
         openDialogAction={actions.dialogs.open.trigger}
         isWalletPasswordSet={activeWallet.hasPassword}

--- a/app/i18n/locales/de-DE.json
+++ b/app/i18n/locales/de-DE.json
@@ -37,6 +37,7 @@
   "global.language.korean": "!!!Korean",
   "global.passwordInstructions": "!!!Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.unit.ada": "!!!Ada",
+  "inline.editing.dropdown.changesSaved": "!!!Your changes have been saved",
   "inline.editing.input.cancel.label": "!!!cancel",
   "inline.editing.input.change.label": "!!!change",
   "inline.editing.input.changesSaved": "!!!Your changes have been saved",

--- a/app/i18n/locales/defaultMessages.json
+++ b/app/i18n/locales/defaultMessages.json
@@ -2734,13 +2734,13 @@
         "description": "Label for the \"Name\" text input on the wallet settings page.",
         "end": {
           "column": 3,
-          "line": 36
+          "line": 35
         },
         "file": "app/components/wallet/WalletSettings.js",
         "id": "wallet.settings.name.label",
         "start": {
           "column": 8,
-          "line": 32
+          "line": 31
         }
       },
       {
@@ -2748,13 +2748,13 @@
         "description": "Label for the \"Transaction assurance security level\" dropdown.",
         "end": {
           "column": 3,
-          "line": 41
+          "line": 40
         },
         "file": "app/components/wallet/WalletSettings.js",
         "id": "wallet.settings.assurance",
         "start": {
           "column": 23,
-          "line": 37
+          "line": 36
         }
       },
       {
@@ -2762,13 +2762,13 @@
         "description": "Label for the \"Password\" field.",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 45
         },
         "file": "app/components/wallet/WalletSettings.js",
         "id": "wallet.settings.password",
         "start": {
           "column": 17,
-          "line": 42
+          "line": 41
         }
       },
       {
@@ -2776,13 +2776,13 @@
         "description": "Last updated X time ago message.",
         "end": {
           "column": 3,
-          "line": 51
+          "line": 50
         },
         "file": "app/components/wallet/WalletSettings.js",
         "id": "wallet.settings.passwordLastUpdated",
         "start": {
           "column": 23,
-          "line": 47
+          "line": 46
         }
       },
       {
@@ -2790,13 +2790,13 @@
         "description": "You still don't have password set message.",
         "end": {
           "column": 3,
-          "line": 56
+          "line": 55
         },
         "file": "app/components/wallet/WalletSettings.js",
         "id": "wallet.settings.passwordNotSet",
         "start": {
           "column": 18,
-          "line": 52
+          "line": 51
         }
       }
     ],
@@ -2834,6 +2834,25 @@
       }
     ],
     "path": "app/components/widgets/forms/AdaCertificateUploadWidget.json"
+  },
+  {
+    "descriptors": [
+      {
+        "defaultMessage": "!!!Your changes have been saved",
+        "description": "Message \"Your changes have been saved\" for inline editing (eg. on Wallet Settings page).",
+        "end": {
+          "column": 3,
+          "line": 15
+        },
+        "file": "app/components/widgets/forms/InlineEditingDropdown.js",
+        "id": "inline.editing.dropdown.changesSaved",
+        "start": {
+          "column": 16,
+          "line": 11
+        }
+      }
+    ],
+    "path": "app/components/widgets/forms/InlineEditingDropdown.json"
   },
   {
     "descriptors": [

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -37,6 +37,7 @@
   "global.language.korean": "Korean",
   "global.passwordInstructions": "Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.unit.ada": "Ada",
+  "inline.editing.dropdown.changesSaved": "Your changes have been saved",
   "inline.editing.input.cancel.label": "cancel",
   "inline.editing.input.change.label": "change",
   "inline.editing.input.changesSaved": "Your changes have been saved",

--- a/app/i18n/locales/hr-HR.json
+++ b/app/i18n/locales/hr-HR.json
@@ -37,6 +37,7 @@
   "global.language.korean": "korejski",
   "global.passwordInstructions": "!!!Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.unit.ada": "ada",
+  "inline.editing.dropdown.changesSaved": "!!!Your changes have been saved",
   "inline.editing.input.cancel.label": "!!!cancel",
   "inline.editing.input.change.label": "!!!change",
   "inline.editing.input.changesSaved": "!!!Your changes have been saved",

--- a/app/i18n/locales/ja-JP.json
+++ b/app/i18n/locales/ja-JP.json
@@ -37,6 +37,7 @@
   "global.language.korean": "韓国語",
   "global.passwordInstructions": "パスワードは７文字以上であり、英字大文字、小文字、数字を含む必要があります。",
   "global.unit.ada": "Ada",
+  "inline.editing.dropdown.changesSaved": "変更は保存されました",
   "inline.editing.input.cancel.label": "キャンセル",
   "inline.editing.input.change.label": "変更",
   "inline.editing.input.changesSaved": "変更は保存されました",

--- a/app/i18n/locales/ko-KR.json
+++ b/app/i18n/locales/ko-KR.json
@@ -37,6 +37,7 @@
   "global.language.korean": "!!!Korean",
   "global.passwordInstructions": "!!!Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.unit.ada": "!!!Ada",
+  "inline.editing.dropdown.changesSaved": "!!!Your changes have been saved",
   "inline.editing.input.cancel.label": "!!!cancel",
   "inline.editing.input.change.label": "!!!change",
   "inline.editing.input.changesSaved": "!!!Your changes have been saved",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -37,6 +37,7 @@
   "global.language.korean": "!!!Korean",
   "global.passwordInstructions": "!!!Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.unit.ada": "!!!Ada",
+  "inline.editing.dropdown.changesSaved": "!!!Your changes have been saved",
   "inline.editing.input.cancel.label": "!!!cancel",
   "inline.editing.input.change.label": "!!!change",
   "inline.editing.input.changesSaved": "!!!Your changes have been saved",

--- a/app/stores/WalletSettingsStore.js
+++ b/app/stores/WalletSettingsStore.js
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import Store from './lib/Store';
 import Request from './lib/LocalizedRequest';
 import globalMessages from '../i18n/global-messages';
-import type { AssuranceMode } from '../types/transactionAssuranceTypes';
 import type {
   UpdateWalletResponse,
   UpdateWalletPasswordResponse,
@@ -32,21 +31,7 @@ export default class WalletSettingsStore extends Store {
     a.cancelEditingWalletField.listen(this._cancelEditingWalletField);
     a.updateWalletField.listen(this._updateWalletField);
     a.updateWalletPassword.listen(this._updateWalletPassword);
-    a.updateWalletAssuranceLevel.listen(this._updateWalletAssuranceLevel);
   }
-
-  @action _updateWalletAssuranceLevel = async ({ assurance }: { assurance: AssuranceMode }) => {
-    const activeWallet = this.stores.wallets.active;
-    if (!activeWallet) return;
-    const { id: walletId, name } = activeWallet;
-    const wallet = await this.updateWalletRequest.execute({ walletId, name, assurance }).promise;
-    if (!wallet) return;
-    await this.stores.wallets.walletsRequest.patch(result => {
-      const walletIndex = _.findIndex(result, { id: walletId });
-      result[walletIndex] = wallet;
-    });
-    this.stores.wallets._setActiveWallet({ walletId });
-  };
 
   @action _updateWalletPassword = async ({ walletId, oldPassword, newPassword }: {
     walletId: string, oldPassword: ?string, newPassword: ?string,

--- a/features/step_definitions/settings-steps.js
+++ b/features/step_definitions/settings-steps.js
@@ -52,7 +52,7 @@ export default function () {
 
   this.When(/^I enter new wallet name:$/, async function (table) {
     const fields = table.hashes()[0];
-    await this.client.setValue('.WalletSettings_component .InlineEditingInput_component input', fields.name);
+    await this.client.setValue('.WalletSettings_component .walletName input', fields.name);
   });
 
   this.When(/^I click outside "name" input field$/, function () {
@@ -60,7 +60,7 @@ export default function () {
   });
 
   this.When(/^I open "Transaction assurance security level" selection dropdown$/, function () {
-    return this.waitAndClick('.WalletSettings_assuranceLevelSelect .SimpleInput_input');
+    return this.waitAndClick('.WalletSettings_component .walletAssuranceLevel input');
   });
 
   this.When(/^I select "Strict" assurance level$/, function () {


### PR DESCRIPTION
This PR introduces a fix for success-messages issues on wallet setting screen.
As a part of this PR InlineEditingDropdown component has been refactored and WalletSettingsStore code simplified.

![screen shot 2017-07-26 at 14 15 32](https://user-images.githubusercontent.com/376611/28620662-31969ef8-720e-11e7-98f5-84e6ea9fb347.png)
