### PR TITLE
Feature/ddw 3 Launch mantis as part of startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ Changelog
 
 ### Features
 
+- Start and stop Mantis Client from Daedalus main process ([PR 568](https://github.com/input-output-hk/daedalus/pull/568))
+
 ### Fixes
 
 ### Chores
 
-- Update DLL package and cleanup translation files ([PR 566](https://github.com/input-output-hk/daedalus/pull/566))
+- Update DLL package and cleanup translation files ([PR 567](https://github.com/input-output-hk/daedalus/pull/567))
 
 ## 0.8.3
 =======

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -56,19 +56,25 @@ let terminateAboutWindow = false;
 const isDev = process.env.NODE_ENV === 'development';
 const isProd = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
+
 const isEtcApi = process.env.API === 'etc';
+const mantisCmd = process.env.MANTIS_CMD || null;
+const mantisArgs = process.env.MANTIS_ARGS || '';
 const mantisPath = process.env.MANTIS_PATH || null;
+
 const daedalusVersion = process.env.DAEDALUS_VERSION || 'dev';
 
-if (isEtcApi && mantisPath) {
+if (isEtcApi && mantisCmd && mantisPath) {
   const { spawn } = require('child_process');
   const psTree = require('ps-tree');
 
   // Start Mantis
-  const mantis = spawn('sbt run', ['-mem 4096'], { cwd: mantisPath, detached: true, shell: true });
+  Log.info('Starting Mantis...');
+  const mantis = spawn(mantisCmd, [mantisArgs], { cwd: mantisPath, detached: true, shell: true });
 
   // Stop Mantis (on app quit)
   app.on('will-quit', () => {
+    Log.info('Stopping Mantis...');
     psTree(mantis.pid, (err, children) => {
       // Kill all Mantis child processes
       spawn('kill', ['-9'].concat(children.map((p) => (p.PID))));

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -56,7 +56,26 @@ let terminateAboutWindow = false;
 const isDev = process.env.NODE_ENV === 'development';
 const isProd = process.env.NODE_ENV === 'production';
 const isTest = process.env.NODE_ENV === 'test';
+const isEtcApi = process.env.API === 'etc';
+const mantisPath = process.env.MANTIS_PATH || null;
 const daedalusVersion = process.env.DAEDALUS_VERSION || 'dev';
+
+if (isEtcApi && mantisPath) {
+  const { spawn } = require('child_process');
+  const psTree = require('ps-tree');
+
+  // Start Mantis
+  const mantis = spawn('sbt run', ['-mem 4096'], { cwd: mantisPath, detached: true, shell: true });
+
+  // Stop Mantis (on app quit)
+  app.on('will-quit', () => {
+    psTree(mantis.pid, (err, children) => {
+      // Kill all Mantis child processes
+      spawn('kill', ['-9'].concat(children.map((p) => (p.PID))));
+    });
+    spawn('kill', ['-9', mantis.pid]); // Kill main Mantis process
+  });
+}
 
 if (isDev) {
   require('electron-debug')(); // eslint-disable-line global-require


### PR DESCRIPTION
This PR introduces feature for starting and stopping Mantis client from Daedalus main process.
Currently it is implemented so that it can work with local Mantis client in development mode.
To start it use the following command: `API=etc MANTIS_PATH={path-to-mantis} npm run dev`