### PR TITLE
[CSM-458] Query `postponeUpdate` endpoint when postponing the update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 ### Features
 
+- Postpone Update Api call integration ([PR 485](https://github.com/input-output-hk/daedalus/pull/485))
+
 ### Fixes
 
 - Fix all features eslint warnings ([PR 468](https://github.com/input-output-hk/daedalus/pull/468))

--- a/app/api/CardanoClientApi.js
+++ b/app/api/CardanoClientApi.js
@@ -518,6 +518,17 @@ export default class CardanoClientApi {
     // return null;
   }
 
+  async postponeUpdate() {
+    Logger.debug('CardanoClientApi::postponeUpdate called');
+    try {
+      const response = await ClientApi.postponeUpdate(tlsConfig);
+      Logger.debug('CardanoClientApi::postponeUpdate success: ' + stringifyData(response));
+    } catch (error) {
+      Logger.error('CardanoClientApi::postponeUpdate error: ' + stringifyError(error));
+      throw new GenericApiError();
+    }
+  }
+
   async applyUpdate() {
     Logger.debug('CardanoClientApi::applyUpdate called');
     try {

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -122,6 +122,8 @@ export type NextUpdateResponse = {
   version: string,
 };
 
+export type PostponeUpdateResponse = void;
+
 export type ApplyUpdateResponse = void;
 
 export type UpdateWalletPasswordRequest = {
@@ -173,6 +175,7 @@ export type Api = {
   redeemPaperVendedAda(request: RedeemPaperVendedAdaRequest): Promise<RedeemPaperVendedAdaResponse>,
   generateMnemonic(): string,
   nextUpdate(): Promise<NextUpdateResponse>,
+  postponeUpdate(): PostponeUpdateResponse,
   applyUpdate(): ApplyUpdateResponse,
   getSyncProgress(): Promise<GetSyncProgressResponse>,
   setUserLocale(locale: string): Promise<string>,

--- a/app/stores/NodeUpdateStore.js
+++ b/app/stores/NodeUpdateStore.js
@@ -3,7 +3,11 @@ import { observable, action } from 'mobx';
 import Store from './lib/Store';
 import Request from './lib/LocalizedRequest';
 import environment from '../environment';
-import type { NextUpdateResponse, PostponeUpdateResponse, ApplyUpdateResponse } from '../api';
+import type {
+  NextUpdateResponse,
+  PostponeUpdateResponse,
+  ApplyUpdateResponse,
+} from '../api';
 
 export default class NodeUpdateStore extends Store {
 
@@ -14,9 +18,13 @@ export default class NodeUpdateStore extends Store {
   @observable isNotificationExpanded = false;
   @observable isUpdateInstalled = false;
   @observable updateVersion = null;
+
+  // REQUESTS
+  /* eslint-disable max-len */
   @observable nextUpdateRequest: Request<NextUpdateResponse> = new Request(this.api.nextUpdate);
   @observable postponeUpdateRequest: Request<PostponeUpdateResponse> = new Request(this.api.postponeUpdate);
   @observable applyUpdateRequest: Request<ApplyUpdateResponse> = new Request(this.api.applyUpdate);
+  /* eslint-disable max-len */
 
   setup() {
     const actions = this.actions.nodeUpdate;

--- a/app/stores/NodeUpdateStore.js
+++ b/app/stores/NodeUpdateStore.js
@@ -3,7 +3,7 @@ import { observable, action } from 'mobx';
 import Store from './lib/Store';
 import Request from './lib/LocalizedRequest';
 import environment from '../environment';
-import type { NextUpdateResponse, ApplyUpdateResponse } from '../api';
+import type { NextUpdateResponse, PostponeUpdateResponse, ApplyUpdateResponse } from '../api';
 
 export default class NodeUpdateStore extends Store {
 
@@ -15,6 +15,7 @@ export default class NodeUpdateStore extends Store {
   @observable isUpdateInstalled = false;
   @observable updateVersion = null;
   @observable nextUpdateRequest: Request<NextUpdateResponse> = new Request(this.api.nextUpdate);
+  @observable postponeUpdateRequest: Request<PostponeUpdateResponse> = new Request(this.api.postponeUpdate);
   @observable applyUpdateRequest: Request<ApplyUpdateResponse> = new Request(this.api.applyUpdate);
 
   setup() {
@@ -40,6 +41,7 @@ export default class NodeUpdateStore extends Store {
   };
 
   @action _postponeNodeUpdate = () => {
+    this.postponeUpdateRequest.execute();
     this.isUpdatePostponed = true;
   };
 

--- a/flow/declarations/DaedalusClientApi.js
+++ b/flow/declarations/DaedalusClientApi.js
@@ -75,6 +75,7 @@ declare module 'daedalus-client-api' {
   // Status
   declare function notify(tls: TlsConfig, onSuccess: Function, onError?: Function): void;
   declare function nextUpdate(tls: TlsConfig): any;
+  declare function postponeUpdate(tls: TlsConfig): any;
   declare function applyUpdate(tls: TlsConfig): any;
   declare function syncProgress(tls: TlsConfig): any;
 


### PR DESCRIPTION
These changes should make Daedalus query `postponeUpdate` endpoint on postponing the update. The endpoint is introduced in https://github.com/input-output-hk/cardano-sl/pull/1586. This is needed to avoid problem with postponing the update described in https://issues.serokell.io/issue/CSM-458?query=%23CSM%20-Resolved