### PR TITLE
build-certificates-win64.bat:  fix logging for space-ful %APPDATA%.

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -147,7 +147,7 @@ writeInstallerNSIS fullVersion = do
           , "DetailPrint \"liteFirewall::AddRule: $0\""
           ]
 
-        exec "build-certificates-win64.bat \"$INSTDIR\" >%APPDATA%\\Daedalus\\Logs\\build-certificates.log 2>&1"
+        exec "build-certificates-win64.bat \"$INSTDIR\" >\"%APPDATA%\\Daedalus\\Logs\\build-certificates.log\" 2>&1"
 
         -- Uninstaller
         writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "InstallLocation" "$INSTDIR\\Daedalus"


### PR DESCRIPTION
This fixes log writing in case `%APPDATA%` has spaces in it -- mostly due to user name.