### PR TITLE
purge-translations now works on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build-storybook": "build-storybook",
     "flow-test": "flow; test $? -eq 0 -o $? -eq 2",
     "manage-translations": "node ./translations/translation-runner.js",
-    "purge-translations": "rm -rf ./translations/messages/app",
+    "purge-translations": "rimraf ./translations/messages/app",
     "build-dll": "webpack --config=webpack/webpack.config.dll.js"
   },
   "bin": {


### PR DESCRIPTION
rm -rf doesn't work on Windows and so

> npm run dev

would cause an error.

I changed it to use rimraf instead which is a cross-compatible package. See documentation [here](https://www.npmjs.com/package/rimraf)