### PR TITLE
Fix/daef 465 Revert makePayment api call

### DIFF
--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -51,8 +51,8 @@ import {
 } from './errors';
 import { LOVELACES_PER_ADA } from '../config/numbersConfig';
 
-import { getSyncProgress } from "./js-api/getSyncProgress";
-import { makePayment } from "./js-api/makePayment";
+import { getSyncProgress } from './js-api/getSyncProgress';
+import { makePayment } from './js-api/makePayment';
 
 const ca = remote.getGlobal('ca');
 const tlsConfig = ClientApi.tlsInit(ca);
@@ -256,7 +256,13 @@ export default class CardanoClientApi {
     const { sender, receiver, amount, password } = request;
     // sender must be set as accountId (account.caId) and not walletId
     try {
-      const response = await makePayment(ca, { from: sender, to: receiver, amount }, { passphrase: password });
+      const response: ApiTransaction = await ClientApi.newPayment(
+        tlsConfig, sender, receiver, amount, password
+      );
+      // Passphrase handling is broken in js-api
+      // const response = await makePayment(
+      //   ca, { from: sender, to: receiver, amount }, { passphrase: password }
+      // );
       Logger.debug('CardanoClientApi::createTransaction success: ' + stringifyData(response));
       return _createTransactionFromServerData(response);
     } catch (error) {

--- a/app/api/js-api/lib/request.js
+++ b/app/api/js-api/lib/request.js
@@ -1,4 +1,4 @@
-//@flow
+// @flow
 import https from 'https';
 import querystring from 'querystring';
 
@@ -17,7 +17,7 @@ export type RequestOptions = {
 export const request = (httpOptions: RequestOptions, queryParams?: {}) => {
   return new Promise((resolve, reject) => {
     // Prepare request with http options and (optional) query params
-    let options: RequestOptions = Object.assign({}, httpOptions);
+    const options: RequestOptions = Object.assign({}, httpOptions);
     let requestBody = '';
     if (queryParams) {
       requestBody = querystring.stringify(queryParams);
@@ -33,7 +33,7 @@ export const request = (httpOptions: RequestOptions, queryParams?: {}) => {
       // Cardano-sl returns chunked requests, so we need to concat them
       response.on('data', (chunk) => body += chunk);
       // Reject errors
-      request.on('error', (error) => reject(error));
+      response.on('error', (error) => reject(error));
       // Resolve JSON results and handle weird backend behavior
       // of "Left" (for errors) and "Right" (for success) properties
       response.on('end', () => {
@@ -41,12 +41,12 @@ export const request = (httpOptions: RequestOptions, queryParams?: {}) => {
         if (parsedBody.Right) {
           // "Right" means 200 ok (success)
           resolve(parsedBody.Right);
-        } else if(parsedBody.Left) {
+        } else if (parsedBody.Left) {
           // "Left" means error case -> return error with contents
           reject(new Error(parsedBody.Left.contents));
         } else {
           // TODO: investigate if that can happen! (no Right or Left in a response)
-          reject(new Error("Unknown response from backend."));
+          reject(new Error('Unknown response from backend.'));
         }
       });
     });

--- a/app/api/js-api/makePayment.js
+++ b/app/api/js-api/makePayment.js
@@ -1,6 +1,6 @@
 // @flow
-import { request } from './lib/request';
 import type { ApiTransaction } from 'daedalus-client-api';
+import { request } from './lib/request';
 
 export type MakePaymentPathParams = {
   from: string,


### PR DESCRIPTION
This PR introduces a fix for broken send-money feature for wallets with spending password.
This is a temporary workaround until js-api makePayment call is fixed.