### PR TITLE
[DAEF-431] target latest master branch of cardano-sl for ci builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 env:
   global:
     - VERSION=0.5
-    - CARDANO_SL_BRANCH=cardano-sl-0.5
+    - CARDANO_SL_BRANCH=master
       # NOTE: when bumping nixpkgs, also update default.nix
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/48ecdcf5980a6504cd3b884b121e29efb2fb83dc.tar.gz
     # AWS access key

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private/iohk-windows-certificate-2.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% cardano-sl-0.5
+  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% master
 
 artifacts:
   - path: release\win32-x64\Daedalus-win32-x64

--- a/webpack/webpack.config.production.js
+++ b/webpack/webpack.config.production.js
@@ -42,10 +42,6 @@ export default validate(merge(baseConfig, {
     ]
   },
 
-  sassLoader: {
-    data: '@import "' + './app/themes/daedalus/_theme.scss' + '";'
-  },
-
   plugins: [
     // https://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin
     // https://github.com/webpack/webpack/issues/864


### PR DESCRIPTION
## Fix CI builds by updating CARDANO_SL_BRANCH env variable

We had issues with latest builds where some api endpoints were missing and after some investigation i figured that we are building all releases against the old `cardano-sl-0.5` branch.

This PR updates the backend target branch to `master`