### PR TITLE
Fix/ddw 84 Improve connecting reconnecting messages on Loading screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog
 - Time of your machine is different from global time. You are 0 seconds behind. ([PR 678](https://github.com/input-output-hk/daedalus/pull/678))
 - Updated copy for the sync error screen ([PR 657](https://github.com/input-output-hk/daedalus/pull/657))
 - Detect when wallet is disconnected ([PR 689](https://github.com/input-output-hk/daedalus/pull/689))
+- Improve connecting/reconnecting messages on Loading screen ([PR 696](https://github.com/input-output-hk/daedalus/pull/696))
 
 ### Chores
 

--- a/app/api/etc/lib/request.js
+++ b/app/api/etc/lib/request.js
@@ -33,14 +33,19 @@ function typedRequest<Response>(
       response.on('error', (error) => reject(error));
       // Resolve JSON results and handle weird backend behavior
       response.on('end', () => {
-        const parsedBody = JSON.parse(body);
-        if (parsedBody.result != null) {
-          resolve(parsedBody.result);
-        } else if (parsedBody.error) {
-          reject(new Error(parsedBody.error.message));
-        } else {
-          // TODO: investigate if that can happen! (no Right or Left in a response)
-          reject(new Error('Unknown response from backend.'));
+        try {
+          const parsedBody = JSON.parse(body);
+          if (parsedBody.result != null) {
+            resolve(parsedBody.result);
+          } else if (parsedBody.error) {
+            reject(new Error(parsedBody.error.message));
+          } else {
+            // TODO: investigate if that can happen! (no Right or Left in a response)
+            reject(new Error('Unknown response from backend.'));
+          }
+        } catch (error) {
+          // Handle internal server errors (e.g. HTTP 500 - 'Something went wrong')
+          reject(new Error(error));
         }
       });
     });

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -102,9 +102,14 @@ export default class Loading extends Component<Props> {
     const currencyLoadingLogo = currencyIcon;
     const apiLoadingLogo = apiIcon;
 
-    const connectingMessage = hasBeenConnected ? messages.reconnecting : (
-      hasBlockSyncingStarted ? messages.waitingForSyncToStart : messages.connecting
-    );
+    let connectingMessage;
+    if (hasBeenConnected) {
+      connectingMessage = messages.reconnecting;
+    } else {
+      connectingMessage = (
+        hasBlockSyncingStarted ? messages.waitingForSyncToStart : messages.connecting
+      );
+    }
 
     return (
       <div className={componentStyles}>

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -102,7 +102,9 @@ export default class Loading extends Component<Props> {
     const currencyLoadingLogo = currencyIcon;
     const apiLoadingLogo = apiIcon;
 
-    const connectingMessage = hasBeenConnected ? messages.reconnecting : messages.connecting;
+    const connectingMessage = hasBeenConnected ? messages.reconnecting : (
+      hasBlockSyncingStarted ? messages.waitingForSyncToStart : messages.connecting
+    );
 
     return (
       <div className={componentStyles}>
@@ -113,17 +115,10 @@ export default class Loading extends Component<Props> {
         </div>
         {hasLoadedCurrentLocale && (
           <div>
-            {isConnecting && !hasBlockSyncingStarted && (
+            {isConnecting && (
               <div className={styles.connecting}>
                 <h1 className={styles.headline}>
                   {intl.formatMessage(connectingMessage)}
-                </h1>
-              </div>
-            )}
-            {isConnecting && hasBlockSyncingStarted && (
-              <div className={styles.connecting}>
-                <h1 className={styles.headline}>
-                  {intl.formatMessage(messages.waitingForSyncToStart)}
                 </h1>
               </div>
             )}


### PR DESCRIPTION
This PR introduces proper handling of Loading screen text messages for connecting and reconnecting scenarios:
- during initial application start `Connecting...` message is displayed
- later during any connection problems `Network connection lost - reconnecting...` message is displayed.
![screen shot 2018-01-28 at 15 21 31](https://user-images.githubusercontent.com/376611/35486041-871e782c-0468-11e8-863a-5ac0d68ffdce.png)

This PR also contains a very important fix for proper handling of `HTTP 500 Internal server errors` in Api responses. To replicate this problems exit/kill local backend node processes which will result in the following response errors:
<img width="1138" alt="screen shot 2018-01-28 at 19 55 30" src="https://user-images.githubusercontent.com/376611/35486073-ed463cd4-0468-11e8-9c2c-e4f673ba75e3.png">
...which break our requests as this message is returned as a string and the code expects a JSON object.
