### PR TITLE
Fix/ddw 154 Show 'Having trouble syncing?' message only if syncing has stalled for 5 minutes

### DIFF
--- a/app/components/loading/Loading.js
+++ b/app/components/loading/Loading.js
@@ -246,7 +246,7 @@ export default class Loading extends Component<Props, State> {
   syncingTimer = () => {
     const syncPercentage = this.props.syncPercentage.toFixed(2);
 
-    if (syncPercentage <= this.state.syncPercentage) {
+    if (syncPercentage === this.state.syncPercentage) {
       // syncPercentage not increased, increase syncing time
       this.setState({ syncingTime: this.state.syncingTime + 1 });
     } else {


### PR DESCRIPTION
This PR fixes a display logic of 'Having trouble syncing?' message on the Syncing screen.
Because of wrong comparison operator this message would show up 5 minutes after syncing percentage reached 9.99% and it would stay shown regardless of the syncing progress until syncing is done.

![fix](https://user-images.githubusercontent.com/376611/36895839-aaa32bfa-1e10-11e8-9bd6-f867e5efb11f.png)
![error](https://user-images.githubusercontent.com/376611/36895840-aac41f36-1e10-11e8-95db-a6ea701ec3f7.png)
