### PR TITLE
[DAEF-513] only send error logs to papertrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changelog
 
 - Update version in About dialog to 0.8.2 ([PR 496](https://github.com/input-output-hk/daedalus/pull/496))
 - Set Dark theme as default one for the mainnet ([PR 497](https://github.com/input-output-hk/daedalus/pull/497))
+- Only log errors to papertrail ([PR 509](https://github.com/input-output-hk/daedalus/pull/509))
 
 ## 0.8.0
 

--- a/app/lib/logger.js
+++ b/app/lib/logger.js
@@ -7,12 +7,10 @@ export const Logger = {
 
   debug: (data: string) => {
     Log.debug(data);
-    Logger.sendToRemote('debug', data);
   },
 
   info: (data: string) => {
     Log.info(data);
-    Logger.sendToRemote('info', data);
   },
 
   error: (data: string) => {
@@ -22,7 +20,6 @@ export const Logger = {
 
   warn: (data: string) => {
     Log.info(data);
-    Logger.sendToRemote('warn', data);
   },
 
   sendToRemote: (type: string, data: string) => {


### PR DESCRIPTION
This PR changes the logging logic so that we only send errors to papertrail.