### PR TITLE
Fix/daef 480 Fix minor react-polymorph dropdown bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changelog
 - Fix all features eslint warnings ([PR 468](https://github.com/input-output-hk/daedalus/pull/468))
 - Fix for disabled buttons on dark-blue theme ([PR 473](https://github.com/input-output-hk/daedalus/pull/473))
 - Remove maximum screen width and height in full-screen mode ([PR 472](https://github.com/input-output-hk/daedalus/pull/472))
+- Fix "label click" dropdown issue in react-polymorph ([PR 479](https://github.com/input-output-hk/daedalus/pull/479))
 
 ### Chores
 

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -145,9 +145,9 @@ export default class NetworkStatusStore extends Store {
         }
         // Update the local and network difficulties on each request
         this.localDifficulty = difficulty.localDifficulty;
-        Logger.debug('Network difficulty changed: ' + this.networkDifficulty);
+        Logger.debug('Local difficulty changed: ' + this.localDifficulty);
         this.networkDifficulty = difficulty.networkDifficulty;
-        Logger.debug('Local difficulty changed: ' + this.networkDifficulty);
+        Logger.debug('Network difficulty changed: ' + this.networkDifficulty);
       });
     } catch (error) {
       // If the sync progress request fails, switch to disconnected state

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "react-intl": "2.2.3",
     "react-markdown": "2.5.0",
     "react-number-format": "1.1.2",
-    "react-polymorph": "0.3.1",
+    "react-polymorph": "0.3.3",
     "react-router": "3.0.3",
     "react-svg-inline": "2.0.0",
     "recharts": "1.0.0-alpha.4",


### PR DESCRIPTION
This bumps the version of react-polymorph to 0.3.3 which includes a fix for the dropdown label clicking issue (did open but not close on label click).

Todo:
- [x] i need a working backend to confirm that this works correctly in the running app