### PR TITLE
Chore/daef 509 Move log to pub folder and remove crash reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 
 - Update version in About dialog to 0.8.2 ([PR 496](https://github.com/input-output-hk/daedalus/pull/496))
 - Set Dark theme as default one for the mainnet ([PR 497](https://github.com/input-output-hk/daedalus/pull/497))
+- Log file moved to public folder and Electron crash reporter removed ([PR 505](https://github.com/input-output-hk/daedalus/pull/505))
 
 ## 0.8.0
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Menu, shell, ipcMain, crashReporter, globalShortcut } from 'electron';
+import { app, BrowserWindow, Menu, shell, ipcMain, globalShortcut } from 'electron';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
@@ -13,7 +13,7 @@ const APP_NAME = 'Daedalus';
 // Configure default logger levels for console and file outputs
 const runtimeFolderPath = getRuntimeFolderPath(process.platform, process.env, APP_NAME);
 const appLogFolderPath = path.join(runtimeFolderPath, 'Logs');
-const logFilePath = path.join(appLogFolderPath, APP_NAME + '.log');
+const logFilePath = path.join(appLogFolderPath, 'pub', APP_NAME + '.log');
 Log.transports.console.level = 'warn';
 Log.transports.file.level = 'debug';
 Log.transports.file.file = logFilePath;
@@ -32,17 +32,6 @@ try {
 } catch (error) {
   Log.error('Error setting up log logging to remote server', error);
 }
-
-// Configure & start crash reporter
-app.setPath('temp', appLogFolderPath);
-
-// TODO: Update when endpoint is ready (crash reports are only saved locally for now)
-crashReporter.start({
-  companyName: 'IOHK',
-  productName: APP_NAME,
-  submitURL: '',
-  uploadToServer: false
-});
 
 Log.info(`========== Daedalus is starting at ${new Date()} ==========`);
 Log.info(`!!! Daedalus is running on ${os.platform()} version ${os.release()}


### PR DESCRIPTION
Moves frontend log file to `Logs/pub` folder and removes currently unused Electron crash reporter.