### PR TITLE
Fix/DDW-93 Poll local time difference every 1 hour when connected

### DIFF
--- a/.nonsense
+++ b/.nonsense
@@ -1,1 +1,2 @@
 ------- Ignore this file, it's created/changed to trigger build -------
+•

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changelog
 - Updated copy for the sync error screen ([PR 657](https://github.com/input-output-hk/daedalus/pull/657))
 - Detect when wallet is disconnected ([PR 689](https://github.com/input-output-hk/daedalus/pull/689))
 - Improve connecting/reconnecting messages on Loading screen ([PR 696](https://github.com/input-output-hk/daedalus/pull/696))
+- Poll local time difference every 1 hour, only when connected ([PR 719](https://github.com/input-output-hk/daedalus/pull/719))
 
 ### Chores
 

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -59,7 +59,7 @@ export default class NetworkStatusStore extends Store {
       this._redirectToWalletAfterSync,
       this._redirectToLoadingWhenDisconnected,
       this._redirectToSyncingWhenLocalTimeDifferent,
-      this._setupTimeDifferencePolling,
+      this._pollTimeDifferenceWhenConnected,
     ]);
     this._pollSyncProgress();
   }
@@ -286,7 +286,7 @@ export default class NetworkStatusStore extends Store {
     return Date.now() - this._startTime;
   }
 
-  _setupTimeDifferencePolling = () => {
+  _pollTimeDifferenceWhenConnected = () => {
     if (!environment.isAdaApi()) return;
     if (this.isConnected) {
       this._pollLocalTimeDifference();

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -47,7 +47,7 @@ export default class NetworkStatusStore extends Store {
   );
   @observable _localDifficultyStartedWith = null;
 
-  _timeDifferenceTimerInterval: ?number = null;
+  _timeDifferencePollInterval: ?number = null;
 
   @action initialize() {
     super.initialize();
@@ -220,14 +220,14 @@ export default class NetworkStatusStore extends Store {
 
   _pollLocalTimeDifference() {
     Logger.debug('Started polling local time difference');
-    if (this._timeDifferenceTimerInterval) clearInterval(this._timeDifferenceTimerInterval);
-    this._timeDifferenceTimerInterval = setInterval(this._updateLocalTimeDifference, TIME_DIFF_POLL_INTERVAL);
+    if (this._timeDifferencePollInterval) clearInterval(this._timeDifferencePollInterval);
+    this._timeDifferencePollInterval = setInterval(this._updateLocalTimeDifference, TIME_DIFF_POLL_INTERVAL);
     this._updateLocalTimeDifference();
   }
 
   _stopPollingLocalTimeDifference() {
     Logger.debug('Stopped polling local time difference');
-    if (this._timeDifferenceTimerInterval) clearInterval(this._timeDifferenceTimerInterval);
+    if (this._timeDifferencePollInterval) clearInterval(this._timeDifferencePollInterval);
   }
 
   _pollSyncProgress() {

--- a/app/stores/NetworkStatusStore.js
+++ b/app/stores/NetworkStatusStore.js
@@ -221,7 +221,9 @@ export default class NetworkStatusStore extends Store {
   _pollLocalTimeDifference() {
     Logger.debug('Started polling local time difference');
     if (this._timeDifferencePollInterval) clearInterval(this._timeDifferencePollInterval);
-    this._timeDifferencePollInterval = setInterval(this._updateLocalTimeDifference, TIME_DIFF_POLL_INTERVAL);
+    this._timeDifferencePollInterval = setInterval(
+      this._updateLocalTimeDifference, TIME_DIFF_POLL_INTERVAL
+    );
     this._updateLocalTimeDifference();
   }
 


### PR DESCRIPTION
This PR changes the logic for polling for local time difference:
- polling is started when connected
- polling is stopped when disconnected
- the polling interval is one hour

Changing the polling interval to one hour is a temporary measure needed since `/api/settings/time/difference` endpoint is consulting the NTP server every time and frequent polling is spamming. Later on, this endpoint will be fixed so the response from the NTP server will be cached. After that, we can poll more frequently.


