### PR TITLE
Fix/ddw 139 Show time sync error even if the syncing has not started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Changelog
 - Fixed various styling issues and updated to react-polymorph 0.6.2 ([PR 726](https://github.com/input-output-hk/daedalus/pull/726))
 - Fixed async restore/import dialogs logic ([PR 735](https://github.com/input-output-hk/daedalus/pull/735))
 - Fixed minor UI issue on receive screen when generating wallet addresses with spending password ([PR 738](https://github.com/input-output-hk/daedalus/pull/738))
+- Fixed `Time sync error notification` not showing up in case blocks syncing has not started ([PR 752](https://github.com/input-output-hk/daedalus/pull/752))
 
 ### Chores
 

--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -212,19 +212,10 @@ export default class Loading extends Component<Props, State> {
               </div>
             )}
             {isSyncing && (
-              <div className="syncingWrapper">
-                <div className={styles.syncing}>
-                  <h1 className={styles.headline}>
-                    {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(2)}%
-                  </h1>
-                </div>
-                {(localTimeDifference > allowedTimeDifference) && (
-                  <SystemTimeErrorOverlay
-                    localTimeDifference={localTimeDifference}
-                    currentLocale={currentLocale}
-                    onProblemSolutionClick={onProblemSolutionClick}
-                  />
-                )}
+              <div className={styles.syncing}>
+                <h1 className={styles.headline}>
+                  {intl.formatMessage(messages.syncing)} {syncPercentage.toFixed(2)}%
+                </h1>
               </div>
             )}
             {!isSyncing && !isConnecting && isLoadingDataForNextScreen && (
@@ -234,6 +225,13 @@ export default class Loading extends Component<Props, State> {
                 </h1>
                 <LoadingSpinner />
               </div>
+            )}
+            {(localTimeDifference > allowedTimeDifference) && (
+              <SystemTimeErrorOverlay
+                localTimeDifference={localTimeDifference}
+                currentLocale={currentLocale}
+                onProblemSolutionClick={onProblemSolutionClick}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
This PR fixes `Time sync error notification` display logic which had a flaw in terms of not displaying the error notification in case block syncing has not stated (or to be more precise - when `networkDifficulty` is not greater than `1`.
This is a minor change which has no impact on the data handling logic - the only change is in placement of `Time sync error notification` element within the Loading page.