### PR TITLE
[CSL-1747] Adapt to newer launcher features

### DIFF
--- a/installers/Launcher.hs
+++ b/installers/Launcher.hs
@@ -20,6 +20,7 @@ data Updater =
 data Launcher = Launcher
     { nodePath             :: FilePath
     , nodeLogPath          :: FilePath
+    , launcherLogPath      :: FilePath
     , walletPath           :: FilePath
     , runtimePath          :: FilePath
     , updater              :: Updater
@@ -32,8 +33,9 @@ launcherArgs Launcher{..} = unwords $
   [ "--node", quote nodePath
   , "--node-log-path", quote nodeLogPath
   , "--wallet", quote walletPath
+  , "--launcher-logs-prefix", quote launcherLogPath
   ] ++ updaterLArgs ++ configurationArgs ++
-  [ "--node-timeout 5 " ++ batchCmdNewline
+  [ "--node-timeout 30 " ++ batchCmdNewline
   , unwords $ map (\x ->  batchCmdNewline ++ "-n " ++ x) nodeArgs
   ]
     where

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -105,6 +105,7 @@ doLauncher = "./cardano-launcher " <> (launcherArgs $ Launcher
   { nodePath = "./cardano-node"
   , walletPath = "./Frontend"
   , nodeLogPath = appdata <> "Logs/cardano-node.log"
+  , launcherLogPath = appdata <> "Logs/pub/"
   , windowsInstallerPath = Nothing
   , runtimePath = appdata
   , updater =

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -24,6 +24,7 @@ launcherScript =
       { nodePath = "%DAEDALUS_DIR%\\cardano-node.exe"
       , nodeLogPath = "%APPDATA%\\Daedalus\\Logs\\cardano-node.log"
       , walletPath = "%DAEDALUS_DIR%\\Daedalus.exe"
+      , launcherLogPath = "%APPDATA%\\Daedalus\\Logs\\pub\\"
       , windowsInstallerPath = Just "%APPDATA%\\Daedalus\\Installer.bat"
       , updater =
           SelfUnpacking


### PR DESCRIPTION
**Note: this PR shouldn't be merged until https://github.com/input-output-hk/cardano-sl/pull/1840 is merged.**

This PR does two things:
* it instructs the launcher to write its logs into `Logs/pub`
* it increases the node killing timeout to 30s (from 5s) because now the launcher uses SIGKILL and sigkilling the node after it's been given only 5×2 seconds to terminate is too harsh