### PR TITLE
[DEVOPS-673] Further merges with DEVOPS-13

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,38 +1,21 @@
 let
-  defaults = {
-    master_config = {
-      # TODO DEVOPS-673
-      cardano_rev = "eef095";
-      cardano_hash = "151qjqswrcscr2afsc6am4figw09hyxr80nd3dv3c35dvp2xx4rp";
-    };
-    pkgs = import (import ./fetchNixpkgs.nix (builtins.fromJSON (builtins.readFile ./nixpkgs-src.json))) { config = {}; overlays = []; };
-  };
-in { cluster ? "mainnet", master_config ? defaults.master_config, pkgs ? defaults.pkgs, version ? "versionNotSet" }:
+  localLib = import ./lib.nix;
+in
+{ system ? builtins.currentSystem
+, config ? {}
+, pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
+, cluster ? "mainnet"
+, version ? "versionNotSet"
+}:
+
 let
   installPath = ".daedalus";
+  cardanoPkgs = import ./cardano-sl.nix {
+    inherit system config pkgs;
+  };
   packages = self: {
-    inherit cluster master_config pkgs version;
-    cardanoSrc = pkgs.fetchFromGitHub {
-      owner = "input-output-hk";
-      repo = "cardano-sl";
-      rev = self.master_config.cardano_rev;
-      sha256 = self.master_config.cardano_hash;
-    };
-    cardanoPkgs = import self.cardanoSrc {
-      gitrev = self.cardanoSrc.rev;
-      config = {
-        packageOverrides = pkgs: {
-          rocksdb = pkgs.rocksdb.overrideDerivation (drv: {
-            outputs = [ "dev" "out" "static" ];
-            postInstall = ''
-              ${drv.postInstall}
-              mkdir -pv $static/lib/
-              mv -vi $out/lib/librocksdb.a $static/lib/
-            '';
-          });
-        };
-      };
-    };
+    inherit cluster pkgs version;
+    inherit (cardanoPkgs) daedalus-bridge;
     daedalus = self.callPackage ./installers/nix/linux.nix {};
     rawapp = self.callPackage ./yarn2nix.nix { api = "ada"; };
     nix-bundle = import (pkgs.fetchFromGitHub {
@@ -63,7 +46,6 @@ let
       cat /etc/resolv.conf > etc/resolv.conf
       exec .${self.nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -c -m /home:/home -m /etc:/host-etc -m etc:/etc -p DISPLAY -p HOME -p XAUTHORITY -- /nix/var/nix/profiles/profile/bin/enter-phase2 daedalus
     '';
-    versionInfo = builtins.toFile "versioninfo.json" (builtins.toJSON self.master_config);
     postInstall = pkgs.writeScriptBin "post-install" ''
       #!${pkgs.stdenv.shell}
 
@@ -77,8 +59,6 @@ let
       exec 2>&1 > $DAEDALUS_DIR/Logs/pub/post-install.log
 
       echo "in post-install hook"
-      cat ${self.versionInfo}
-      echo
 
       cp -f ${self.iconPath} $DAEDALUS_DIR/icon.png
       cp -Lf ${self.namespaceHelper}/bin/namespaceHelper $DAEDALUS_DIR/namespaceHelper

--- a/installers/MacInstaller.hs
+++ b/installers/MacInstaller.hs
@@ -22,12 +22,11 @@ import           Control.Monad (unless)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           System.Directory (copyFile, createDirectoryIfMissing, doesFileExist, renameFile)
-import           System.Environment (setEnv)
 import           System.FilePath ((</>), FilePath)
 import           System.FilePath.Glob (glob)
 import           Filesystem.Path.CurrentOS (encodeString)
 import qualified Filesystem.Path as P
-import           Turtle (Shell, ExitCode (..), echo, proc, procs, inproc, which, Managed, with, printf, (%), l, s, pwd, cd, sh, mktree)
+import           Turtle (Shell, ExitCode (..), echo, proc, procs, inproc, which, Managed, with, printf, (%), l, s, pwd, cd, sh, mktree, export)
 import           Turtle.Line (unsafeTextToLine)
 
 import           RewriteLibs (chain)
@@ -72,7 +71,7 @@ npmPackage = do
   mktree "release"
   echo "~~~ Installing nodejs dependencies..."
   procs "npm" ["install"] empty
-  liftIO $ setEnv "NODE_ENV" "production"
+  export "NODE_ENV" "production"
   echo "~~~ Running electron packager script..."
   procs "npm" ["run", "package"] empty
   size <- inproc "du" ["-sh", "release"] empty

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -116,9 +116,6 @@ DAEDALUS_BRIDGE=$(nix-build --no-out-link cardano-sl.nix -A daedalus-bridge)
 if [ -f $DAEDALUS_BRIDGE/build-id ]; then echo "cardano-sl build id is $(cat $DAEDALUS_BRIDGE/build-id)"; fi
 if [ -f $DAEDALUS_BRIDGE/commit-id ]; then echo "cardano-sl revision is $(cat $DAEDALUS_BRIDGE/commit-id)"; fi
 
-test "$(find node_modules/ | wc -l)" -gt 100 -a -n "${fast_impure}" ||
-        $nix_shell --run "npm install"
-
 cd installers
     echo '~~~ Prebuilding dependencies for cardano-installer, quietly..'
     $nix_shell default.nix --run true || echo "Prebuild failed!"


### PR DESCRIPTION
This changes the nix build to use `cardanoPkgs.daedalus-bridge` from DEVOPS-673.
