### PR TITLE
[DAEF-393] force user to wait for dialog actions to be completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Changelog
 - Fixed eslint syntax warnings ([PR 403](https://github.com/input-output-hk/daedalus/pull/403))
 - Fixed wallet spending password fields error messages positioning on wallet create/restore/import dialogs ([PR 407](https://github.com/input-output-hk/daedalus/pull/407))
 - Fixed inline-editing success-messages on wallet settings screen ([PR 408](https://github.com/input-output-hk/daedalus/pull/408))
+- Fixed the issue of dialogs being closable while wallet import/creation/restoring is happening ([PR 393](https://github.com/input-output-hk/daedalus/pull/414))
 
 ### Chores
 

--- a/app/components/wallet/PaperWalletImportDialog.js
+++ b/app/components/wallet/PaperWalletImportDialog.js
@@ -258,7 +258,7 @@ export default class PaperWalletImportDialog extends Component {
         actions={actions}
         closeOnOverlayClick
         onClose={!isSubmitting ? onCancel : null}
-        closeButton={<DialogCloseButton onClose={onCancel} />}
+        closeButton={<DialogCloseButton />}
       >
 
         <Input

--- a/app/components/wallet/WalletAddDialog.js
+++ b/app/components/wallet/WalletAddDialog.js
@@ -88,7 +88,7 @@ export default class WalletAddDialog extends Component {
         title={intl.formatMessage(messages.title)}
         closeOnOverlayClick
         onClose={canClose ? onCancel : null}
-        closeButton={canClose && <DialogCloseButton onClose={onCancel} />}
+        closeButton={canClose && <DialogCloseButton />}
       >
         <div className={styles.buttonsContainer}>
           <div className={styles.firstRow}>

--- a/app/components/wallet/WalletCreateDialog.js
+++ b/app/components/wallet/WalletCreateDialog.js
@@ -198,7 +198,7 @@ export default class WalletCreateDialog extends Component {
         actions={actions}
         closeOnOverlayClick
         onClose={!isSubmitting ? onCancel : null}
-        closeButton={<DialogCloseButton onClose={onCancel} />}
+        closeButton={<DialogCloseButton />}
       >
 
         <Input

--- a/app/components/wallet/WalletRestoreDialog.js
+++ b/app/components/wallet/WalletRestoreDialog.js
@@ -227,7 +227,7 @@ export default class WalletRestoreDialog extends Component {
         actions={actions}
         closeOnOverlayClick
         onClose={!isSubmitting ? onCancel : null}
-        closeButton={<DialogCloseButton onClose={onCancel} />}
+        closeButton={<DialogCloseButton />}
       >
 
         <Input

--- a/app/components/wallet/key-import/WalletKeyImportDialog.js
+++ b/app/components/wallet/key-import/WalletKeyImportDialog.js
@@ -184,7 +184,7 @@ export default class WalletKeyImportDialog extends Component {
         actions={actions}
         closeOnOverlayClick
         onClose={!isSubmitting ? onClose : null}
-        closeButton={<DialogCloseButton onClose={onClose} />}
+        closeButton={<DialogCloseButton />}
       >
 
         <div className={styles.keyUpload}>

--- a/app/components/widgets/Dialog.js
+++ b/app/components/widgets/Dialog.js
@@ -75,7 +75,7 @@ export default class Dialog extends Component {
             </div>
           }
 
-          {closeButton}
+          {closeButton ? React.cloneElement(closeButton, { onClose: onClose }) : null}
           {backButton}
 
         </div>

--- a/app/containers/wallet/WalletAddPage.js
+++ b/app/containers/wallet/WalletAddPage.js
@@ -28,48 +28,30 @@ export default class WalletAddPage extends Component {
         dialog: WalletAddDialog,
       });
     }
-  }
+  };
 
   render() {
     const { uiDialogs } = this.props.stores;
     let activeDialog = null;
 
     if (uiDialogs.isOpen(WalletAddDialog)) {
-      activeDialog = (
-        <WalletAddDialogContainer />
-      );
+      activeDialog = <WalletAddDialogContainer />;
     }
 
     if (uiDialogs.isOpen(WalletCreateDialog)) {
-      activeDialog = (
-        <WalletCreateDialogContainer
-          onClose={this.onClose}
-        />
-      );
+      activeDialog = <WalletCreateDialogContainer onClose={this.onClose} />;
     }
 
     if (uiDialogs.isOpen(WalletBackupDialog)) {
-      activeDialog = (
-        <WalletBackupDialogContainer
-          onClose={this.onClose}
-        />
-      );
+      activeDialog = <WalletBackupDialogContainer onClose={this.onClose} />;
     }
 
     if (uiDialogs.isOpen(WalletRestoreDialog)) {
-      activeDialog = (
-        <WalletRestoreDialogContainer
-          onClose={this.onClose}
-        />
-      );
+      activeDialog = <WalletRestoreDialogContainer onClose={this.onClose} />;
     }
 
     if (uiDialogs.isOpen(WalletKeyImportDialog)) {
-      activeDialog = (
-        <WalletKeyImportDialogContainer
-          onClose={this.onClose}
-        />
-      );
+      activeDialog = <WalletKeyImportDialogContainer onClose={this.onClose} />;
     }
 
     return activeDialog;


### PR DESCRIPTION
This small PR solves the issue of dialogs being closable while wallet import/creation/restoring is happening, which could lead to problems if users are trying to use the not-yet-imported wallet (like sending transactions).

https://issues.serokell.io/issue/DAEF-393