### PR TITLE
Chore/ddw 82 Ada redemption tests in mainnnet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog
 - Update terms of use for ETC version ([PR 606](https://github.com/input-output-hk/daedalus/pull/606))
 - Update Electron to version 1.7.11 which resolves security issues ([PR 677](https://github.com/input-output-hk/daedalus/pull/677))
 - Document Cardano SL build ([PR 654](https://github.com/input-output-hk/daedalus/pull/654))
+- Ada redemption tests modified to run in mainnet mode ([PR 681](https://github.com/input-output-hk/daedalus/pull/681))
 
 ## 0.8.3
 =======

--- a/features/step_definitions/ada-redemption-steps.js
+++ b/features/step_definitions/ada-redemption-steps.js
@@ -1,6 +1,7 @@
 import { Given, When, Then } from 'cucumber';
 import path from 'path';
 import { navigateTo } from '../support/helpers/route-helpers';
+import environment from '../../app/environment';
 
 const regularAdaCertificateFilePath = path.resolve(__dirname, '../support/ada_certificates/regular.pdf');
 const regularEncryptedAdaCertificateFilePath = path.resolve(__dirname, '../support/ada_certificates/regular.pdf.enc');
@@ -22,19 +23,19 @@ Given(/^I am on the ada redemption screen$/, async function () {
 });
 
 Given(/^I see the "Daedalus Redemption Disclaimer" overlay$/, function () {
-  return this.client.waitForVisible('.AdaRedemptionDisclaimer_component');
+  return environment.isMainnet() || this.client.waitForVisible('.AdaRedemptionDisclaimer_component');
 });
 
 When(/^I click on the "I've understood the information above" checkbox$/, function () {
-  return this.waitAndClick('.AdaRedemptionDisclaimer_component .SimpleCheckbox_root');
+  return environment.isMainnet() || this.waitAndClick('.AdaRedemptionDisclaimer_component .SimpleCheckbox_root');
 });
 
 When(/^I click on the "Continue" button$/, function () {
-  return this.waitAndClick('.AdaRedemptionDisclaimer_component button');
+  return environment.isMainnet() || this.waitAndClick('.AdaRedemptionDisclaimer_component button');
 });
 
 Then(/^I should not see the "Daedalus Redemption Disclaimer" overlay anymore$/, function () {
-  return this.client.waitForVisible('.AdaRedemptionDisclaimer_component', null, true);
+  return environment.isMainnet() || this.client.waitForVisible('.AdaRedemptionDisclaimer_component', null, true);
 });
 
 Then(/^I should(?: still)? be on the ada redemption screen$/, function () {


### PR DESCRIPTION
This PR modifies Ada redemption tests to run in `mainnet` mode, where Ada redemption warning is not shown.

To run the tests in mainnet mode use: `NETWORK=mainnet npm run test`

### Note
This PR contains ported work from the original PR: https://github.com/input-output-hk/daedalus/pull/498 which is to be closed in favour of this one.