### PR TITLE
Fix/ddw 199 fix disabled form-fields background color

### DIFF
--- a/source/renderer/app/components/widgets/forms/InlineEditingInput.scss
+++ b/source/renderer/app/components/widgets/forms/InlineEditingInput.scss
@@ -3,18 +3,11 @@
   position: relative;
 
   :global {
-    .SimpleFormField_root {
-      .SimpleFormField_label {
-        color: var(--theme-input-label-color);
-      }
-    }
-
     .SimpleInput_disabled {
-      background: none;
-      & .SimpleInput_input {
+      .SimpleInput_input {
         background-color: var(--theme-input-background-color);
         border-color: var(--theme-input-border-color);
-        color: var(--theme-input-text-color) !important;
+        color: var(--theme-input-text-color);
       }
     }
   }

--- a/source/renderer/app/components/widgets/forms/ReadOnlyInput.scss
+++ b/source/renderer/app/components/widgets/forms/ReadOnlyInput.scss
@@ -3,18 +3,11 @@
   position: relative;
 
   :global {
-    .SimpleFormField_root {
-      .SimpleFormField_label {
-        color: var(--theme-input-label-color);
-      }
-    }
-
     .SimpleInput_disabled {
-      background: none;
       .SimpleInput_input {
         background-color: var(--theme-input-background-color);
         border-color: var(--theme-input-border-color);
-        color: var(--theme-input-text-color) !important;
+        color: var(--theme-input-text-color);
       }
     }
   }

--- a/source/renderer/app/themes/daedalus/cardano.js
+++ b/source/renderer/app/themes/daedalus/cardano.js
@@ -103,7 +103,8 @@ export default {
   '--theme-input-remove-color-lighter': '#ec5d6b',
   '--theme-input-remove-color-lightest': '#fac8ce',
   '--theme-input-background-color': '#fafbfc',
-  '--theme-input-disabled-background-color': '#cfcfcf',
+  '--theme-input-disabled-background-color': 'rgba(94, 96, 102, 0.05)',
+  '--theme-input-disabled-border-color': 'rgba(94, 96, 102, 0.05)',
   '--theme-input-focus-border-color': '#5e6066',
 
   '--theme-main-body-background-color': '#efefef',

--- a/source/renderer/app/themes/daedalus/dark-blue.js
+++ b/source/renderer/app/themes/daedalus/dark-blue.js
@@ -103,7 +103,8 @@ export default {
   '--theme-input-remove-color-lighter': '#ec5d6b',
   '--theme-input-remove-color-lightest': '#393546',
   '--theme-input-background-color': '#263345',
-  '--theme-input-disabled-background-color': '#cfcfcf',
+  '--theme-input-disabled-background-color': 'rgba(135, 147, 161, 0.1)',
+  '--theme-input-disabled-border-color': 'rgba(135, 147, 161, 0.1)',
   '--theme-input-focus-border-color': '#667a8a',
 
   '--theme-main-body-background-color': '#0b1926',

--- a/source/renderer/app/themes/daedalus/light-blue.js
+++ b/source/renderer/app/themes/daedalus/light-blue.js
@@ -103,7 +103,8 @@ export default {
   '--theme-input-remove-color-lighter': '#ec5d6b',
   '--theme-input-remove-color-lightest': '#fac8ce',
   '--theme-input-background-color': '#fafbfc',
-  '--theme-input-disabled-background-color': '#cfcfcf',
+  '--theme-input-disabled-background-color': 'rgba(94, 96, 102, 0.05)',
+  '--theme-input-disabled-border-color': 'rgba(94, 96, 102, 0.05)',
   '--theme-input-focus-border-color': '#5e6066',
 
   '--theme-main-body-background-color': '#ebeff2',

--- a/source/renderer/app/themes/simple/SimpleFormField.scss
+++ b/source/renderer/app/themes/simple/SimpleFormField.scss
@@ -11,3 +11,11 @@
 .label {
   color: var(--theme-input-label-color);
 }
+
+.disabled {
+  background: none !important;
+
+  .label {
+    color: var(--theme-input-label-color);
+  }
+}

--- a/source/renderer/app/themes/simple/SimpleInput.scss
+++ b/source/renderer/app/themes/simple/SimpleInput.scss
@@ -8,3 +8,7 @@
     color: var(--theme-input-right-floating-text-color);
   }
 }
+
+.disabled {
+  color: var(--theme-input-placeholder-color);
+}

--- a/source/renderer/app/themes/simple/_config.scss
+++ b/source/renderer/app/themes/simple/_config.scss
@@ -16,7 +16,7 @@ $input-border: 1px solid var(--theme-input-border-color);
 $input-border-focus-color: var(--theme-input-focus-border-color);
 $input-color: var(--theme-input-text-color);
 $input-disabled-bg-color: var(--theme-input-disabled-background-color);
-$input-disabled-color: var(--theme-input-placeholder-color);
+$input-disabled-color: var(--theme-input-disabled-border-color);
 $input-placeholder-color: var(--theme-input-placeholder-color);
 $input-errored-border-color: var(--theme-input-error-color);
 
@@ -70,7 +70,7 @@ $textarea-color: var(--theme-input-text-color);
 $textarea-placeholder-color: var(--theme-input-placeholder-color);
 $textarea-border: 1px solid var(--theme-input-border-color);
 $textarea-border-focus-color: var(--theme-input-focus-border-color);
-$textarea-disabled-border-color: #cfcfcf !default;
+$textarea-disabled-border-color: var(--theme-input-disabled-border-color);
 $textarea-disabled-bg-color: var(--theme-input-disabled-background-color);
 $textarea-bg-color: var(--theme-input-background-color);
 $textarea-error-color: var(--theme-input-error-color);


### PR DESCRIPTION
This PR fixes bad styling of the disabled form input elements which was the result of React-Polymorph misconfiguration.

### Before the fix:
![screen shot 2018-03-21 at 12 46 38](https://user-images.githubusercontent.com/376611/37742408-c4fbd876-2d65-11e8-975f-568f6c0361fa.png)
![screen shot 2018-03-21 at 12 52 45](https://user-images.githubusercontent.com/376611/37742409-c51fa3d2-2d65-11e8-96ff-9b969f84d4b5.png)

### After the fix:
![screen shot 2018-03-21 at 23 51 47](https://user-images.githubusercontent.com/376611/37742423-d0e50ee6-2d65-11e8-9bbb-31468cae3b29.png)
![screen shot 2018-03-21 at 23 53 09](https://user-images.githubusercontent.com/376611/37742424-d0fe8df8-2d65-11e8-9028-1d8388a228cc.png)
