### PR TITLE
Chore/daef 494 Set dark-theme as default one for the mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changelog
 
 ### Chores
 
+- Set Dark theme as default one for the mainnet ([PR 497](https://github.com/input-output-hk/daedalus/pull/497))
+
 ## 0.8.0
 
 ### Features

--- a/app/stores/AppStore.js
+++ b/app/stores/AppStore.js
@@ -77,7 +77,7 @@ export default class AppStore extends Store {
   @computed get currentTheme(): string {
     const { result } = this.getThemeRequest.execute();
     if (this.isCurrentThemeSet) return result;
-    return environment.isMainnet() ? THEMES.CARDANO : THEMES.LIGHT_BLUE; // default
+    return environment.isMainnet() ? THEMES.DARK_BLUE : THEMES.LIGHT_BLUE; // default
   }
 
   @computed get isCurrentThemeSet(): boolean {


### PR DESCRIPTION
This PR sets the dark theme as the default one for the `mainnet`.
To see this change while testing don't forget to run Daedalus with `NETWORK=mainnet npm run dev`.

![screen shot 2017-09-22 at 12 04 16](https://user-images.githubusercontent.com/376611/30739677-8563904c-9f8e-11e7-86e8-6471332398fd.png)
