### PR TITLE
Chore/daef 389 Update README file's NETWORK env variable options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Changelog
 - Temporary workaround for missing Japanese translations for Terms of Use that allows users to accept them in English
 - Added readme file for running acceptance tests ([PR 395](https://github.com/input-output-hk/daedalus/pull/395))
 - Improved webpack build performance ([PR 402](https://github.com/input-output-hk/daedalus/pull/402))
+- Updated README file "Development - network options" section ([PR 410](https://github.com/input-output-hk/daedalus/pull/410))
 
 ## 0.6.2
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Run with `npm run dev`
 
 ### Development - network options
 
-There are four different network options you can run Deadalus in: `mainnet`, `testnet`, `staging` and `development` (default).
+There are four different network options you can run Deadalus in: `mainnet`, `testnet` and `development` (default).
 To set desired network option use `NETWORK` environment variable:
 
 ```bash


### PR DESCRIPTION
This PR updates README file's "Development - network options" section. `staging` option is removed from available options list.