### PR TITLE
[DEVOPS-317] Windows installer: build cert synchronously (#475)

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -147,7 +147,7 @@ writeInstallerNSIS fullVersion = do
           , "DetailPrint \"liteFirewall::AddRule: $0\""
           ]
 
-        exec "build-certificates-win64.bat \"$INSTDIR\" >\"%APPDATA%\\Daedalus\\Logs\\build-certificates.log\" 2>&1"
+        execWait "build-certificates-win64.bat \"$INSTDIR\" >\"%APPDATA%\\Daedalus\\Logs\\build-certificates.log\" 2>&1"
 
         -- Uninstaller
         writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "InstallLocation" "$INSTDIR\\Daedalus"


### PR DESCRIPTION
It's possible for the Windows installer to "finish" before the build
certificates script has finished.