### PR TITLE
Fix/ddw 160 Debug context menu copy & paste actions on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ Changelog
 ### Fixes
 
 - Updated moment.js dependency to the latest version which fixes ReDOS vulnerability ([PR 782](https://github.com/input-output-hk/daedalus/pull/782))
-- Remove 5 transactions limit from transactions screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
-- Fix broken copy & paste context menu actions on Windows ([PR 816](https://github.com/input-output-hk/daedalus/pull/816))
+- Fixed bug causing only 5 transactions to be shown on the transaction list screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
+- Fixed broken copy & paste context menu actions on Windows ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 
 ### Chores
 
 - Improve build system ([PR 692](https://github.com/input-output-hk/daedalus/pull/692))
+- New Edit section in system menu with copy & paste and related actions ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 
 ## 0.9.0
 =======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 
 - Updated moment.js dependency to the latest version which fixes ReDOS vulnerability ([PR 782](https://github.com/input-output-hk/daedalus/pull/782))
 - Remove 5 transactions limit from transactions screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
+- Fix broken copy & paste context menu actions on Windows ([PR 816](https://github.com/input-output-hk/daedalus/pull/816))
 
 ### Chores
 

--- a/source/main/menus/osx.js
+++ b/source/main/menus/osx.js
@@ -16,29 +16,29 @@ export const osxMenu = (app, window, openAbout) => (
     submenu: [{
       label: 'Undo',
       accelerator: 'Command+Z',
-      selector: 'undo:'
+      role: 'undo'
     }, {
       label: 'Redo',
       accelerator: 'Shift+Command+Z',
-      selector: 'redo:'
+      role: 'redo'
     }, {
       type: 'separator'
     }, {
       label: 'Cut',
       accelerator: 'Command+X',
-      selector: 'cut:'
+      role: 'cut'
     }, {
       label: 'Copy',
       accelerator: 'Command+C',
-      selector: 'copy:'
+      role: 'copy'
     }, {
       label: 'Paste',
       accelerator: 'Command+V',
-      selector: 'paste:'
+      role: 'paste'
     }, {
       label: 'Select All',
       accelerator: 'Command+A',
-      selector: 'selectAll:'
+      role: 'selectall'
     }]
   }, {
     label: 'View',

--- a/source/main/menus/win-linux.js
+++ b/source/main/menus/win-linux.js
@@ -1,33 +1,62 @@
 export const winLinuxMenu = (app, window, openAbout) => (
   [{
-    label: '&Daedalus',
+    label: 'Daedalus',
     submenu: [{
-      label: '&About',
+      label: 'About',
       click() {
         openAbout();
       }
     }, {
-      label: '&Close',
+      label: 'Close',
       accelerator: 'Ctrl+W',
       click() {
         app.quit();
       }
     }]
   }, {
-    label: '&View',
+    label: 'Edit',
+    submenu: [{
+      label: 'Undo',
+      accelerator: 'Ctrl+Z',
+      role: 'undo'
+    }, {
+      label: 'Redo',
+      accelerator: 'Shift+Ctrl+Z',
+      role: 'redo'
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Cut',
+      accelerator: 'Ctrl+X',
+      role: 'cut'
+    }, {
+      label: 'Copy',
+      accelerator: 'Ctrl+C',
+      role: 'copy'
+    }, {
+      label: 'Paste',
+      accelerator: 'Ctrl+V',
+      role: 'paste'
+    }, {
+      label: 'Select All',
+      accelerator: 'Ctrl+A',
+      role: 'selectall'
+    }]
+  }, {
+    label: 'View',
     submenu: [
       {
-        label: '&Reload',
+        label: 'Reload',
         accelerator: 'Ctrl+R',
         click() { window.webContents.reload(); }
       },
       {
-        label: 'Toggle &Full Screen',
+        label: 'Toggle Full Screen',
         accelerator: 'F11',
         click() { window.setFullScreen(!window.isFullScreen()); }
       },
       {
-        label: 'Toggle &Developer Tools',
+        label: 'Toggle Developer Tools',
         accelerator: 'Alt+Ctrl+I',
         click() { window.toggleDevTools(); }
       }

--- a/source/main/windows/main.js
+++ b/source/main/windows/main.js
@@ -46,8 +46,8 @@ export const createMainWindow = () => {
 
   window.webContents.on('context-menu', (e, props) => {
     const contextMenuOptions = [
-      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-      { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+      { label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
     ];
 
     if (environment.isDev() || environment.isTest()) {


### PR DESCRIPTION
This PR fixes broken copy&past context menu actions on Windows.
It also adds an `Edit` tab with various options to the application menu:

![screen shot 2018-03-28 at 13 08 26](https://user-images.githubusercontent.com/376611/38025660-6a64168e-3289-11e8-915d-8f4e4f32cba1.png)
