### PR TITLE
Fix/daef 391 transaction info toggle bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Changelog
 - Fixed eslint syntax warnings ([PR 403](https://github.com/input-output-hk/daedalus/pull/403))
 - Fixed wallet spending password fields error messages positioning on wallet create/restore/import dialogs ([PR 407](https://github.com/input-output-hk/daedalus/pull/407))
 - Fixed inline-editing success-messages on wallet settings screen ([PR 408](https://github.com/input-output-hk/daedalus/pull/408))
+- Fixes Transaction additional info showing/hiding affects all user's wallets ([PR 411](https://github.com/input-output-hk/daedalus/pull/411))
 
 ### Chores
 

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -34,6 +34,7 @@ export default class WalletTransactionsList extends Component {
     hasMoreToLoad: boolean,
     onLoadMore: Function,
     assuranceMode: AssuranceMode,
+    walletId: string,
   };
 
   static contextTypes = {
@@ -117,6 +118,7 @@ export default class WalletTransactionsList extends Component {
       isLoadingTransactions,
       hasMoreToLoad,
       assuranceMode,
+      walletId,
     } = this.props;
 
     const transactionsGroups = this.groupTransactionsByDay(transactions);
@@ -137,11 +139,11 @@ export default class WalletTransactionsList extends Component {
         ref={(div) => { this.list = div; }}
       >
         {transactionsGroups.map((group, groupIndex) => (
-          <div className={styles.group} key={groupIndex}>
+          <div className={styles.group} key={walletId + '-' + groupIndex}>
             <div className={styles.groupDate}>{this.localizedDate(group.date)}</div>
             <div className={styles.list}>
               {group.transactions.map((transaction, transactionIndex) => (
-                <div key={transactionIndex}>
+                <div key={walletId + '-' + transaction.id}>
                   <Transaction
                     data={transaction}
                     isLastInList={transactionIndex === group.transactions.length - 1}

--- a/app/containers/wallet/WalletSummaryPage.js
+++ b/app/containers/wallet/WalletSummaryPage.js
@@ -52,6 +52,7 @@ export default class WalletSummaryPage extends Component {
           hasMoreToLoad={false}
           onLoadMore={() => {}}
           assuranceMode={wallet.assuranceMode}
+          walletId={wallet.id}
         />
       );
     } else if (!hasAny) {

--- a/app/containers/wallet/WalletTransactionsPage.js
+++ b/app/containers/wallet/WalletTransactionsPage.js
@@ -77,6 +77,7 @@ export default class WalletTransactionsPage extends Component {
           hasMoreToLoad={totalAvailable > searchLimit}
           onLoadMore={actions.transactions.loadMoreTransactions.trigger}
           assuranceMode={activeWallet.assuranceMode}
+          walletId={activeWallet.id}
         />
       );
     } else if (wasSearched && !hasAny) {

--- a/stories/WalletTransactionsList.stories.js
+++ b/stories/WalletTransactionsList.stories.js
@@ -48,5 +48,6 @@ storiesOf('WalletTransactionsList', module)
       isLoadingTransactions={false}
       hasMoreToLoad={false}
       assuranceMode={{ low: 1, medium: 2 }}
+      walletId="test-wallet"
     />
   ));


### PR DESCRIPTION
This PR fixes [issue 391](https://issues.serokell.io/issue/DAEF-391) (Transaction additional info showing/hiding affects all user's wallets) by assigning unique keys for transaction groups and transaction items in the `WalletTransactionList`