### PR TITLE
Fix/ddw 8 async wallet import issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog
 - Disable wallet import and export features for the mainnet ([PR 503](https://github.com/input-output-hk/daedalus/pull/503))
 - Correctly prevent max-window-size in electron ([PR 532](https://github.com/input-output-hk/daedalus/pull/532))
 - Make sure wallet import and restore in-progress notification is hidden once process is done ([PR 540](https://github.com/input-output-hk/daedalus/pull/540))
+- Fix async wallet import/restore issues ([PR 562](https://github.com/input-output-hk/daedalus/pull/562))
 
 ### Chores
 

--- a/app/stores/WalletStore.js
+++ b/app/stores/WalletStore.js
@@ -18,7 +18,7 @@ import environment from '../environment';
 export default class WalletsStore extends Store {
 
   WALLET_REFRESH_INTERVAL = 5000;
-  WAIT_FOR_SERVER_ERROR_TIME = 500;
+  WAIT_FOR_SERVER_ERROR_TIME = 2000;
   MIN_NOTIFICATION_TIME = 500;
 
   @observable active: ?Wallet = null;

--- a/app/stores/ada/AdaWalletsStore.js
+++ b/app/stores/ada/AdaWalletsStore.js
@@ -117,7 +117,10 @@ export default class AdaWalletsStore extends WalletStore {
     }, this.WAIT_FOR_SERVER_ERROR_TIME);
 
     const restoredWallet = await this.restoreRequest.execute(params).promise;
-    setTimeout(() => { this._setIsRestoreActive(false); }, this.MIN_NOTIFICATION_TIME);
+    setTimeout(() => {
+      this._setIsRestoreActive(false);
+      this.actions.dialogs.closeActiveDialog.trigger();
+    }, this.MIN_NOTIFICATION_TIME);
     if (!restoredWallet) throw new Error('Restored wallet was not received correctly');
     this.restoreRequest.reset();
     await this._patchWalletRequestWithNewWallet(restoredWallet);
@@ -142,7 +145,10 @@ export default class AdaWalletsStore extends WalletStore {
     const importedWallet = await this.importFromFileRequest.execute({
       filePath, walletName, walletPassword,
     }).promise;
-    setTimeout(() => { this._setIsImportActive(false); }, this.MIN_NOTIFICATION_TIME);
+    setTimeout(() => {
+      this._setIsImportActive(false);
+      this.actions.dialogs.closeActiveDialog.trigger();
+    }, this.MIN_NOTIFICATION_TIME);
     if (!importedWallet) throw new Error('Imported wallet was not received correctly');
     this.importFromFileRequest.reset();
     await this._patchWalletRequestWithNewWallet(importedWallet);


### PR DESCRIPTION
This PR introduces a fix for issues with async wallet import and restore processes.
It used happen that import/restore process errors out after `WAIT_FOR_SERVER_ERROR_TIME` which was set to `500ms`. Now this is changed to `2000ms` which should be enough. All acceptance tests are now passing.

### Note
In case even this new timeout will not be sufficient we will have to completely rethink and refactor this feature.