### PR TITLE
[DDW-70] Duplicate transaction ids for ETC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changelog
 - Fixed a bug related to gas limit when sending transactions ([PR 586](https://github.com/input-output-hk/daedalus/pull/586))
 - Remove transactions sorting ([PR 587](https://github.com/input-output-hk/daedalus/pull/587))
 - Improve ETC transaction amount validation ([PR 590](https://github.com/input-output-hk/daedalus/pull/590))
+- Fixed a bug related to rendering of transactions with duplicated ids ([PR 697](https://github.com/input-output-hk/daedalus/pull/697))
 
 ### Chores
 

--- a/app/components/wallet/transactions/WalletTransactionsList.js
+++ b/app/components/wallet/transactions/WalletTransactionsList.js
@@ -108,7 +108,7 @@ export default class WalletTransactionsList extends Component<Props> {
             <div className={styles.groupDate}>{this.localizedDate(group.date)}</div>
             <div className={styles.list}>
               {group.transactions.map((transaction, transactionIndex) => (
-                <div key={walletId + '-' + transaction.id}>
+                <div key={`${walletId}-${transaction.id}-${transaction.type}`}>
                   <Transaction
                     data={transaction}
                     isLastInList={transactionIndex === group.transactions.length - 1}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cucumber": "3.1.0",
     "del": "2.2.2",
     "devtron": "1.4.0",
-    "electron": "^1.7.9",
+    "electron": "1.7.9",
     "electron-devtools-installer": "2.2.1",
     "electron-inspector": "0.1.4",
     "electron-packager": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "cucumber": "3.1.0",
     "del": "2.2.2",
     "devtron": "1.4.0",
-    "electron": "1.7.9",
+    "electron": "^1.7.9",
     "electron-devtools-installer": "2.2.1",
     "electron-inspector": "0.1.4",
     "electron-packager": "9.1.0",


### PR DESCRIPTION
This PR fixes rendering issues when there are transactions with duplicated ids - such as when you create `A -> A` transaction. This problem is affecting only Daedalus/Mantis version.

![screen shot 2018-01-30 at 22 51 00](https://user-images.githubusercontent.com/376611/35593414-2356d2cc-0610-11e8-925a-77a845eb3df2.png)
