### PR TITLE
Fix/daef 390 incorrect tx assurance level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Changelog
 - Fixed eslint syntax warnings ([PR 403](https://github.com/input-output-hk/daedalus/pull/403))
 - Fixed wallet spending password fields error messages positioning on wallet create/restore/import dialogs ([PR 407](https://github.com/input-output-hk/daedalus/pull/407))
 - Fixed inline-editing success-messages on wallet settings screen ([PR 408](https://github.com/input-output-hk/daedalus/pull/408))
+- Fixed calculation and display of transaction assurance levels ([PR 390](https://github.com/input-output-hk/daedalus/pull/416))
 
 ### Chores
 

--- a/app/config/transactionAssuranceConfig.js
+++ b/app/config/transactionAssuranceConfig.js
@@ -11,12 +11,12 @@ export const assuranceModeOptions: {
 
 export const assuranceModes: { NORMAL: AssuranceMode, STRICT: AssuranceMode } = {
   NORMAL: {
-    low: 3,
-    medium: 7,
+    low: 2,
+    medium: 6,
   },
   STRICT: {
-    low: 5,
-    medium: 11,
+    low: 4,
+    medium: 10,
   }
 };
 

--- a/app/config/transactionAssuranceConfig.js
+++ b/app/config/transactionAssuranceConfig.js
@@ -11,12 +11,12 @@ export const assuranceModeOptions: {
 
 export const assuranceModes: { NORMAL: AssuranceMode, STRICT: AssuranceMode } = {
   NORMAL: {
-    low: 2,
-    medium: 6,
+    low: 3,
+    medium: 9,
   },
   STRICT: {
-    low: 4,
-    medium: 10,
+    low: 5,
+    medium: 15,
   }
 };
 


### PR DESCRIPTION
This PR fixes the calculation and display of transaction assurance levels according to the docs:
https://cardanodocs.com/cardano/transaction-assurance/

**normal**
- LOW < 3
- MEDIUM < 9
- HIGH >= 9

**strict**
- LOW < 5
- MEDIUM < 15
- HIGH >= 15