### PR TITLE
Fix/ddw 61 Detect when wallet is out of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog
 - Fixed storybook and resolver issues ([PR 617](https://github.com/input-output-hk/daedalus/pull/617))
 - Time of your machine is different from global time. You are 0 seconds behind. ([PR 678](https://github.com/input-output-hk/daedalus/pull/678))
 - Updated copy for the sync error screen ([PR 657](https://github.com/input-output-hk/daedalus/pull/657))
+- Detect when wallet is disconnected ([PR 689](https://github.com/input-output-hk/daedalus/pull/689))
 
 ### Chores
 

--- a/app/api/ada/index.js
+++ b/app/api/ada/index.js
@@ -596,7 +596,6 @@ export default class AdaApi {
 
   getSyncProgress = async (): Promise<GetSyncProgressResponse> => {
     Logger.debug('AdaApi::syncProgress called');
-
     try {
       const response: AdaSyncProgressResponse = await getAdaSyncProgress({ ca });
       Logger.debug('AdaApi::syncProgress success: ' + stringifyData(response));


### PR DESCRIPTION
This PR introduces an improved connected/disconnected state detection which tracks `networkDifficulty` value and in case it remains unchanged for more than `2 minutes` redirects the user to the Connecting screen.
Described scenario happens when the Internet connection is lost and Api is unaware of new blocks and therefore sends the same `networkDifficulty` value to the UI.