### PR TITLE
Increase supported npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,6 @@
   },
   "devEngines": {
     "node": "6.x",
-    "npm": "3.x"
+    "npm": ">=3.x"
   }
 }


### PR DESCRIPTION
The README states

> Note: requires a node version >= 4 and an npm version >= 3. This project defaults to 6.x

However the package version requires strictly 3. I changed this to >= 3 to match the README.