### PR TITLE
[DAEF-542] handle special etc tx errors

### DIFF
--- a/app/api/etc/errors.js
+++ b/app/api/etc/errors.js
@@ -1,0 +1,33 @@
+import { defineMessages } from 'react-intl';
+import LocalizableError from '../../i18n/LocalizableError';
+
+const messages = defineMessages({
+  noKeyForGivenAddress: {
+    id: 'api.errors.etc.NoKeyForGivenAddress',
+    defaultMessage: '!!!No key found for given address.',
+    description: 'Error message that is displayed when no key was found for a given address.'
+  },
+  accountLockedOrUnknown: {
+    id: 'api.errors.etc.AccountLockedOrUnknown',
+    defaultMessage: '!!!Account is locked or unknown',
+    description: 'Error message that is displayed when account is locked or unknown.'
+  },
+});
+
+export class NoKeyForGivenAddress extends LocalizableError {
+  constructor() {
+    super({
+      id: messages.noKeyForGivenAddress.id,
+      defaultMessage: messages.noKeyForGivenAddress.defaultMessage,
+    });
+  }
+}
+
+export class AccountLockedOrUnknown extends LocalizableError {
+  constructor() {
+    super({
+      id: messages.accountLockedOrUnknown.id,
+      defaultMessage: messages.accountLockedOrUnknown.defaultMessage,
+    });
+  }
+}

--- a/app/api/etc/index.js
+++ b/app/api/etc/index.js
@@ -42,6 +42,7 @@ import type { GetEtcTransactionByHashResponse } from './getEtcTransaction';
 import type { GetEtcTransactionsResponse } from './getEtcTransactions';
 import type { EtcTransaction } from './types';
 import type { TransactionType } from '../../domain/WalletTransaction';
+import { AccountLockedOrUnknown, NoKeyForGivenAddress } from './errors';
 
 // Load Dummy ETC Wallets into Local Storage
 (async () => {
@@ -229,6 +230,10 @@ export default class EtcApi {
       Logger.error('EtcApi::createTransaction error: ' + stringifyError(error));
       if (error.message.includes('Could not decrypt key with given passphrase')) {
         throw new IncorrectWalletPasswordError();
+      } else if (error.message.includes('No key found for the given address')) {
+        throw new NoKeyForGivenAddress();
+      } else if (error.message.includes('account is locked or unknown')) {
+        throw new AccountLockedOrUnknown();
       }
       throw new GenericApiError();
     }

--- a/app/i18n/locales/en-US.json
+++ b/app/i18n/locales/en-US.json
@@ -13,6 +13,8 @@
   "api.errors.WalletAlreadyImportedError": "Wallet you are trying to import already exists.",
   "api.errors.WalletAlreadyRestoredError": "Wallet you are trying to restore already exists.",
   "api.errors.WalletFileImportError": "Wallet could not be imported, please make sure you are providing a correct file.",
+  "api.errors.etc.NoKeyForGivenAddress": "No key found for given address.",
+  "api.errors.etc.AccountLockedOrUnknown": "Account is locked or unknown",
   "cardano.node.sync.status.blocksSynced": "Blocks synced {percentage}%",
   "cardano.node.update.notification.accept.button.label": "Update and restart",
   "cardano.node.update.notification.message": "Daedalus and Cardano node update is available. Would you like to install the update?",


### PR DESCRIPTION
This PR adds handling of special errors that can be thrown by the mantis backend when sending ETC.

```
personal_sendTransaction:
    LogicError("No key found for the given address")
    LogicError("account is locked or unknown")
```

# WAITING FOR from Mantis team:

- [ ] Explanation of what these error messages actually mean for the end user / Daedalus (so we can write up a proper error message
- [x] How can we trigger/test these errors with Daedalus?
- [ ] my mantis/daedalus setup is broken so i could not properly test these