### PR TITLE
Fix/daef 411 Used address is not styled as used when it is the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Changelog
 - Fixed the issue of dialogs being closable while wallet import/creation/restoring is happening ([PR 393](https://github.com/input-output-hk/daedalus/pull/414))
 - Fixed calculation and display of transaction assurance levels ([PR 390](https://github.com/input-output-hk/daedalus/pull/416))
 - Fixes Transaction additional info showing/hiding affects all user's wallets ([PR 411](https://github.com/input-output-hk/daedalus/pull/411))
+- Fixed missing 'used address' styling for default wallet address on wallet receive screen ([PR 422](https://github.com/input-output-hk/daedalus/pull/422))
 
 ### Chores
 

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -68,6 +68,7 @@ export default class WalletReceive extends Component {
 
   props: {
     walletAddress: string,
+    isWalletAddressUsed: boolean,
     walletAddresses: Array<WalletAddress>,
     onGenerateAddress: Function,
     onCopyAddress: Function,
@@ -136,10 +137,15 @@ export default class WalletReceive extends Component {
       walletAddress, walletAddresses,
       onCopyAddress, isSidebarExpanded,
       walletHasPassword, isSubmitting,
-      error,
+      error, isWalletAddressUsed,
     } = this.props;
     const { intl } = this.context;
     const { showUsed } = this.state;
+
+    const walletAddressClasses = classnames([
+      styles.hash,
+      isWalletAddressUsed ? styles.usedHash : null,
+    ]);
 
     const generateAddressWrapperClasses = classnames([
       styles.generateAddressWrapper,
@@ -188,7 +194,7 @@ export default class WalletReceive extends Component {
             </div>
 
             <div className={styles.instructions}>
-              <div className={styles.hash}>
+              <div className={walletAddressClasses}>
                 {walletAddress}
                 <CopyToClipboard
                   text={walletAddress}

--- a/app/components/wallet/WalletReceive.scss
+++ b/app/components/wallet/WalletReceive.scss
@@ -61,6 +61,10 @@
       word-break: break-all;
     }
 
+    .usedHash {
+      opacity: 0.4;
+    }
+
     .hashLabel {
       margin-bottom: 6px;
       opacity: 0.5;

--- a/app/containers/wallet/WalletReceivePage.js
+++ b/app/containers/wallet/WalletReceivePage.js
@@ -67,6 +67,7 @@ export default class WalletReceivePage extends Component {
     if (!wallet) throw new Error('Active wallet required for WalletReceivePage.');
 
     const walletAddress = addresses.active ? addresses.active.id : '';
+    const isWalletAddressUsed = addresses.active ? addresses.active.isUsed : false;
     const walletAddresses = addresses.all.reverse();
 
     const notification = {
@@ -85,6 +86,7 @@ export default class WalletReceivePage extends Component {
 
         <WalletReceive
           walletAddress={walletAddress}
+          isWalletAddressUsed={isWalletAddressUsed}
           walletAddresses={walletAddresses}
           onGenerateAddress={this.handleGenerateAddress}
           onCopyAddress={(address) => {


### PR DESCRIPTION
This PR implements missing 'used address' styling for default wallet address on wallet receive screen.

![screen shot 2017-08-17 at 11 07 50](https://user-images.githubusercontent.com/376611/29407127-96b46108-8343-11e7-9dc6-b175bcde57e5.png)
