### PR TITLE
[DDW-124] dont show validation error after clearing spending password field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changelog
 - Poll local time difference every 1 hour, only when connected ([PR 719](https://github.com/input-output-hk/daedalus/pull/719))
 - Fixed various styling issues and updated to react-polymorph 0.6.2 ([PR 726](https://github.com/input-output-hk/daedalus/pull/726))
 - Fixed async restore/import dialogs logic ([PR 735](https://github.com/input-output-hk/daedalus/pull/735))
+- Fixed minor UI issue on receive screen when generating wallet addresses with spending password ([PR 738](https://github.com/input-output-hk/daedalus/pull/738))
 
 ### Chores
 

--- a/app/components/wallet/WalletReceive.js
+++ b/app/components/wallet/WalletReceive.js
@@ -111,8 +111,9 @@ export default class WalletReceive extends Component<Props, State> {
     },
   }, {
     options: {
+      validationDebounceWait: 0, // Disable debounce to avoid error state after clearing
       validateOnChange: true,
-      validationDebounceWait: 250,
+      showErrorsOnClear: false,
     },
   });
 
@@ -123,13 +124,7 @@ export default class WalletReceive extends Component<Props, State> {
         const { spendingPassword } = form.values();
         const password = walletHasPassword ? spendingPassword : null;
         this.props.onGenerateAddress(password);
-
-        // We need to disable on-change validation before reseting the form in order to
-        // avoid debounced validation being called straight after the form is reset
-        form.state.options.set({ validateOnChange: false });
-        form.reset();
-        form.showErrors(false);
-        form.state.options.set({ validateOnChange: true });
+        form.clear();
       },
       onError: () => {}
     });


### PR DESCRIPTION
This PR fixes a minor UI issue on the receive screen when generating new address for a wallet that has a spending password set. After submit the password field was cleared and remained in an error state … this is now fixed by simplifying the setup and removing the validation debounce (which doesn't have any positive UX effect in this case anyway)