### PR TITLE
Fix/ddw 166 Remove 5 transactions limit from transactions screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 
 ### Fixes
 
+- Remove 5 transactions limit from transactions screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
+
 ### Chores
 
 ## 0.9.0

--- a/app/stores/TransactionsStore.js
+++ b/app/stores/TransactionsStore.js
@@ -130,18 +130,22 @@ export default class TransactionsStore extends Store {
     if (this.stores.networkStatus.isConnected) {
       const allWallets = this.stores[environment.API].wallets.all;
       for (const wallet of allWallets) {
-        const requestParams = {
+        const recentRequest = this._getTransactionsRecentRequest(wallet.id);
+        recentRequest.invalidate({ immediately: false });
+        recentRequest.execute({
           walletId: wallet.id,
           limit: this.RECENT_TRANSACTIONS_LIMIT,
           skip: 0,
           searchTerm: '',
-        };
-        const recentRequest = this._getTransactionsRecentRequest(wallet.id);
-        recentRequest.invalidate({ immediately: false });
-        recentRequest.execute(requestParams);
+        });
         const allRequest = this._getTransactionsAllRequest(wallet.id);
         allRequest.invalidate({ immediately: false });
-        allRequest.execute(requestParams);
+        allRequest.execute({
+          walletId: wallet.id,
+          limit: this.INITIAL_SEARCH_LIMIT,
+          skip: 0,
+          searchTerm: '',
+        });
       }
     }
   };


### PR DESCRIPTION
This PR increases the limit of `get-all-transactions` call from `5` to `1000`.
We limit number of transactions on Summary screen, but on the Transactions screen all transactions should be shown.