### PR TITLE
Fix/daef 508 Disable wallet file imports for mainnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog
 - Fix "label prop type" checkbox issue in react-polymorph ([PR 487](https://github.com/input-output-hk/daedalus/pull/487))
 - Remove all drag and drop instructions from UI ([PR 495](https://github.com/input-output-hk/daedalus/pull/495))
 - Preferences saved to local storage prefixed with network ([PR 501](https://github.com/input-output-hk/daedalus/pull/501))
+- Disable wallet import feature for the mainnet ([PR 503](https://github.com/input-output-hk/daedalus/pull/503))
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Changelog
 - Fix "label prop type" checkbox issue in react-polymorph ([PR 487](https://github.com/input-output-hk/daedalus/pull/487))
 - Remove all drag and drop instructions from UI ([PR 495](https://github.com/input-output-hk/daedalus/pull/495))
 - Preferences saved to local storage prefixed with network ([PR 501](https://github.com/input-output-hk/daedalus/pull/501))
-- Disable wallet import feature for the mainnet ([PR 503](https://github.com/input-output-hk/daedalus/pull/503))
+- Disable wallet import and export features for the mainnet ([PR 503](https://github.com/input-output-hk/daedalus/pull/503))
 
 ### Chores
 

--- a/app/components/wallet/WalletAddDialog.js
+++ b/app/components/wallet/WalletAddDialog.js
@@ -11,6 +11,7 @@ import createIcon from '../../assets/images/create-ic.inline.svg';
 import importIcon from '../../assets/images/import-ic.inline.svg';
 import joinSharedIcon from '../../assets/images/join-shared-ic.inline.svg';
 import restoreIcon from '../../assets/images/restore-ic.inline.svg';
+import environment from '../../environment';
 
 const messages = defineMessages({
   title: {
@@ -121,6 +122,7 @@ export default class WalletAddDialog extends Component {
               icon={importIcon}
               label={intl.formatMessage(messages.importLabel)}
               description={intl.formatMessage(messages.importDescription)}
+              isDisabled={environment.isMainnet()}
             />
           </div>
         </div>

--- a/app/components/wallet/WalletSettings.js
+++ b/app/components/wallet/WalletSettings.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { defineMessages, intlShape } from 'react-intl';
 import moment from 'moment';
+import environment from '../../environment';
 import LocalizableError from '../../i18n/LocalizableError';
 import BorderedBox from '../widgets/BorderedBox';
 import InlineEditingInput from '../widgets/forms/InlineEditingInput';
@@ -178,14 +179,16 @@ export default class WalletSettings extends Component {
           {error && <p className={styles.error}>{intl.formatMessage(error)}</p>}
 
           <div className={styles.actionButtons}>
-            <button
-              className={styles.exportLink}
-              onClick={() => openDialogAction({
-                dialog: WalletExportDialog
-              })}
-            >
-              {intl.formatMessage(messages.exportButtonLabel)}
-            </button>
+            {!environment.isMainnet() ? (
+              <button
+                className={styles.exportLink}
+                onClick={() => openDialogAction({
+                  dialog: WalletExportDialog
+                })}
+              >
+                {intl.formatMessage(messages.exportButtonLabel)}
+              </button>
+            ) : null}
 
             <DeleteWalletButton
               onClick={() => openDialogAction({


### PR DESCRIPTION
This PR disables wallet file import AND export features for mainnet only. The features will still work in TN.

## Mainnet
![screen shot 2017-09-26 at 12 46 07](https://user-images.githubusercontent.com/376611/30856520-ea82ad14-a2b8-11e7-8d6c-50e84c4bddd5.png)
![screen shot 2017-09-26 at 13 23 03](https://user-images.githubusercontent.com/376611/30857951-f900c452-a2bd-11e7-910a-ced720ab0b30.png)


## Testnet
![screen shot 2017-09-26 at 12 45 21](https://user-images.githubusercontent.com/376611/30856525-eed5cff4-a2b8-11e7-81e7-49e03a95577c.png)
![screen shot 2017-09-26 at 13 22 17](https://user-images.githubusercontent.com/376611/30857955-fbcb209c-a2bd-11e7-8a02-fb10c7cfad12.png)

