### PR TITLE
Fix/daef 466 Limit and validate Wallet name max length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Changelog
 - Improved QR code colors on wallet send screen for dark themes ([PR 448](https://github.com/input-output-hk/daedalus/pull/448))
 - Fixed failing acceptance-tests ([PR 454](https://github.com/input-output-hk/daedalus/pull/454))
 - Prevent application window auto focusing while running acceptance-tests ([PR 458](https://github.com/input-output-hk/daedalus/pull/458))
+- Limit and validate wallet's name maximum length ([PR 465](https://github.com/input-output-hk/daedalus/pull/465))
 
 ### Chores
 

--- a/app/components/sidebar/wallets/SidebarWalletMenuItem.js
+++ b/app/components/sidebar/wallets/SidebarWalletMenuItem.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames';
 import styles from './SidebarWalletMenuItem.scss';
-import { ellipsis } from '../../../lib/string-helpers';
 
 @observer
 export default class SidebarWalletMenuItem extends Component {
@@ -26,7 +25,7 @@ export default class SidebarWalletMenuItem extends Component {
     return (
       <button className={componentStyles} onClick={onClick}>
         <span className={styles.meta}>
-          <span className={styles.title}>{ellipsis(title, 17)}</span>
+          <span className={styles.title}>{title}</span>
           <span className={styles.info}>{info}</span>
         </span>
       </button>

--- a/app/components/sidebar/wallets/SidebarWalletMenuItem.scss
+++ b/app/components/sidebar/wallets/SidebarWalletMenuItem.scss
@@ -31,6 +31,7 @@
   display: flex;
   flex-direction: column;
   text-align: left;
+  width: 100%;
 }
 
 .title {
@@ -38,6 +39,8 @@
   font-family: var(--font-regular);
   font-size: 18px;
   line-height: 1.5em;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -28,7 +28,7 @@ export default defineMessages({
   },
   invalidWalletName: {
     id: 'global.errors.invalidWalletName',
-    defaultMessage: '!!!The wallet name must have at least 3 letters.',
+    defaultMessage: '!!!Requires at least 3 and at most 40 letters.',
     description: 'Error message shown when invalid wallet name was entered in create wallet dialog.'
   },
   invalidWalletPassword: {

--- a/app/i18n/global-messages.js
+++ b/app/i18n/global-messages.js
@@ -28,7 +28,7 @@ export default defineMessages({
   },
   invalidWalletName: {
     id: 'global.errors.invalidWalletName',
-    defaultMessage: '!!!Requires at least 3 and at most 40 letters.',
+    defaultMessage: '!!!Wallet name requires at least 3 and at most 40 letters.',
     description: 'Error message shown when invalid wallet name was entered in create wallet dialog.'
   },
   invalidWalletPassword: {

--- a/app/i18n/locales/de-DE.json
+++ b/app/i18n/locales/de-DE.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!The wallet name must have at least 3 letters.",
+  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/de-DE.json
+++ b/app/i18n/locales/de-DE.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
+  "global.errors.invalidWalletName": "!!!Wallet name requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/defaultMessages.json
+++ b/app/i18n/locales/defaultMessages.json
@@ -3485,7 +3485,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Requires at least 3 and at most 40 letters.",
+        "defaultMessage": "!!!Wallet name requires at least 3 and at most 40 letters.",
         "description": "Error message shown when invalid wallet name was entered in create wallet dialog.",
         "end": {
           "column": 3,

--- a/app/i18n/locales/defaultMessages.json
+++ b/app/i18n/locales/defaultMessages.json
@@ -3485,7 +3485,7 @@
         }
       },
       {
-        "defaultMessage": "!!!The wallet name must have at least 3 letters.",
+        "defaultMessage": "!!!Requires at least 3 and at most 40 letters.",
         "description": "Error message shown when invalid wallet name was entered in create wallet dialog.",
         "end": {
           "column": 3,

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "Doesn't match",
-  "global.errors.invalidWalletName": "Requires at least 3 and at most 40 letters.",
+  "global.errors.invalidWalletName": "Wallet name requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "Invalid password",
   "global.labels.cancel": "Cancel",
   "global.labels.change": "Change",

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "Doesn't match",
-  "global.errors.invalidWalletName": "Requires at least 3 letters.",
+  "global.errors.invalidWalletName": "Requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "Invalid password",
   "global.labels.cancel": "Cancel",
   "global.labels.change": "Change",

--- a/app/i18n/locales/hr-HR.json
+++ b/app/i18n/locales/hr-HR.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!The wallet name must have at least 3 letters.",
+  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/hr-HR.json
+++ b/app/i18n/locales/hr-HR.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
+  "global.errors.invalidWalletName": "!!!Wallet name requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/ja-JP.json
+++ b/app/i18n/locales/ja-JP.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "無効なメールアドレスです、再度確認してください。",
   "global.errors.invalidMnemonic": "無効なパスフレーズが入力されました、再度確認してください。",
   "global.errors.invalidRepeatPassword": "パスワードが一致しません",
-  "global.errors.invalidWalletName": "３文字以上のウォレット名を入力してください。",
+  "global.errors.invalidWalletName": "ウォレット名は3文字以上40文字以内である必要があります",
   "global.errors.invalidWalletPassword": "無効なパスワード",
   "global.labels.cancel": "キャンセル",
   "global.labels.change": "変更",

--- a/app/i18n/locales/ko-KR.json
+++ b/app/i18n/locales/ko-KR.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!The wallet name must have at least 3 letters.",
+  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/ko-KR.json
+++ b/app/i18n/locales/ko-KR.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
+  "global.errors.invalidWalletName": "!!!Wallet name requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!The wallet name must have at least 3 letters.",
+  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/i18n/locales/zh-CN.json
+++ b/app/i18n/locales/zh-CN.json
@@ -25,7 +25,7 @@
   "global.errors.invalidEmail": "!!!Invalid email entered, please check.",
   "global.errors.invalidMnemonic": "!!!Invalid phrase entered, please check.",
   "global.errors.invalidRepeatPassword": "!!!Doesn't match",
-  "global.errors.invalidWalletName": "!!!Requires at least 3 and at most 40 letters.",
+  "global.errors.invalidWalletName": "!!!Wallet name requires at least 3 and at most 40 letters.",
   "global.errors.invalidWalletPassword": "!!!Invalid password",
   "global.labels.cancel": "!!!Cancel",
   "global.labels.change": "!!!Change",

--- a/app/lib/validations.js
+++ b/app/lib/validations.js
@@ -1,7 +1,10 @@
 import BigNumber from 'bignumber.js';
 import isInt from 'validator/lib/isInt';
 
-export const isValidWalletName = (walletName) => walletName.length >= 3;
+export const isValidWalletName = (walletName) => {
+  const nameLength = walletName.length;
+  return nameLength >= 3 && nameLength <= 40;
+};
 
 export const isValidWalletPassword = (walletPassword) => {
   // Validation rules:


### PR DESCRIPTION
This PR introduces maximum length validation (and limiting) of wallet name attribute.
Wallet name maximum length is set to 40 characters.
In the scope of this PR sidebar styling was updated - until now wallet name shown sidebar items was truncated via char count (which has different results based on width of individual characters) and now we use more precise CSS method (text-oveflow: ellipsis).

## TODO
- [x] Inject update Japanese translation for invalid wallet name error message:
```
"global.errors.invalidWalletName": "Requires at least 3 and at most 40 letters."
```

![screen shot 2017-09-05 at 13 43 25](https://user-images.githubusercontent.com/376611/30060142-69f4a08e-9242-11e7-884a-be322adb4be6.png)
 