### PR TITLE
[DEVOPS-622/github #664]:  deprecate non-sha256 MD support in the cert generator

### DIFF
--- a/installers/build-certificates-win64.bat
+++ b/installers/build-certificates-win64.bat
@@ -16,9 +16,9 @@ set OUTDIR=%1
 @echo [1/10] Creating database in %OUTDIR%
 rmdir /s /q          %OUTDIR%\tls\ca %OUTDIR%\tls\server 2>nul
 mkdir                %OUTDIR%
-copy  /y ca.conf     %OUTDIR%
-copy  /y client.conf %OUTDIR%
-copy  /y server.conf %OUTDIR%
+copy  /y ca.conf.windows     %OUTDIR%\ca.conf
+copy  /y client.conf.windows %OUTDIR%\client.conf
+copy  /y server.conf.windows %OUTDIR%\server.conf
 xcopy /y /s /e  x86  %OUTDIR%\x86
 xcopy /y /s /e  x64  %OUTDIR%\x64
 cd                   %OUTDIR%
@@ -28,15 +28,6 @@ copy nul  tls\ca\db\ca.db
 copy nul  tls\ca\db\ca.db.attr
 echo 01 > tls\ca\db\ca.crt.srl
 @echo ============================================================================
-
-echo [2/10] Choosing OpenSSL message digest
-set MD=sha256
-echo Elected message digest '%MD%'
-echo Updating: ca.conf client.conf server.conf
-powershell -Command "(gc ca.conf)     -replace 'OPENSSL_MD', '%MD%' | Out-File -encoding ASCII ca.conf"
-powershell -Command "(gc client.conf) -replace 'OPENSSL_MD', '%MD%' | Out-File -encoding ASCII client.conf"
-powershell -Command "(gc server.conf) -replace 'OPENSSL_MD', '%MD%' | Out-File -encoding ASCII server.conf"
-echo ============================================================================
 
 @echo [3/10] Generating install-time-only use password for the CA key
 @echo %RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM%%RANDOM% > tls\secret

--- a/installers/cardano-installer.cabal
+++ b/installers/cardano-installer.cabal
@@ -25,6 +25,7 @@ executable make-installer
                      , directory
                      , temporary
                      , megaparsec
+                     , split
 
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts

--- a/installers/cardano-installer.nix
+++ b/installers/cardano-installer.nix
@@ -1,5 +1,5 @@
 { mkDerivation, base, directory, filepath, Glob, megaparsec, nsis
-, stdenv, temporary, text, turtle
+, split, stdenv, temporary, text, turtle
 }:
 mkDerivation {
   pname = "cardano-installer";
@@ -8,7 +8,7 @@ mkDerivation {
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
-    base directory filepath Glob megaparsec nsis temporary text turtle
+    base directory filepath Glob megaparsec nsis split temporary text turtle
   ];
   description = "Cardano Installer";
   license = stdenv.lib.licenses.mit;


### PR DESCRIPTION
This fixes #664 by removing the logic that used to choose the OpenSSL MD on OS X -- this sometimes breaks on Windows in an obscure way, apparently due to Powershell incompatibilities.

This also essentially breaks OS X Yosemite (circa 2014 and earlier) -- but those are arguably insecure to use: the last update, 10.10.5 is dated 13 Aug 2015.

Tested on Windows 7.

Sister mainnet hot-fix is https://github.com/input-output-hk/daedalus/pull/666