### PR TITLE
[DEVOPS-685] installers: always sign Mac builds on Buildkite

### DIFF
--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -87,11 +87,12 @@ main = do
   run "rm" [toText tempInstaller]
   echo $ "Generated " <> unsafeTextToLine (pkg cfg)
 
--- | Only sign installer if this is not a normal PR build.
+-- | When on travis, only sign installer if for non-PR builds.
 shouldSignDecision :: IO Bool
 shouldSignDecision = do
   pr <- pullRequestFromEnv
-  pure (pr == Nothing || pr == Just "629")
+  isTravis <- isJust <$> travisJobIdFromEnv
+  pure (not isTravis || pr == Nothing)
 
 makeScriptsDir :: InstallerConfig -> Managed T.Text
 makeScriptsDir cfg = case icApi cfg of

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -141,7 +141,7 @@ cd installers
     INSTALLER=$(nix-build -j 2 --no-out-link)
 
     # For Travis MacOSX non-PR builds only
-    if test \( "${pr_id}" = "false" -o "${pr_id}" = "629" \) -a -n "${TRAVIS_JOB_ID:-}" -a "${OS_NAME}" != "linux"
+    if test "${pr_id}" = "false" -a -n "${TRAVIS_JOB_ID:-}" -a "${OS_NAME}" != "linux"
     then
         echo "Downloading and importing signing certificate.."
         retry 5 $nix_shell -p awscli --run "aws s3 cp --region eu-central-1 s3://iohk-private/${key} macos.p12 || true"


### PR DESCRIPTION
Because with Buildkite we don't make builds for untrusted users.