### PR TITLE
[DEVOPS-673] Pin cardano-sl to git revision instead of branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,17 +1,15 @@
 steps:
   - label: 'daedalus-x86_64-darwin'
-    command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION $CARDANO_SL_BRANCH  --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
+    command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
       VERSION: 1.1.0
-      CARDANO_SL_BRANCH: release/1.1.0
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       NETWORK: mainnet
     agents:
       system: x86_64-darwin
   - label: 'daedalus-x86_64-linux'
-    command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION $CARDANO_SL_BRANCH  --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
+    command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
       VERSION: 1.1.0
-      CARDANO_SL_BRANCH: release/1.1.0
     agents:
       system: x86_64-linux

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ Daedalus - cryptocurrency wallet
 Platform-specific build scripts facilitate building Daedalus the way it is built
 by the IOHK CI:
 
-   - `scripts/build-installer-unix.sh     <DAEDALUS-VERSION> <CARDANO-BRANCH> [OPTIONS..]`
+   - `scripts/build-installer-unix.sh     <DAEDALUS-VERSION> [OPTIONS..]`
       - where OS is either `linux` or `osx`
-      - facilitates installer upload to S3 via `--upload-s3`
-   - `scripts/build-installer-windows.bat <DAEDALUS-VERSION> <CARDANO-BRANCH>`
+   - `scripts/build-installer-windows.bat <DAEDALUS-VERSION>`
 
 The result can be found at:
-   - on OS X:    `${BUILD}/installers/dist/Daedalus-installer-*.pkg`
+   - on OS X:    `${BUILD}/installers/dist/csl-daedalus/Daedalus-installer-*.pkg`
    - on WIndows: `${BUILD}/installers/daedalus-*-installer.exe`
 
 ### One-click build-fresh-daedalus scripts

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private-2/iohk-windows-certificate-4.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% release/1.1.0
+  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION%
 
 artifacts:
   - path: release\win32-x64\Daedalus-win32-x64

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://github.com/input-output-hk/cardano-sl",
+    "fetchSubmodules": "true",
+    "rev": "1bba2fd0183f575752f4529182205e04074db336",
+    "sha256": "1qfi307x7nfp42ldb6sjx30mk7b0zfvd4b48pmyd9g465f7sp420"
+}

--- a/cardano-sl.nix
+++ b/cardano-sl.nix
@@ -15,20 +15,5 @@ let
     gitrev = cardano-sl-src.rev;
   };
 
-in stdenv.mkDerivation {
-  name = "daedalus";
-
-  buildInputs = [
-    nix bash binutils coreutils curl gnutar
-    git python27 curl electron nodejs-6_x
-    nodePackages.node-gyp nodePackages.node-pre-gyp
-    gnumake
-  ];
-
-  passthru = {
-    inherit (cardano-sl-pkgs) daedalus-bridge;
-  };
-
-  src = null;
-
-}
+in
+  cardano-sl-pkgs

--- a/default.nix
+++ b/default.nix
@@ -25,6 +25,10 @@ in stdenv.mkDerivation {
     gnumake
   ];
 
