### PR TITLE
[CSL-2307] Do not redirect cardano-node's logs to a file

### DIFF
--- a/installers/launcher-config-mac.yaml
+++ b/installers/launcher-config-mac.yaml
@@ -22,7 +22,6 @@ nodeArgs:
 - ./wallet-topology.yaml
 nodeDbPath: $HOME/Library/Application Support/Daedalus/DB-1.0
 nodeLogConfig: log-config-prod.yaml
-nodeLogPath: $HOME/Library/Application Support/Daedalus/Logs/cardano-node.log
 
 walletPath: ./Frontend
 walletArgs: []

--- a/installers/launcher-config-windows.yaml
+++ b/installers/launcher-config-windows.yaml
@@ -22,7 +22,6 @@ nodeArgs:
 - wallet-topology.yaml
 nodeDbPath: ! '%APPDATA%\Daedalus\DB-1.0'
 nodeLogConfig: log-config-prod.yaml
-nodeLogPath: ! '%APPDATA%\Daedalus\Logs\cardano-node.log'
 
 walletPath: ! '%DAEDALUS_DIR%\Daedalus.exe'
 walletArgs: []


### PR DESCRIPTION
Previously all output from cardano-node was redirected to `cardano-node.log`.
Now we don't want it, because this file became quite big after several months.
Now output won't be redirected, cardano-node will inherit cardano-launcher's
stdout and stderr.
It should be tested though.
Note: there will still be logs in `node` and `node.pub` files.
`cardano-node.log` was duplicating them.