### PR TITLE
Remove maximum window size limitations

### DIFF
--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -185,7 +185,6 @@ app.on('ready', async () => {
   });
 
   mainWindow.setMinimumSize(900, 600);
-  mainWindow.setMaximumSize(1500, 2500);
 
   // Initialize our ipc api methods that can be called by the render processes
   ipcApi({ mainWindow });


### PR DESCRIPTION
Limiting setMaximumSize does not really serve a purpose. It is actually more annoying to not being able to maximize the window on a 13" retina display.