+  passthru = {
+    inherit (cardano-sl-pkgs) daedalus-bridge;
+  };
+
   src = null;
 
 }

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,21 @@
-with (import (fetchTarball https://github.com/NixOS/nixpkgs/archive/fb235c98d839ae37a639695ad088d19ef8382608.tar.gz) {});
-# NOTE: when bumping nixpkgs, also update nixpkgs-src.json
+let
+  localLib = import ./lib.nix;
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
+}:
 
-stdenv.mkDerivation {
+with pkgs;
+
+let
+  # we allow on purpose for cardano-sl to have it's own nixpkgs to avoid rebuilds
+  cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);
+  cardano-sl-pkgs = import (pkgs.fetchgit cardano-sl-src) {
+    gitrev = cardano-sl-src.rev;
+  };
+
+in stdenv.mkDerivation {
   name = "daedalus";
 
   buildInputs = [

--- a/installers/AppVeyor.hs
+++ b/installers/AppVeyor.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE NoImplicitPrelude, OverloadedStrings, LambdaCase, RecordWildCards, DeriveDataTypeable, DeriveGeneric #-}
+
+module AppVeyor (downloadCardanoSL, AppVeyorError(..)) where
+
+import Universum hiding (get)
+import Data.Aeson
+import GitHub hiding (URL)
+import GitHub.Endpoints.Repos.Statuses
+import qualified GitHub as GH
+import qualified Data.ByteString.Lazy.Char8 as L8
+import qualified Data.Text as T
+import Network.URI
+import Data.Maybe (mapMaybe)
+import Network.Wreq
+import Data.Aeson.Lens
+import Lens.Micro
+import Turtle.Format (printf, (%), d, s, w, Format, makeFormat)
+import GHC.Generics
+
+-- | Gets CardanoSL.zip corresponding to the src json revision from AppVeyor CI
+downloadCardanoSL :: FilePath -> IO L8.ByteString
+downloadCardanoSL srcJson = do
+  src@CardanoSource{..} <- getCardanoRev srcJson
+  printf ("Fetching GitHub CI status for commit "%n%" of "%n%"/"%n%"\n") srcRev srcOwner srcRepo
+  buildURL <- appVeyorURL src
+  printf ("Build URL is "%s%"\n") (getUrl buildURL)
+  jobs <- appVeyorJobs buildURL
+  printf ("Build has "%d%" job(s), status "%ss%".\n") (length jobs)
+    (map (show . jobStatus) jobs)
+  arts <- appVeyorArtifacts $ map jobId jobs
+  printf ("Artifacts are: "%ss%"\n") (map fst arts)
+  case findAppVeyorArtifact "CardanoSL.zip" arts of
+    Just bs -> printf "Done\n" >> pure bs
+    Nothing -> throwM (MissingArtifactsError $ getUrl buildURL)
+
+n :: Format r (Name a -> r)
+n = makeFormat untagName
+
+ss :: Format r ([Text] -> r)
+ss = makeFormat (T.intercalate ",")
+
+----------------------------------------------------------------------------
+
+-- | Given a build status URL, query AppVeyor for job IDs.
+appVeyorJobs :: GH.URL -> IO [Job]
+appVeyorJobs buildURL = do
+  let Just req = buildAPI buildURL
+  r <- asValue =<< get (show req)
+  pure (r ^.. responseBody . buildJobs)
+
+-- | Download all artifacts for all job ids.
+appVeyorArtifacts :: [Text] -> IO [(Text, L8.ByteString)]
+appVeyorArtifacts = fmap concat . mapM artifactForJobId
+
+-- | Filter the artifact we are interested in.
+findAppVeyorArtifact :: Text -> [(Text, L8.ByteString)] -> Maybe L8.ByteString
+findAppVeyorArtifact name arts = head [bs | (name', bs) <- arts, name' == name]
+
+-- | Downloads all artifacts for a job.
+-- Returns the filename and contents.
+artifactForJobId :: Text -> IO [(Text, L8.ByteString)]
+artifactForJobId jobId = do
+  let req = jobArtifactsURI jobId
+  r <- asValue =<< get req
+  forM (r ^.. responseBody . artifactFilenames) $ \filename -> do
+    let req' = req ++ ('/':T.unpack filename)
+    printf ("Downloading "%w%" ... ") req'
+    r' <- get req'
+    printf "done\n"
+    pure (filename, r' ^. responseBody)
+
+-- | Looks into AppVeyor API build info json to get job IDs
+buildJobs :: Monoid r => Getting r Value Job
+buildJobs = key "build" . key "jobs" . _Array . traverse . _JSON
+
+-- | Looks into AppVeyor API job artifacts json to get the filenames
+artifactFilenames :: Monoid r => Getting r Value Text
+artifactFilenames = _Array . traverse . key "fileName" . _String
+
+-- | The AppVeyor API URL of an build, given its web URL.
+buildAPI :: GH.URL -> Maybe URI
+buildAPI = parseAbsoluteURI . T.unpack . T.replace "/project/" "/api/projects/" . getUrl
+
+-- | The AppVeyor API URL to list artifacts belonging to a job.
+jobArtifactsURI :: Text -> String
+jobArtifactsURI jobId = "https://ci.appveyor.com/api/buildJobs/" <> T.unpack jobId <> "/artifacts"
+
+-- | Use GitHub API to find AppVeyor build status
+appVeyorURL :: CardanoSource -> IO GH.URL
+appVeyorURL src = fmap collect <$> statusFor' src >>= \case
+  Right (Just u) -> pure u
+  Right Nothing  -> throwM $ StatusMissingError src
+  Left err       -> throwM $ GitHubStatusError src err
+  where
+    collect = head . mapMaybe statusTargetUrl . filter isAppVeyor .
+              toList . combinedStatusStatuses
+    isAppVeyor st = statusContext st == Just "continuous-integration/appveyor/branch"
+
+statusFor' :: CardanoSource -> IO (Either GH.Error GH.CombinedStatus)
+statusFor' CardanoSource{..} = statusFor noAuth srcOwner srcRepo srcRev
+  where noAuth = BasicAuth "" ""
+
+data JobStatus = JobSuccess | JobFailed | JobRunning
+               | JobUnknown Text deriving (Show, Eq, Generic)
+
+data Job = Job { jobId :: Text
+               , jobStatus :: JobStatus
+               } deriving (Show, Eq, Generic)
+
+instance FromJSON JobStatus where
+  parseJSON = withText "status" $ \case
+    "success" -> pure JobSuccess
+    "failed" -> pure JobFailed
+    "running" -> pure JobRunning
+    other -> pure $ JobUnknown other
+
+instance FromJSON Job where
+  parseJSON = withObject "Job" $ \o -> Job <$> o .: "jobId" <*> o .: "status"
+
+instance ToJSON JobStatus
+instance ToJSON Job -- Only required for _JSON prism
+
+----------------------------------------------------------------------------
+
+-- | Load commit hash and GitHub repo name from cardano-sl-src.json.
+getCardanoRev :: FilePath -> IO CardanoSource
+getCardanoRev src = eitherDecode <$> L8.readFile src >>= \case
+  Right rev -> pure rev
+  Left err -> throwM (SourceJSONDecodeError err)
+
+data CardanoSource = CardanoSource
+  { srcOwner :: Name Owner
+  , srcRepo  :: Name Repo
+  , srcRev   :: Name Commit
+  } deriving (Show, Eq)
+
+instance FromJSON CardanoSource where
+  parseJSON = withObject "fetchGit source" $ \o -> do
+    (owner, repo) <- parseGitHubURL <$> o .: "url"
+    CardanoSource owner repo <$> o .: "rev"
+
+instance FromJSON URI where
+  parseJSON = withText "Absolute URI" $ \u -> case parseAbsoluteURI (T.unpack u) of
+    Just uri -> pure uri
+    Nothing -> fail "Could not parse absolute URI"
+
+-- | Gets owner/repo from gitcom.com URL
+parseGitHubURL :: URI -> (Name Owner, Name Repo)
+parseGitHubURL uri = (fromString owner, fromString (drop 1 repo))
+  where (owner, repo) = break (== '/') (drop 1 $ uriPath uri)
+
+----------------------------------------------------------------------------
+
+data AppVeyorError = SourceJSONDecodeError String
+                   | GitHubStatusError CardanoSource GH.Error
+                   | StatusMissingError CardanoSource
+                   | MissingArtifactsError Text
+                   deriving (Show, Typeable)
+
+instance Exception AppVeyorError

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -89,8 +89,6 @@ makeInstaller opts@Options{..} appRoot = do
 
       -- Config files (from daedalus-bridge)
       copyFile (bridge </> "config/configuration.yaml") (dir </> "configuration.yaml")
-      genesisFiles <- glob (bridge </> "config/*genesis*.json")
-      procs "cp" (fmap toText (genesisFiles <> [dir])) mempty
       copyFile (bridge </> "config/log-config-prod.yaml") (dir </> "log-config-prod.yaml")
 
       -- Genesis (from daedalus-bridge)

--- a/installers/README.md
+++ b/installers/README.md
@@ -54,11 +54,11 @@ for a certificate decryption password, or you can put this in the
 
 The cardano-sl node and configuration files used by the installer
 builder are available as the `daedalus-bridge` attribute of the
-top-level file [`default.nix`](../default.nix). To get/build the
+top-level file [`cardano-sl.nix`](../cardano-sl.nix). To get/build the
 files, run:
 
-    nix-build -A daedalus-bridge
-    ls result
+    nix-build cardano-sl.nix -A daedalus-bridge
+    ls result/
 
 To update the cardano-sl version, update the revision in
 [`cardano-sl-src.json`](../cardano-sl-src.json). This replaces the

--- a/installers/README.md
+++ b/installers/README.md
@@ -49,3 +49,17 @@ Before signing the Mac installer, the keychain needs to be set up. Do this by ru
 The certificate is required to be in PKCS#12 format. It will prompt
 for a certificate decryption password, or you can put this in the
 `CERT_PASS` environment variable.
+
+## Bumping cardano-sl version
+
+The cardano-sl node and configuration files used by the installer
+builder are available as the `daedalus-bridge` attribute of the
+top-level file [`default.nix`](../default.nix). To get/build the
+files, run:
+
+    nix-build -A daedalus-bridge
+    ls result
+
+To update the cardano-sl version, update the revision in
+[`cardano-sl-src.json`](../cardano-sl-src.json). This replaces the
+`CARDANO_SL_BRANCH` environment variable which was previously used.

--- a/installers/RewriteLibs.hs
+++ b/installers/RewriteLibs.hs
@@ -44,7 +44,7 @@ chain dir args@(x:xs) = do
             -- parse again all libraries pointing to nix store that we haven't processed yet
             let libs = filter (isPrefixOf "/nix/store/") files
             filtered <- traverse (patchLib x dir) libs
-            chained <- chain dir (xs ++ (filter (\f -> notElem f args) $ catMaybes filtered))
+            chained <- chain dir (xs ++ (filter (\f -> not $ elem f args) $ catMaybes filtered))
             return $ x : chained
 chain _ [] = return []
 

--- a/installers/Types.hs
+++ b/installers/Types.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 module Types
   (  -- * Atomic types
-    API(..)
-  , OS(..)
+    OS(..)
   , Cluster(..)
   , Config(..)
   , CI(..)
@@ -29,11 +28,6 @@ import qualified Universum
 import           Prelude
 
 
-
-data API
-  = Cardano
-  | ETC
-  deriving (Bounded, Enum, Eq, Read, Show)
 
 data OS
   = Linux

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -3,11 +3,11 @@ module WindowsInstaller
     ( main
     ) where
 
-import           Universum hiding (pass, writeFile)
+import           Universum hiding (pass, writeFile, stdout)
 
 import           Control.Monad (unless)
 import qualified Data.List as L
-import           Data.Maybe (fromJust, fromMaybe)
+import           Data.Maybe (fromJust)
 import           Data.Monoid ((<>))
 import           Data.Text (Text, unpack)
 import qualified Data.Text as T
@@ -23,9 +23,13 @@ import           Development.NSIS (Attrib (IconFile, IconIndex, RebootOK, Recurs
 import           Prelude ((!!))
 import           System.Directory (doesFileExist)
 import           System.Environment (lookupEnv)
+import           System.FilePath ((</>))
 import           System.IO (writeFile)
-import           Turtle (ExitCode (..), echo, proc, procs, shells)
+import           Filesystem.Path.CurrentOS (decodeString)
+import           Turtle (ExitCode (..), echo, proc, procs, shells, testfile, stdout, input)
 import           Turtle.Line (unsafeTextToLine)
+import           AppVeyor
+import qualified Codec.Archive.Zip    as Zip
 
 import           Config
 import           Types
@@ -207,6 +211,9 @@ main opts@Options{..}  = do
     echo "Packaging frontend"
     packageFrontend
 
+    fetchCardanoSL "."
+    printCardanoBuildInfo "."
+
     echo "Adding permissions manifest to cardano-launcher.exe"
     procs "C:\\Program Files (x86)\\Windows Kits\\8.1\\bin\\x64\\mt.exe" ["-manifest", "cardano-launcher.exe.manifest", "-outputresource:cardano-launcher.exe;#1"] mempty
 
@@ -223,3 +230,22 @@ main opts@Options{..}  = do
     echo "Generating NSIS installer"
     procs "C:\\Program Files (x86)\\NSIS\\makensis" ["daedalus.nsi"] mempty
     signFile opts $ unpack fullName
+
+-- | Download and extract the cardano-sl windows build.
+fetchCardanoSL :: FilePath -> IO ()
+fetchCardanoSL dst = do
+  bs <- downloadCardanoSL "../cardano-sl-src.json"
+  let opts = [Zip.OptDestination dst, Zip.OptVerbose]
+  Zip.extractFilesFromArchive opts (Zip.toArchive bs)
+
+printCardanoBuildInfo :: MonadIO io => FilePath -> io ()
+printCardanoBuildInfo dst = do
+  let buildInfo what f = do
+        let f' = decodeString (dst </> f)
+        e <- testfile f'
+        when e $ do
+          echo what
+          stdout (input f')
+  buildInfo "cardano-sl build-id:" "build-id"
+  buildInfo "cardano-sl commit-id:" "commit-id"
+  buildInfo "cardano-sl ci-url:" "ci-url"

--- a/installers/daedalus-installer.cabal
+++ b/installers/daedalus-installer.cabal
@@ -1,6 +1,6 @@
-name:                cardano-installer
+name:                daedalus-installer
 version:             0.1.0.0
-synopsis:            Cardano Installer
+synopsis:            Daedalus Installer Builder
 description:         Please see README.md
 license:             MIT
 author:              Serokell

--- a/installers/daedalus-installer.cabal
+++ b/installers/daedalus-installer.cabal
@@ -15,7 +15,7 @@ executable make-installer
   other-modules:       MacInstaller
                      , WindowsInstaller
                      , RewriteLibs
-
+                     , AppVeyor
   build-depends:       base
                      , bytestring
                      , containers
@@ -23,6 +23,7 @@ executable make-installer
                      , dhall-json
                      , directory
                      , filepath
+                     , github
                      , Glob
                      , megaparsec
                      , nsis
@@ -37,6 +38,13 @@ executable make-installer
                      , turtle
                      , universum
                      , yaml
+                     , wreq
+                     , lens-aeson
+                     , zip-archive
+                     , microlens
+                     , network-uri
+                     , bytestring
+                     , aeson
 
   default-language:    Haskell2010
   ghc-options:         -threaded -rtsopts

--- a/installers/daedalus-installer.nix
+++ b/installers/daedalus-installer.nix
@@ -5,7 +5,7 @@
 , cabal-install, nodejs, nix
 }:
 mkDerivation {
-  pname = "cardano-installer";
+  pname = "daedalus-installer";
   version = "0.1.0.0";
   src = ./.;
   isLibrary = false;
@@ -16,6 +16,6 @@ mkDerivation {
     trifecta turtle universum yaml
     cabal-install nodejs nix
   ];
-  description = "Cardano Installer";
+  description = "Daedalus Installer Builder";
   license = stdenv.lib.licenses.mit;
 }

--- a/installers/daedalus-installer.nix
+++ b/installers/daedalus-installer.nix
@@ -1,8 +1,9 @@
-{ mkDerivation, base, bytestring, dhall, dhall-json, directory
-, filepath, Glob, megaparsec, nsis, optparse-applicative, split
-, stdenv, system-filepath, temporary, text, trifecta, turtle
-, universum, yaml
-, cabal-install, nodejs, nix
+{ mkDerivation, aeson, base, bytestring, containers, dhall
+, dhall-json, directory, filepath, github, Glob, lens-aeson
+, megaparsec, microlens, network-uri, nsis, optional-args
+, optparse-applicative, optparse-generic, split, stdenv
+, system-filepath, temporary, text, turtle, universum, wreq, yaml
+, zip-archive
 }:
 mkDerivation {
   pname = "daedalus-installer";
@@ -11,10 +12,11 @@ mkDerivation {
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
-    base bytestring dhall dhall-json directory filepath Glob megaparsec
-    nsis optparse-applicative split system-filepath temporary text
-    trifecta turtle universum yaml
-    cabal-install nodejs nix
+    aeson base bytestring containers dhall dhall-json directory
+    filepath github Glob lens-aeson megaparsec microlens network-uri
+    nsis optional-args optparse-applicative optparse-generic split
+    system-filepath temporary text turtle universum wreq yaml
+    zip-archive
   ];
   description = "Daedalus Installer Builder";
   license = stdenv.lib.licenses.mit;

--- a/installers/default.nix
+++ b/installers/default.nix
@@ -14,6 +14,7 @@ let
     overrides = self: super: {
       dhall-json = self.callPackage ./dhall-json.nix {};
       dhall = doJailbreak (self.callPackage ./dhall-haskell.nix {});
+      github = self.callPackage ./github.nix {};
     };
   };
 

--- a/installers/default.nix
+++ b/installers/default.nix
@@ -1,32 +1,22 @@
-with (import (fetchTarball https://github.com/NixOS/nixpkgs/archive/56ebd9129956339ab98ba2f40cb233df0735f5a1.tar.gz) { config = {}; });
+let
+  localLib = import ../lib.nix;
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
+}:
 
+with pkgs;
 with haskell.lib;
 
-(justStaticExecutables (haskell.packages.ghc802.callPackage ./cardano-installer.nix {})).override
-  (with haskell.packages.ghc802; {
-    dhall-json = (overrideCabal dhall-json (drv: {
-      src = pkgs.fetchFromGitHub {
-        owner  = "dhall-lang";
-        repo   = "dhall-json";
-        rev    = "d6adaa265dcf8ab5899396b05d612b2d8092dca4";
-        sha256 = "0pvbpbg6475drvpakny12y3z2dv0vj6x4hlk853dgb84xbsd8i33";
-      };
-      jailbreak = true;
-    })).override {
-      dhall      = overrideCabal dhall (drv: {
-        src = pkgs.fetchFromGitHub {
-          owner  = "dhall-lang";
-          repo   = "dhall-haskell";
-          rev    = "4a085aa3d622886cf7dd96a1ad475ba914d5ab1f";
-          sha256 = "0849rvv9m5rgxgvn60q2bwfr7m1syjkgxrrs4xafs10ymfdx0g9f";
-        };
-        jailbreak = true;
-        libraryHaskellDepends = drv.libraryHaskellDepends ++ [
-          insert-ordered-containers
-          lens-family-core
-          prettyprinter-ansi-terminal
-          repline
-        ];
-      });
+let
+  haskellPackages = haskell.packages.ghc802.override {
+    overrides = self: super: {
+      dhall-json = self.callPackage ./dhall-json.nix {};
+      dhall = doJailbreak (self.callPackage ./dhall-haskell.nix {});
     };
-  })
+  };
+
+in
+
+  justStaticExecutables (haskellPackages.callPackage ./daedalus-installer.nix {})

--- a/installers/dhall-haskell.nix
+++ b/installers/dhall-haskell.nix
@@ -1,0 +1,39 @@
+{ mkDerivation, ansi-terminal, ansi-wl-pprint, base
+, base16-bytestring, bytestring, case-insensitive, containers
+, contravariant, cryptonite, deepseq, directory, exceptions
+, fetchgit, filepath, formatting, haskeline, http-client
+, http-client-tls, insert-ordered-containers, lens-family-core
+, memory, mtl, optparse-generic, parsers, prettyprinter
+, prettyprinter-ansi-terminal, repline, scientific, stdenv, tasty
+, tasty-hunit, text, transformers, trifecta, unordered-containers
+, vector
+}:
+mkDerivation {
+  pname = "dhall";
+  version = "1.11.1";
+  src = fetchgit {
+    url = "https://github.com/dhall-lang/dhall-haskell.git";
+    rev    = "4a085aa3d622886cf7dd96a1ad475ba914d5ab1f";
+    sha256 = "0849rvv9m5rgxgvn60q2bwfr7m1syjkgxrrs4xafs10ymfdx0g9f";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    ansi-wl-pprint base base16-bytestring bytestring case-insensitive
+    containers contravariant cryptonite directory exceptions filepath
+    formatting http-client http-client-tls insert-ordered-containers
+    lens-family-core memory parsers prettyprinter
+    prettyprinter-ansi-terminal scientific text transformers trifecta
+    unordered-containers vector
+  ];
+  executableHaskellDepends = [
+    ansi-terminal base haskeline mtl optparse-generic prettyprinter
+    prettyprinter-ansi-terminal repline text trifecta
+  ];
+  testHaskellDepends = [
+    base deepseq insert-ordered-containers prettyprinter tasty
+    tasty-hunit text vector
+  ];
+  description = "A configuration language guaranteed to terminate";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/installers/dhall-json.nix
+++ b/installers/dhall-json.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, aeson-pretty, base, bytestring, dhall
+, fetchgit, optparse-generic, stdenv, text, trifecta
+, unordered-containers, yaml
+}:
+mkDerivation {
+  pname = "dhall-json";
+  version = "1.0.12";
+  src = fetchgit {
+    url = "https://github.com/dhall-lang/dhall-json";
+    sha256 = "0pvbpbg6475drvpakny12y3z2dv0vj6x4hlk853dgb84xbsd8i33";
+    rev = "d6adaa265dcf8ab5899396b05d612b2d8092dca4";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base bytestring dhall text trifecta unordered-containers
+  ];
+  executableHaskellDepends = [
+    aeson aeson-pretty base bytestring dhall optparse-generic text yaml
+  ];
+  description = "Compile Dhall to JSON or YAML";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/installers/github.nix
+++ b/installers/github.nix
@@ -1,0 +1,32 @@
+{ mkDerivation, aeson, aeson-compat, base, base-compat
+, base16-bytestring, binary, binary-orphans, byteable, bytestring
+, containers, cryptohash, deepseq, deepseq-generics, exceptions
+, file-embed, hashable, hspec, hspec-discover, http-client
+, http-client-tls, http-link-header, http-types, iso8601-time, mtl
+, network-uri, semigroups, stdenv, text, time, tls, transformers
+, transformers-compat, unordered-containers, vector
+, vector-instances
+}:
+mkDerivation {
+  pname = "github";
+  version = "0.18";
+  sha256 = "31dc02d345e46b09bbc7ae7b898102630b2861b50814a13f6265c6929ad18c44";
+  revision = "2";
+  editedCabalFile = "1rywfb78acwh81mdnxb4q35n374k1wbxg0562biis0i0jjxfp211";
+  libraryHaskellDepends = [
+    aeson aeson-compat base base-compat base16-bytestring binary
+    binary-orphans byteable bytestring containers cryptohash deepseq
+    deepseq-generics exceptions hashable http-client http-client-tls
+    http-link-header http-types iso8601-time mtl network-uri semigroups
+    text time tls transformers transformers-compat unordered-containers
+    vector vector-instances
+  ];
+  testHaskellDepends = [
+    aeson-compat base base-compat bytestring file-embed hspec
+    unordered-containers vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/phadej/github";
+  description = "Access to the GitHub API, v3";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/installers/shell.nix
+++ b/installers/shell.nix
@@ -1,1 +1,1 @@
-(import ./default.nix).env
+(import ./default.nix {}).env

--- a/installers/stack.yaml
+++ b/installers/stack.yaml
@@ -10,7 +10,9 @@ nix:
 
 extra-deps:
   - universum-0.8.0
-  #   allow-newer: true
+  - microlens-0.4.8.1
+  - github-0.18
+  - zip-archive-0.3.1.1
 
 packages:
   - location: .

--- a/lib.nix
+++ b/lib.nix
@@ -1,0 +1,7 @@
+let
+  fetchNixPkgs = import ./fetch-nixpkgs.nix;
+  pkgs = import fetchNixPkgs {};
+  lib = pkgs.lib;
+in lib // (rec {
+  inherit fetchNixPkgs;
+})

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -108,7 +108,7 @@ if [ -n "${NIX_SSL_CERT_FILE-}" ]; then export SSL_CERT_FILE=$NIX_SSL_CERT_FILE;
 ARTIFACT_BUCKET=ci-output-sink
 
 # Build/get cardano bridge which is used by make-installer
-export DAEDALUS_BRIDGE=$(nix-build --no-out-link default.nix -A daedalus-bridge)
+export DAEDALUS_BRIDGE=$(nix-build --no-out-link cardano-sl.nix -A daedalus-bridge)
 # Note: Printing build-id is required for the iohk-ops find-installers
 # script which searches in buildkite logs.
 if [ -f $DAEDALUS_BRIDGE/build-id ]; then echo "cardano-sl build id is $(cat $DAEDALUS_BRIDGE/build-id)"; fi

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -138,7 +138,7 @@ cd installers
           INSTALLER_CMD+="  --cluster          ${cluster}"
           INSTALLER_CMD+="  --daedalus-version ${DAEDALUS_VERSION}"
           INSTALLER_CMD+="  --output           ${INSTALLER_PKG}"
-          $nix_shell --run "${INSTALLER_CMD}"
+          $nix_shell ../shell.nix --run "${INSTALLER_CMD}"
 
           APP_NAME="csl-daedalus"
 

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -108,7 +108,7 @@ if [ -n "${NIX_SSL_CERT_FILE-}" ]; then export SSL_CERT_FILE=$NIX_SSL_CERT_FILE;
 ARTIFACT_BUCKET=ci-output-sink
 
 # Build/get cardano bridge which is used by make-installer
-export DAEDALUS_BRIDGE=$(nix-build --no-out-link cardano-sl.nix -A daedalus-bridge)
+DAEDALUS_BRIDGE=$(nix-build --no-out-link cardano-sl.nix -A daedalus-bridge)
 # Note: Printing build-id is required for the iohk-ops find-installers
 # script which searches in buildkite logs.
 if [ -f $DAEDALUS_BRIDGE/build-id ]; then echo "cardano-sl build id is $(cat $DAEDALUS_BRIDGE/build-id)"; fi
@@ -133,7 +133,7 @@ cd installers
                     INSTALLER_PKG="Daedalus-installer-${DAEDALUS_VERSION}-${cluster}.pkg"
 
           INSTALLER_CMD="$INSTALLER/bin/make-installer ${pull_request} ${test_installer}"
-          INSTALLER_CMD+="  ${API:+--api $API}"
+          INSTALLER_CMD+="  --cardano          ${DAEDALUS_BRIDGE}"
           INSTALLER_CMD+="  --build-job        ${BUILDKITE_BUILD_NUMBER}"
           INSTALLER_CMD+="  --cluster          ${cluster}"
           INSTALLER_CMD+="  --daedalus-version ${DAEDALUS_VERSION}"

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -58,7 +58,6 @@ pull_request=
 test_installer=
 
 daedalus_version="$1"; arg2nz "daedalus version" $1; shift
-cardano_branch="$(printf '%s' "$1" | tr '/' '-')"; arg2nz "Cardano SL branch to build Daedalus with" $1; shift
 
 # Parallel build options for Buildkite agents only
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
@@ -106,28 +105,14 @@ export PATH=$HOME/.local/bin:$PATH
 export DAEDALUS_VERSION=${daedalus_version}.${build_id}
 if [ -n "${NIX_SSL_CERT_FILE-}" ]; then export SSL_CERT_FILE=$NIX_SSL_CERT_FILE; fi
 
-CARDANO_BUILD_UID="${OS_NAME}-${cardano_branch//\//-}"
-ARTIFACT_BUCKET=ci-output-sink        # ex- cardano-sl-travis
-CARDANO_ARTIFACT=cardano-binaries     # ex- daedalus-bridge
-CARDANO_ARTIFACT_FULL_NAME=${CARDANO_ARTIFACT}-${CARDANO_BUILD_UID}
+ARTIFACT_BUCKET=ci-output-sink
 
-test -d node_modules/daedalus-client-api/ -a -n "${fast_impure}" || {
-        retry 5 curl -o ${CARDANO_ARTIFACT_FULL_NAME}.tar.xz \
-              "https://s3.eu-west-1.amazonaws.com/${ARTIFACT_BUCKET}/cardano-sl/${CARDANO_ARTIFACT_FULL_NAME}.tar.xz"
-        mkdir -p node_modules/daedalus-client-api/
-        du -sh  ${CARDANO_ARTIFACT_FULL_NAME}.tar.xz
-        tar xJf ${CARDANO_ARTIFACT_FULL_NAME}.tar.xz --strip-components=1 -C node_modules/daedalus-client-api/
-        rm      ${CARDANO_ARTIFACT_FULL_NAME}.tar.xz
-        echo "cardano-sl build id is $(cat node_modules/daedalus-client-api/build-id)"
-        if [ -f node_modules/daedalus-client-api/commit-id ]; then echo "cardano-sl revision is $(cat node_modules/daedalus-client-api/commit-id)"; fi
-        if [ -f node_modules/daedalus-client-api/ci-url ]; then echo "cardano-sl ci-url is $(cat node_modules/daedalus-client-api/ci-url)"; fi
-        pushd node_modules/daedalus-client-api
-              mv log-config-prod.yaml cardano-node cardano-launcher configuration.yaml *genesis*.json ../../installers
-        popd
-        chmod +w installers/cardano-{node,launcher}
-        strip installers/cardano-{node,launcher}
-        rm -f node_modules/daedalus-client-api/cardano-*
-}
+# Build/get cardano bridge which is used by make-installer
+export DAEDALUS_BRIDGE=$(nix-build --no-out-link default.nix -A daedalus-bridge)
+# Note: Printing build-id is required for the iohk-ops find-installers
+# script which searches in buildkite logs.
+if [ -f $DAEDALUS_BRIDGE/build-id ]; then echo "cardano-sl build id is $(cat $DAEDALUS_BRIDGE/build-id)"; fi
+if [ -f $DAEDALUS_BRIDGE/commit-id ]; then echo "cardano-sl revision is $(cat $DAEDALUS_BRIDGE/commit-id)"; fi
 
 test "$(find node_modules/ | wc -l)" -gt 100 -a -n "${fast_impure}" ||
         $nix_shell --run "npm install"

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -137,7 +137,6 @@ pushd installers
 
 if NOT DEFINED APPVEYOR_BUILD_NUMBER        ( set APPVEYOR_BUILD_NUMBER=0 )
 set XARGS="--build-job %APPVEYOR_BUILD_NUMBER% -v %DAEDALUS_VERSION%"
-IF     DEFINED API                          ( set XARGS="%XARGS:"=% --api %API%" )
 IF     DEFINED APPVEYOR_PULL_REQUEST_NUMBER ( set XARGS="%XARGS:"=% --pull-request %APPVEYOR_PULL_REQUEST_NUMBER%" )
 
 FOR %%C IN (%CLUSTERS:"=%) DO (

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -12,27 +12,20 @@ set /p CLUSTERS=<installer-clusters.cfg
 @echo ###
 @echo ##############################################################################
 
-set MIN_CARDANO_BYTES=20000000
 set LIBRESSL_VERSION=2.5.3
 set CURL_VERSION=7.54.0
-set CARDANO_BRANCH_DEFAULT=release/1.1.0
-set DAEDALUS_VERSION_DEFAULT=local-dev-build-%CARDANO_BRANCH_DEFAULT%
+set DAEDALUS_VERSION_DEFAULT=local-dev-build
 
 set DAEDALUS_VERSION=%1
 @if [%DAEDALUS_VERSION%]==[] (@echo WARNING: DAEDALUS_VERSION [argument #1] wasnt provided, defaulting to %DAEDALUS_VERSION_DEFAULT%
     set DAEDALUS_VERSION=%DAEDALUS_VERSION_DEFAULT%);
-set CARDANO_BRANCH=%2
-@if [%CARDANO_BRANCH%]==[]   (@echo WARNING: CARDANO_BRANCH [argument #2] wasnt provided, defaulting to %CARDANO_BRANCH_DEFAULT%
-    set CARDANO_BRANCH=%CARDANO_BRANCH_DEFAULT%);
 
 set CURL_URL=https://bintray.com/artifact/download/vszakats/generic/curl-%CURL_VERSION%-win64-mingw.7z
 set CURL_BIN=curl-%CURL_VERSION%-win64-mingw\bin
-set CARDANO_URL=https://ci.appveyor.com/api/projects/input-output/cardano-sl/artifacts/CardanoSL.zip?branch=%CARDANO_BRANCH%
 set LIBRESSL_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip
 set DLLS_URL=https://s3.eu-central-1.amazonaws.com/daedalus-ci-binaries/DLLs.zip
 
 @echo Building Daedalus version:  %DAEDALUS_VERSION%
-@echo ..with Cardano branch:      %CARDANO_BRANCH%
 @echo ..with LibreSSL version:    %LIBRESSL_VERSION%
 @echo .
 
@@ -68,51 +61,6 @@ call npm install
 @if %errorlevel% neq 0 (@echo FAILED: npm install
     exit /b 1)
 :after_node
-
-@if not [%SKIP_CARDANO_FETCH%]==[] (@echo "WARNING: SKIP_CARDANO_FETCH set, not re-fetching Cardano"
-    goto :after_cardano_fetch)
-@echo ##############################################################################
-@echo ###
-@echo ### Obtaining Cardano from branch %CARDANO_BRANCH%
-@echo ###
-@echo ##############################################################################
-rmdir /s/q node_modules\daedalus-client-api 2>nul
-mkdir      node_modules\daedalus-client-api
-
-pushd node_modules\daedalus-client-api
-    del /f CardanoSL.zip 2>nul
-    ..\..\curl --location %CARDANO_URL% -o CardanoSL.zip
-    @if %errorlevel% neq 0 (@echo FAILED: couldn't obtain the cardano-sl package
-	popd & exit /b 1)
-    @for /F "usebackq" %%A in ('CardanoSL.zip') do set size=%%~zA
-    if %size% lss %MIN_CARDANO_BYTES% (@echo FAILED: CardanoSL.zip is too small: threshold=%MIN_CARDANO_BYTES%, actual=%size% bytes
-        popd & exit /b 1)
-popd
-:after_cardano_fetch
-
-pushd node_modules\daedalus-client-api
-    7z x CardanoSL.zip -y
-    @if %errorlevel% neq 0 (@echo FAILED: 7z x CardanoSL.zip -y
-	popd & exit /b 1)
-popd
-
-@echo ##############################################################################
-@echo ###
-@echo ### cardano-sl build-id:
-@type node_modules\daedalus-client-api\build-id
-@echo ### cardano-sl commit-id:
-@type node_modules\daedalus-client-api\commit-id
-@echo ### cardano-sl ci-url:
-@type node_modules\daedalus-client-api\ci-url
-@echo ###
-@echo ##############################################################################
-
-move   node_modules\daedalus-client-api\log-config-prod.yaml installers\log-config-prod.yaml
-move   node_modules\daedalus-client-api\cardano-node.exe     installers\
-move   node_modules\daedalus-client-api\cardano-launcher.exe installers\
-move   node_modules\daedalus-client-api\configuration.yaml installers\
-move   node_modules\daedalus-client-api\*genesis*.json installers\
-del /f node_modules\daedalus-client-api\*.exe
 
 @echo ##############################################################################
 @echo ###

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -129,8 +129,8 @@ pushd installers
     call ..\scripts\appveyor-retry stack install dhall dhall-json
     @if %errorlevel% neq 0 (@echo FATAL: persistent failure while installing dhall/dhall-json
         popd & exit /b 1)
-    call ..\scripts\appveyor-retry stack --no-terminal -j 2 install cardano-installer
-    @if %errorlevel% neq 0 (@echo FATAL: persistent failure while installing cardano-installer
+    call ..\scripts\appveyor-retry stack --no-terminal -j 2 install daedalus-installer
+    @if %errorlevel% neq 0 (@echo FATAL: persistent failure while installing daedalus-installer
         popd & exit /b 1)
 
 :build_installers

--- a/scripts/link-bridge.sh
+++ b/scripts/link-bridge.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-npm link daedalus-client-api

--- a/scripts/osx-build-fresh-daedalus.sh
+++ b/scripts/osx-build-fresh-daedalus.sh
@@ -4,7 +4,7 @@
 #   2. 'nix-shell'
 #   3. 'stack'
 
-DEFAULT_DAEDALUS_BRANCH=cardano-sl-0.4
+DEFAULT_DAEDALUS_BRANCH=master
 
 DAEDALUS_BRANCH=${1:-${DEFAULT_DAEDALUS_BRANCH}}
 GITHUB_USER=${2:-input-output-hk}
@@ -54,6 +54,5 @@ pushd daedalus
 
     scripts/build-installer-unix.sh \
             "${GITHUB_USER}-${DAEDALUS_BRANCH}-$(git show-ref --hash HEAD)" \
-            "${DEFAULT_DAEDALUS_BRANCH}" \
             "$@"
 popd

--- a/scripts/unlink-bridge.sh
+++ b/scripts/unlink-bridge.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-npm unlink daedalus-client-api
-touch ./node_modules/daedalus-client-api

--- a/scripts/windows-build-fresh-daedalus.bat
+++ b/scripts/windows-build-fresh-daedalus.bat
@@ -3,7 +3,7 @@ rem   1. Node.js ('npm' binary in PATH)
 rem   2. 7zip    ('7z'  binary in PATH)
 rem   3. Git     ('git' binary in PATH)
 
-@set DEFAULT_DAEDALUS_BRANCH=cardano-sl-0.4
+@set DEFAULT_DAEDALUS_BRANCH=master
 
 set DAEDALUS_BRANCH=%1
 @if [%DAEDALUS_BRANCH%]==[] (set DAEDALUS_BRANCH=%DEFAULT_DAEDALUS_BRANCH%)
@@ -26,8 +26,5 @@ git clone %URL%
     @for /f %%a in ('git show-ref --hash HEAD') do set version=%%a
     @call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat"
 
-    @rem NOTE: we're setting the CARDANO_BRANCH to DEFAULT_DAEDALUS_BRANCH:
-    @rem       1. there's no obvious better choice
-    @rem       2. this is intended as a workflow script sitting outside the repository, anyway
-    call scripts\build-installer-win64 %GITHUB_USER%-%DAEDALUS_BRANCH%-%version% %DEFAULT_DAEDALUS_BRANCH%
+    call scripts\build-installer-win64 %GITHUB_USER%-%DAEDALUS_BRANCH%-%version%
 @popd

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,23 @@
+let
+  localLib = import ./lib.nix;
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
+}:
+
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "daedalus";
+
+  buildInputs = [
+    nix bash binutils coreutils curl gnutar
+    git python27 curl electron nodejs-6_x
+    nodePackages.node-gyp nodePackages.node-pre-gyp
+    gnumake
+  ];
+
+  src = null;
+
+}


### PR DESCRIPTION
With input-output-hk/cardano-sl#2671, there is a `daedalus-bridge` which provides cardano-sl programs and config files.

This change integrates that cardano-sl built by nix into the installer build, according to a specific git revision, rather than downloading the latest build from a branch.
