### PR TITLE
[DEVOPS-304] Subsequent Windows installs reuse install dir

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -113,11 +113,16 @@ writeInstallerNSIS fullVersion = do
     unsafeInjectGlobal $ "VIProductVersion " <> (L.intercalate "." $ parseVersion fullVersion)
     unsafeInjectGlobal $ "VIAddVersionKey \"ProductVersion\" " <> fullVersion
     unsafeInjectGlobal "Unicode true"
-    installDir "$PROGRAMFILES64\\Daedalus"   -- The default installation directory
     requestExecutionLevel Highest
     unsafeInjectGlobal "!addplugindir \"nsis_plugins\\liteFirewall\\bin\""
 
+    installDir "$PROGRAMFILES64\\Daedalus"                   -- Default installation directory...
+    installDirRegKey HKLM "Software/Daedalus" "Install_Dir"  -- ...except when already installed.
+
     page Directory                   -- Pick where to install
+    constant "INSTALLEDAT" $ readRegStr HKLM "Software/Daedalus" "Install_Dir"
+    onPagePre Directory (iff_ (strLength "$INSTALLEDAT" %/= 0) $ abort "")
+
     page InstFiles                   -- Give a progress bar while installing
 
     _ <- section "" [Required] $ do


### PR DESCRIPTION
Primary motivation is to avoid an update installation clashing with an older version.