### PR TITLE
Fix/daef 537 correctly prevent max-window-size in electron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 - Fix error message text for A to A transaction error ([PR 484](https://github.com/input-output-hk/daedalus/pull/484))
 - Fix "label prop type" checkbox issue in react-polymorph ([PR 487](https://github.com/input-output-hk/daedalus/pull/487))
 - Remove all drag and drop instructions from UI ([PR 495](https://github.com/input-output-hk/daedalus/pull/495))
+- Correctly prevent max-window-size in electron ([PR 532](https://github.com/input-output-hk/daedalus/pull/532))
 
 ### Chores
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -236,15 +236,6 @@ app.on('ready', async () => {
     mainWindow.setMenu(menu);
   }
 
-  // Unset max height/width in fullscreen
-  mainWindow.on('enter-full-screen', () => {
-    mainWindow.setMaximumSize(2147483647, 2147483647);
-  });
-
-  mainWindow.on('leave-full-screen', () => {
-    mainWindow.setMaximumSize(1500, 2500);
-  });
-
   // Hide application window on Cmd+H hotkey (OSX only!)
   if (process.platform === 'darwin') {
     app.on('activate', () => {


### PR DESCRIPTION
This PR introduces a fix which correctly prevents max-window-size in electron.