### PR TITLE
Chore/DAEF 454 Testnet label for Release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Changelog
 - Implemented sync progress and payment requests with new JS api as first step to remove the purescript api ([PR 437](https://github.com/input-output-hk/daedalus/pull/437))
 - Speed optimizations for page reloads while running tests by loading bundled up for one-time tests runs ([PR 448](https://github.com/input-output-hk/daedalus/pull/445))
 - Optimized structure and naming of theming files ([PR 453](https://github.com/input-output-hk/daedalus/pull/453))
-- Added testnet label, loaded from translations for release candidate ([PR 454](https://github.com/input-output-hk/daedalus/pull/454))
+- Added testnet label, loaded from translations for release candidate ([PR 454](https://github.com/input-output-hk/daedalus/pull/460))
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Changelog
 - Implemented sync progress and payment requests with new JS api as first step to remove the purescript api ([PR 437](https://github.com/input-output-hk/daedalus/pull/437))
 - Speed optimizations for page reloads while running tests by loading bundled up for one-time tests runs ([PR 448](https://github.com/input-output-hk/daedalus/pull/445))
 - Optimized structure and naming of theming files ([PR 453](https://github.com/input-output-hk/daedalus/pull/453))
+- Added testnet label, loaded from translations for release candidate ([PR 454](https://github.com/input-output-hk/daedalus/pull/454))
 
 ## 0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Changelog
 - Implemented sync progress and payment requests with new JS api as first step to remove the purescript api ([PR 437](https://github.com/input-output-hk/daedalus/pull/437))
 - Speed optimizations for page reloads while running tests by loading bundled up for one-time tests runs ([PR 448](https://github.com/input-output-hk/daedalus/pull/445))
 - Optimized structure and naming of theming files ([PR 453](https://github.com/input-output-hk/daedalus/pull/453))
-- Added testnet label, loaded from translations for release candidate ([PR 454](https://github.com/input-output-hk/daedalus/pull/460))
+- Added testnet label, loaded from translations for release candidate ([PR 460](https://github.com/input-output-hk/daedalus/pull/460))
 
 ## 0.7.0
 

--- a/app/components/widgets/WalletTestEnvironmentLabel.js
+++ b/app/components/widgets/WalletTestEnvironmentLabel.js
@@ -1,17 +1,26 @@
 import React, { Component } from 'react';
+import { defineMessages, intlShape } from 'react-intl';
 import styles from './WalletTestEnvironmentLabel.scss';
+
+const messages = defineMessages({
+  testnetLabel: {
+    id: 'test.environment.testnetLabel',
+    defaultMessage: '!!!Testnet vx',
+    description: 'Label for testnet with version.'
+  },
+});
 
 export default class WalletTestEnvironmentLabel extends Component {
 
-  props: {
-    version: number,
+  static contextTypes = {
+    intl: intlShape.isRequired,
   };
 
   render() {
-    const { version } = this.props;
+    const { intl } = this.context;
     return (
       <div className={styles.component}>
-        Testnet v{version}
+        {intl.formatMessage(messages.testnetLabel)}
       </div>
     );
   }

--- a/app/containers/TopBarContainer.js
+++ b/app/containers/TopBarContainer.js
@@ -17,9 +17,8 @@ export default class TopBarContainer extends Component {
     const { actions, stores } = this.props;
     const { sidebar, networkStatus, app } = stores;
     const isMainnet = environment.isMainnet();
-    const testnetVersion = 0.5;
     const testnetLabel = (
-      !isMainnet ? <WalletTestEnvironmentLabel version={testnetVersion} /> : null
+      !isMainnet ? <WalletTestEnvironmentLabel /> : null
     );
 
     return (

--- a/app/i18n/locales/de-DE.json
+++ b/app/i18n/locales/de-DE.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "!!!2017.0.1 x64 Release",
   "static.about.title": "!!!Daedalus",
+  "test.environment.testnetLabel": "!!!Testnet vx",
   "wallet.add.dialog.create.description": "!!!Create a new wallet",
   "wallet.add.dialog.create.label": "!!!Create",
   "wallet.add.dialog.import.description": "!!!Import wallet from a file",

--- a/app/i18n/locales/defaultMessages.json
+++ b/app/i18n/locales/defaultMessages.json
@@ -428,13 +428,13 @@
         "description": "Label for the \"Theme\" selection on the display settings page.",
         "end": {
           "column": 3,
-          "line": 16
+          "line": 17
         },
         "file": "app/components/settings/categories/DisplaySettings.js",
         "id": "settings.display.themeLabel",
         "start": {
           "column": 14,
-          "line": 12
+          "line": 13
         }
       },
       {
@@ -442,13 +442,13 @@
         "description": "Name of the \"Light blue\" theme on the display settings page.",
         "end": {
           "column": 3,
-          "line": 21
+          "line": 22
         },
         "file": "app/components/settings/categories/DisplaySettings.js",
         "id": "settings.display.themeNames.lightBlue",
         "start": {
           "column": 18,
-          "line": 17
+          "line": 18
         }
       },
       {
@@ -456,13 +456,13 @@
         "description": "Name of the \"Cardano\" theme on the display settings page.",
         "end": {
           "column": 3,
-          "line": 26
+          "line": 27
         },
         "file": "app/components/settings/categories/DisplaySettings.js",
         "id": "settings.display.themeNames.cardano",
         "start": {
           "column": 16,
-          "line": 22
+          "line": 23
         }
       },
       {
@@ -470,13 +470,13 @@
         "description": "Name of the \"Dark blue\" theme on the display settings page.",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 32
         },
         "file": "app/components/settings/categories/DisplaySettings.js",
         "id": "settings.display.themeNames.darkBlue",
         "start": {
           "column": 17,
-          "line": 27
+          "line": 28
         }
       }
     ],
@@ -2430,13 +2430,13 @@
         "description": "Label for wallet address on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 27
+          "line": 26
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.walletAddressLabel",
         "start": {
           "column": 22,
-          "line": 23
+          "line": 22
         }
       },
       {
@@ -2444,13 +2444,13 @@
         "description": "Wallet receive payments instructions on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 32
+          "line": 31
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.walletReceiveInstructions",
         "start": {
           "column": 29,
-          "line": 28
+          "line": 27
         }
       },
       {
@@ -2458,13 +2458,13 @@
         "description": "Label for \"Generate new address\" button on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 37
+          "line": 36
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.generateNewAddressButtonLabel",
         "start": {
           "column": 33,
-          "line": 33
+          "line": 32
         }
       },
       {
@@ -2472,13 +2472,13 @@
         "description": "\"Generated addresses\" section title on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 42
+          "line": 41
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.generatedAddressesSectionTitle",
         "start": {
           "column": 34,
-          "line": 38
+          "line": 37
         }
       },
       {
@@ -2486,13 +2486,13 @@
         "description": "Label for \"hide used\" wallet addresses link on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 47
+          "line": 46
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.hideUsedLabel",
         "start": {
           "column": 17,
-          "line": 43
+          "line": 42
         }
       },
       {
@@ -2500,13 +2500,13 @@
         "description": "Label for \"show used\" wallet addresses link on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 52
+          "line": 51
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.showUsedLabel",
         "start": {
           "column": 17,
-          "line": 48
+          "line": 47
         }
       },
       {
@@ -2514,13 +2514,13 @@
         "description": "Placeholder for \"spending password\" on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 57
+          "line": 56
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.spendingPasswordPlaceholder",
         "start": {
           "column": 31,
-          "line": 53
+          "line": 52
         }
       },
       {
@@ -2528,13 +2528,13 @@
         "description": "Label for \"Copy address\" link on the wallet \"Receive page\"",
         "end": {
           "column": 3,
-          "line": 62
+          "line": 61
         },
         "file": "app/components/wallet/WalletReceive.js",
         "id": "wallet.receive.page.copyAddressLabel",
         "start": {
           "column": 20,
-          "line": 58
+          "line": 57
         }
       }
     ],
@@ -3321,6 +3321,25 @@
       }
     ],
     "path": "app/components/widgets/Transaction.json"
+  },
+  {
+    "descriptors": [
+      {
+        "defaultMessage": "!!!Testnet vx",
+        "description": "Label for testnet with version.",
+        "end": {
+          "column": 3,
+          "line": 10
+        },
+        "file": "app/components/widgets/WalletTestEnvironmentLabel.js",
+        "id": "test.environment.testnetLabel",
+        "start": {
+          "column": 16,
+          "line": 6
+        }
+      }
+    ],
+    "path": "app/components/widgets/WalletTestEnvironmentLabel.json"
   },
   {
     "descriptors": [

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "2017.0.1 x64 Release",
   "static.about.title": "Daedalus",
+  "test.environment.testnetLabel": "Release candidate",
   "wallet.add.dialog.create.description": "Create a new wallet",
   "wallet.add.dialog.create.label": "Create",
   "wallet.add.dialog.import.description": "Import wallet from a file",

--- a/app/i18n/locales/hr-HR.json
+++ b/app/i18n/locales/hr-HR.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "!!!2017.0.1 x64 Release",
   "static.about.title": "!!!Daedalus",
+  "test.environment.testnetLabel": "!!!Testnet vx",
   "wallet.add.dialog.create.description": "!!!Create a new wallet",
   "wallet.add.dialog.create.label": "!!!Create",
   "wallet.add.dialog.import.description": "!!!Import wallet from a file",

--- a/app/i18n/locales/ja-JP.json
+++ b/app/i18n/locales/ja-JP.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "!!!2017.0.1 x64 Release",
   "static.about.title": "!!!Daedalus",
+  "test.environment.testnetLabel": "リリース候補版",
   "wallet.add.dialog.create.description": "ウォレット新規作成",
   "wallet.add.dialog.create.label": "作成",
   "wallet.add.dialog.import.description": "ファイルからウォレットをインポートする",

--- a/app/i18n/locales/ko-KR.json
+++ b/app/i18n/locales/ko-KR.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "!!!2017.0.1 x64 Release",
   "static.about.title": "!!!Daedalus",
+  "test.environment.testnetLabel": "!!!Testnet vx",
   "wallet.add.dialog.create.description": "!!!Create a new wallet",
   "wallet.add.dialog.create.label": "!!!Create",
   "wallet.add.dialog.import.description": "!!!Import wallet from a file",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -88,6 +88,7 @@
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.release.version": "!!!2017.0.1 x64 Release",
   "static.about.title": "!!!Daedalus",
+  "test.environment.testnetLabel": "!!!Testnet vx",
   "wallet.add.dialog.create.description": "!!!Create a new wallet",
   "wallet.add.dialog.create.label": "!!!Create",
   "wallet.add.dialog.import.description": "!!!Import wallet from a file",


### PR DESCRIPTION
This PR replaces "Testnet v0.5" label with "Release candidate"  and refractors hardcoded value to be loaded from the translations.

![screen shot 2017-09-01 at 15 08 12](https://user-images.githubusercontent.com/4280521/29971262-f1304b98-8f27-11e7-976d-107815f7b59b.png)
![screen shot 2017-09-01 at 15 08 06](https://user-images.githubusercontent.com/4280521/29971263-f13644d0-8f27-11e7-913b-786b029dcdde.png)
