### PR TITLE
[DEVOPS-676] bake the REPORT_URL into the binary at build time

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "webpack-dev-middleware": "1.10.1",
     "webpack-hot-middleware": "2.17.1",
     "webpack-merge": "0.14.1",
-    "webpack-validator": "2.3.0"
+    "webpack-validator": "2.3.0",
+    "yamljs": "0.3.0"
   },
   "dependencies": {
     "aes-js": "2.1.1",

--- a/webpack/webpack.config.base.js
+++ b/webpack/webpack.config.base.js
@@ -5,6 +5,9 @@
 const path = require('path');
 const validate = require('webpack-validator');
 const webpack = require('webpack');
+const yamljs = require("yamljs");
+
+const reportUrl = yamljs.parseFile("installers/launcher-config-windows.yaml").reportServer;
 
 module.exports = validate({
   cache: true,
@@ -54,7 +57,8 @@ module.exports = validate({
       'process.env.API': JSON.stringify(process.env.API || 'ada'),
       'process.env.NETWORK': JSON.stringify(process.env.NETWORK || 'development'),
       'process.env.MOBX_DEV_TOOLS': process.env.MOBX_DEV_TOOLS || 0,
-      'process.env.DAEDALUS_VERSION': JSON.stringify(process.env.DAEDALUS_VERSION || 'dev')
+      'process.env.DAEDALUS_VERSION': JSON.stringify(process.env.DAEDALUS_VERSION || 'dev'),
+      'process.env.REPORT_URL': JSON.stringify(reportUrl)
     }),
   ],
 


### PR DESCRIPTION
before:
```
import environment from '../../environment';

alert(process.env.REPORT_URL);

const messages = defineMessages({
```
after:
```
var n,o,i,s=a(7),l=r(s),u=a(3),c=r(u),d=a(2),f=r(d),h=a(4),p=r(h),m=a(6),g=r(m),v=a(5),y=r(v),b=a(1),w=(r(b),a(37)),A=r(w),k=a(9),T=a(12),L=a(11),x=r(L),M=a(567),C=r(M),N=a(171),S=r(N),D=a(961),P=r(D),E=a(1403),O=r(E),I=a(23),R=r(I);
alert("http://report-server.cardano-mainnet.iohk.io:8080");
var B=(0,T.defineMessages)({connecting:{id:"loading.screen.connectingToNetworkM...
```
after webpack has had its way with the source, the environment lookup is just gone and it becomes a hard-coded string

but if your running daedalus via `npm`, it will be untouched, and obey whatever you have manually set with `export REPORT_URL=foo` prior to running npm
