### PR TITLE
Fix/ddw 119 Fix wallet restore reactions configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@ Changelog
 - Detect when wallet is disconnected ([PR 689](https://github.com/input-output-hk/daedalus/pull/689))
 - Improve connecting/reconnecting messages on Loading screen ([PR 696](https://github.com/input-output-hk/daedalus/pull/696))
 - Poll local time difference every 1 hour, only when connected ([PR 719](https://github.com/input-output-hk/daedalus/pull/719))
-- Fixed various styling issues and updated to react-polymorph 0.6.2 ([PR 726](https://github.com/input-output-hk/daedalus/pull/726)) 
+- Fixed various styling issues and updated to react-polymorph 0.6.2 ([PR 726](https://github.com/input-output-hk/daedalus/pull/726))
+- Fixed async restore/import dialogs logic ([PR 735](https://github.com/input-output-hk/daedalus/pull/735))
 
 ### Chores
 

--- a/app/stores/WalletStore.js
+++ b/app/stores/WalletStore.js
@@ -211,9 +211,6 @@ export default class WalletsStore extends Store {
   );
 
   _toggleAddWalletDialogOnWalletsLoaded = () => {
-    // Register mobx observers for active import and restore in order to trigger reaction on change
-    this.isImportActive; // eslint-disable-line
-    this.isRestoreActive; // eslint-disable-line
     if (this.hasLoadedWallets && !this.hasAnyWallets) {
       this.actions.dialogs.open.trigger({ dialog: WalletAddDialog });
     } else if (untracked(() => this.stores.uiDialogs.isOpen(WalletAddDialog))) {


### PR DESCRIPTION
This PR improves async restore/import dialogs closing logic by enforcing the following:
```
Once restore/import is under way we need to either:
A) show the 'Add wallet' dialog (in case we don't have any wallets) or
B) just close the active dialog and unblock the UI
```
...which prevents the following situation:
![screen shot 2018-02-19 at 22 54 38](https://user-images.githubusercontent.com/376611/36415392-01c07610-1626-11e8-9c3b-ffc3aaebd62c.png)
