### PR TITLE
Chore/daef 553 get test reset working for etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog
 - Update flow-bin to version `0.59.0` ([PR 544](https://github.com/input-output-hk/daedalus/pull/544))
 - Cleanup and standardization of ETC Api calls ([PR 549](https://github.com/input-output-hk/daedalus/pull/549))
 - Unused vendor dependencies cleanup and DLL file optimization ([PR 555](https://github.com/input-output-hk/daedalus/pull/555))
+- Introduce `testReset` endpoint for ETC api ([PR 558](https://github.com/input-output-hk/daedalus/pull/558))
 
 ## 0.8.0
 

--- a/app/api/etc/index.js
+++ b/app/api/etc/index.js
@@ -122,9 +122,8 @@ export default class EtcApi {
   getWallets = async (): Promise<GetWalletsResponse> => {
     Logger.debug('EtcApi::getWallets called');
     try {
-      const response: GetEtcAccountsResponse = await getEtcAccounts({ ca });
-      Logger.debug('EtcApi::getWallets success: ' + stringifyData(response));
-      const accounts = response;
+      const accounts: GetEtcAccountsResponse = await getEtcAccounts({ ca });
+      Logger.debug('EtcApi::getWallets success: ' + stringifyData(accounts));
       return await Promise.all(accounts.map(async (id) => {
         const amount = await this.getAccountBalance(id);
         try {
@@ -218,7 +217,7 @@ export default class EtcApi {
       return new Wallet({ id, name, amount, assurance, hasPassword, passwordUpdateDate });
     } catch (error) {
       Logger.error('EtcApi::importWallet error: ' + stringifyError(error));
-      throw new GenericApiError();
+      throw error; // Error is handled in parent method (e.g. createWallet/restoreWallet)
     }
   }
 
@@ -251,7 +250,7 @@ export default class EtcApi {
   }
 
   async createTransaction(params: CreateTransactionRequest): CreateTransactionResponse {
-    Logger.debug('EtcApi::createTransaction called with ' + stringifyData(params));
+    Logger.debug('EtcApi::createTransaction called');
     try {
       const senderAccount = params.from;
       const { from, to, value, password } = params;
@@ -365,7 +364,7 @@ export default class EtcApi {
     }
   }
 
-  async testReset(): Promise<boolean> {
+  testReset = async (): Promise<boolean> => {
     Logger.debug('EtcApi::testReset called');
     try {
       const accounts: GetEtcAccountsResponse = await getEtcAccounts({ ca });

--- a/app/api/etc/index.js
+++ b/app/api/etc/index.js
@@ -355,6 +355,19 @@ export default class EtcApi {
       throw new GenericApiError();
     }
   }
+
+  async testReset(): Promise<boolean> {
+    Logger.debug('EtcApi::testReset called');
+    try {
+      const accounts: GetEtcAccountsResponse = await getEtcAccounts({ ca });
+      await Promise.all(accounts.map(async (id) => this.deleteWallet({ walletId: id })));
+      Logger.debug('EtcApi::testReset success');
+      return true;
+    } catch (error) {
+      Logger.error('EtcApi::testReset error: ' + stringifyError(error));
+      throw new GenericApiError();
+    }
+  }
 }
 
 const _createWalletTransactionFromServerData = async (


### PR DESCRIPTION
This PR introduces a new `api.etc.testReset` method which deletes all wallets … and refactors the `createWallet` and `restoreWallet` endpoints to use the new `importWallet` that works for private keys.