### PR TITLE
[Mantis] Increase bootstrap installer required disk space

### DIFF
--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -58,7 +58,7 @@ main = do
         }
       makeInstaller cfg'
     "etc" -> do
-      renameDirectory "../release/darwin-x64/Daedalus-darwin-x64/Daedalus.app" "../release/darwin-x64/Daedalus-darwin-x64/DaedalusMantis.app"
+      --renameDirectory "../release/darwin-x64/Daedalus-darwin-x64/Daedalus.app" "../release/darwin-x64/Daedalus-darwin-x64/DaedalusMantis.app"
       let
         cfg' = cfg {
             appNameLowercase = "daedalusmantis"

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -108,7 +108,7 @@ writeInstallerNSIS fullVersion predownloadChain = do
     bootstrap_hash = "7e210991f10f9ddebd5d9fe42e98c59e"
     -- how much space the chain will take in gig
     bootstrap_size :: Int
-    bootstrap_size = 33
+    bootstrap_size = 45
   let -- Where to produce the installer
     outputFile :: String
     outputFile = if predownloadChain then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daedalus",
-  "productName": "Daedalus",
+  "productName": "DaedalusMantis",
   "version": "0.8.0",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main.js",


### PR DESCRIPTION
This change is needed because with latest changes in Mantis, bootstrap zip is downloaded to the same target directory where it's later being unzipped. See https://github.com/input-output-hk/mantis/pull/375