### PR TITLE
[DAEF-427] move tls workaround into daedalus repo to fix build issue

### DIFF
--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -9,7 +9,7 @@ import ipcApi from './ipc-api';
 import getLogsFolderPath from './lib/getLogsFolderPath';
 import { daedalusLogger, cardanoNodeLogger } from './lib/remoteLog';
 import ClientApi from 'daedalus-client-api';
-import jsClientApi from 'daedalus-client-api/src/tls_workaround';
+import { readCA, notify } from './tls-workaround';
 
 const APP_NAME = 'Daedalus';
 // Configure default logger levels for console and file outputs
@@ -99,12 +99,12 @@ app.on('ready', async () => {
 
   try {
 
-    const ca = jsClientApi.readCA(path.join(__dirname, '../tls/ca.crt'));
+    const ca = readCA(path.join(__dirname, '../tls/ca.crt'));
 
     const tlsConfig = ClientApi.tlsInit(ca);
     let messageCallback, errorCallback = null;
 
-    jsClientApi.notify(
+    notify(
       ca,
       function handleNotifyMessage(...args) {
         if (messageCallback) {

--- a/electron/tls-workaround.js
+++ b/electron/tls-workaround.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import WebSocket from 'ws';
+
+export const readCA = (path) => fs.readFileSync(path);
+
+export const notify = (ca, succ, err) => {
+  const ws = new WebSocket('wss://localhost:8090', {ca: ca});
+  ws.on('close', () => {
+    setTimeout(() => {
+      // reconnect
+      ws.terminate();
+      notify(ca, succ, err);
+    }, 5000);
+  });
+  ws.on('error', err);
+  ws.on('message', succ);
+};

--- a/package.json
+++ b/package.json
@@ -151,7 +151,8 @@
     "validator": "6.3.0",
     "wallet-address-validator": "0.1.0",
     "winston": "2.3.1",
-    "winston-papertrail": "1.0.4"
+    "winston-papertrail": "1.0.4",
+    "ws": "^3.1.0"
   },
   "devEngines": {
     "node": "6.x",


### PR DESCRIPTION
Refactors the tls workaround from cardano-sl into the daedalus repo to (hopefully) fix the build issue:

```
Error: Cannot find module "daedalus-client-api/src/tls_workaround"
    at webpackMissingModule (C:\Program Files\Daedalus2584\resources\app\dist\webpack:\electron\main.development.js:12:1)
    at Object.<anonymous> (C:\Program Files\Daedalus2584\resources\app\dist\webpack:\electron\main.development.js:12:1)
    at __webpack_require__ (C:\Program Files\Daedalus2584\resources\app\dist\webpack:\webpack\bootstrap a1c555050b822396d3a8:19:1)
    at Object.<anonymous> (C:\Program Files\Daedalus2584\resources\app\dist\main.js:50:19)
    at __webpack_require__ (C:\Program Files\Daedalus2584\resources\app\dist\webpack:\webpack\bootstrap a1c555050b822396d3a8:19:1)
    at C:\Program Files\Daedalus2584\resources\app\dist\webpack:\webpack\bootstrap a1c555050b822396d3a8:39:1
    at Object.<anonymous> (C:\Program Files\Daedalus2584\resources\app\dist\main.js:45:10)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
```