### PR TITLE
Fix/daef 544 Hide wallet import/restore notification message once process is done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog
 - Preferences saved to local storage prefixed with network ([PR 501](https://github.com/input-output-hk/daedalus/pull/501))
 - Disable wallet import and export features for the mainnet ([PR 503](https://github.com/input-output-hk/daedalus/pull/503))
 - Correctly prevent max-window-size in electron ([PR 532](https://github.com/input-output-hk/daedalus/pull/532))
+- Make sure wallet import and restore in-progress notification is hidden once process is done ([PR 540](https://github.com/input-output-hk/daedalus/pull/540))
 
 ### Chores
 

--- a/app/stores/WalletsStore.js
+++ b/app/stores/WalletsStore.js
@@ -236,7 +236,7 @@ export default class WalletsStore extends Store {
     setTimeout(() => {
       if (!this.restoreRequest.isError) {
         this.actions.dialogs.closeActiveDialog.trigger();
-        this._setIsRestoreActive(true);
+        if (this.restoreRequest.isExecuting) this._setIsRestoreActive(true);
       }
     }, 500);
 
@@ -260,7 +260,7 @@ export default class WalletsStore extends Store {
     setTimeout(() => {
       if (!this.importFromFileRequest.isError) {
         this.actions.dialogs.closeActiveDialog.trigger();
-        this._setIsImportActive(true);
+        if (this.importFromFileRequest.isExecuting) this._setIsImportActive(true);
       }
     }, 500);
 


### PR DESCRIPTION
This PR introduces a fix which takes care of hiding import/restore in-progress notification once this process is done. The issue was exposed in development mode where import/restore is finished within 500ms.