### PR TITLE
[DEVOPS-643] Fix nix-shell dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,12 @@ with (import (fetchTarball https://github.com/NixOS/nixpkgs/archive/fb235c98d839
 stdenv.mkDerivation {
   name = "daedalus";
 
-  buildInputs = [git python27 curl electron nodejs-6_x nodePackages.node-gyp nodePackages.node-pre-gyp ];
+  buildInputs = [
+    nix bash binutils coreutils curl
+    git python27 curl electron nodejs-6_x
+    nodePackages.node-gyp nodePackages.node-pre-gyp
+    gnumake
+  ];
 
   src = null;
 

--- a/nixpkgs-src.json
+++ b/nixpkgs-src.json
@@ -1,6 +1,6 @@
 {
     "owner":  "NixOS",
     "repo":   "nixpkgs",
-    "rev":    "61fbdb47a69f78998f55207e64122a0798047b5d",
-    "sha256": "050r55sgpy121j5qs00jw43rg5pnqidbdbvvj4lr1i9lmv9f1vfv"
+    "rev":    "fb235c98d839ae37a639695ad088d19ef8382608",
+    "sha256": "1wwddmk0pbqg90lfpzkxpqw4213hi7bkv2s3fm20mdbmm1li432z"
 }

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -161,6 +161,7 @@ cd installers
         mv "${INSTALLER_PKG}" "${APP_NAME}/${INSTALLER_PKG}"
 
         if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
+            export PATH=${BUILDKITE_BIN_PATH:-}:$PATH
             buildkite-agent artifact upload "${APP_NAME}/${INSTALLER_PKG}" s3://${ARTIFACT_BUCKET} --job $BUILDKITE_JOB_ID
         elif test -n "${TRAVIS_JOB_ID:-}" -a -n "${upload_s3}"
         then

--- a/scripts/nix-shell.sh
+++ b/scripts/nix-shell.sh
@@ -20,4 +20,6 @@ export NIX_REMOTE=daemon
 export NIX_PATH="nixpkgs=$(${NIX_BUILD} fetch-nixpkgs.nix -o nixpkgs)"
 export NIX_BUILD_SHELL
 
-${NIX_SHELL} -p nix bash binutils coreutils curl "$@"
+exec ${NIX_SHELL} default.nix \
+     --arg pkgs 'import <nixpkgs> {}' \
+     "$@"


### PR DESCRIPTION
This adds the full list of build dependencies required for building to the nix-shell.

There is also a change to make the `buildkite-agent` program available when running on nix-darwin.

I'm not sure I like the `nix-shell.sh` script. Perhaps if all build agents are configured with nix available and the pipelines specify `NIX_PATH`, then it wouldn't be required?