### PR TITLE
Fix/daef 395 Suppress electron window from forcing focus during acceptance testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Changelog
 - Show correct error message for A -> A transaction error ([PR 441](https://github.com/input-output-hk/daedalus/pull/441))
 - Improved QR code colors on wallet send screen for dark themes ([PR 448](https://github.com/input-output-hk/daedalus/pull/448))
 - Fixed failing acceptance-tests ([PR 454](https://github.com/input-output-hk/daedalus/pull/454))
+- Prevent application window auto focusing while running acceptance-tests ([PR 458](https://github.com/input-output-hk/daedalus/pull/458))
 
 ### Chores
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -12,7 +12,7 @@ import { daedalusLogger } from './lib/remoteLog';
 const APP_NAME = 'Daedalus';
 // Configure default logger levels for console and file outputs
 const runtimeFolderPath = getRuntimeFolderPath(process.platform, process.env, APP_NAME);
-const appLogFolderPath = path.join(runtimeFolderPath, 'Logs')
+const appLogFolderPath = path.join(runtimeFolderPath, 'Logs');
 const logFilePath = path.join(appLogFolderPath, APP_NAME + '.log');
 Log.transports.console.level = 'warn';
 Log.transports.file.level = 'debug';
@@ -102,9 +102,9 @@ function openAbout() {
 
   // prevent direct link navigation in electron window -> open in default browser
   aboutWindow.webContents.on('will-navigate', (e, url) => {
-    e.preventDefault()
+    e.preventDefault();
     require('electron').shell.openExternal(url)
-  })
+  });
 
   aboutWindow.webContents.on('context-menu', (e, props) => {
     const contextMenuOptions = [];
@@ -122,7 +122,7 @@ function openAbout() {
   });
 
   // handle about window when content loaded
-  aboutWindow.webContents.on('did-finish-load', ()=>{
+  aboutWindow.webContents.on('did-finish-load', () => {
     aboutWindow.show(); // show also focuses the window
   });
 }

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -92,7 +92,7 @@ function openAbout() {
 
   aboutWindow.loadURL(`file://${__dirname}/../app/index.html?window=about`);
   aboutWindow.on('page-title-updated', event => {
-   event.preventDefault()
+    event.preventDefault()
   });
   aboutWindow.setTitle(`About Daedalus`); // default title
 
@@ -119,8 +119,7 @@ function openAbout() {
 
   // handle about window when content loaded
   aboutWindow.webContents.on('did-finish-load', ()=>{
-    aboutWindow.show();
-    aboutWindow.focus();
+    aboutWindow.show(); // show also focuses the window
   });
 }
 
@@ -142,7 +141,7 @@ app.on('ready', async () => {
   try {
     // Path to certificate in development
     let pathToCertificate = '../tls/ca.crt';
-    
+
     if (isProd) {
       // --> PATH TO CERTIFICATE IN PRODUCTION:
       pathToCertificate = '../../../tls/ca/ca.crt';
@@ -175,8 +174,11 @@ app.on('ready', async () => {
   mainWindow.setTitle(`Daedalus (${daedalusVersion})`);
 
   mainWindow.webContents.on('did-finish-load', () => {
-    mainWindow.show();
-    mainWindow.focus();
+    if (isTest) {
+      mainWindow.showInactive(); // show without focusing the window
+    } else {
+      mainWindow.show(); // show also focuses the window
+    }
   });
 
   mainWindow.on('closed', () => {


### PR DESCRIPTION
This PR introduces a fix which prevents automatic application window focusing during acceptance testing.
Please note that the window still sets itself on top of other windows which can not be prevented BUT the good thing is that focus remains intact. Easy way to get around this is to simply drag the application window out of sight.