### PR TITLE
Fix/ddw 160 Debug context menu copy & paste actions on Windows [HOTFIX]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 ### Fixes
 
 - Remove 5 transactions limit from transactions screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
+- Fix broken copy & paste context menu actions on Windows ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Changelog
 
 ### Fixes
 
-- Remove 5 transactions limit from transactions screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
-- Fix broken copy & paste context menu actions on Windows ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
+- Fixed bug causing only 5 transactions to be shown on the transaction list screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
+- Fixed broken copy & paste context menu actions on Windows ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 
 ### Chores
 
@@ -21,6 +21,7 @@ Changelog
 - Do not block the UI while wallet is being restored/imported ([PR 457](https://github.com/input-output-hk/daedalus/pull/457))
 - Start and stop Mantis Client from Daedalus main process ([PR 568](https://github.com/input-output-hk/daedalus/pull/568))
 - Add ADA and Mantis logo to loader screens ([PR 584](https://github.com/input-output-hk/daedalus/pull/584))
+- New Edit section in system menu with copy & paste and related actions ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 
 ### Fixes
 

--- a/electron/main.development.js
+++ b/electron/main.development.js
@@ -228,8 +228,8 @@ app.on('ready', async () => {
 
   mainWindow.webContents.on('context-menu', (e, props) => {
     const contextMenuOptions = [
-      { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
-      { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
+      { label: 'Copy', accelerator: 'CmdOrCtrl+C', role: 'copy' },
+      { label: 'Paste', accelerator: 'CmdOrCtrl+V', role: 'paste' },
     ];
 
     if (isDev || isTest) {

--- a/electron/menus/osx.js
+++ b/electron/menus/osx.js
@@ -16,29 +16,29 @@ export default (app, window, openAbout) => (
     submenu: [{
       label: 'Undo',
       accelerator: 'Command+Z',
-      selector: 'undo:'
+      role: 'undo'
     }, {
       label: 'Redo',
       accelerator: 'Shift+Command+Z',
-      selector: 'redo:'
+      role: 'redo'
     }, {
       type: 'separator'
     }, {
       label: 'Cut',
       accelerator: 'Command+X',
-      selector: 'cut:'
+      role: 'cut'
     }, {
       label: 'Copy',
       accelerator: 'Command+C',
-      selector: 'copy:'
+      role: 'copy'
     }, {
       label: 'Paste',
       accelerator: 'Command+V',
-      selector: 'paste:'
+      role: 'paste'
     }, {
       label: 'Select All',
       accelerator: 'Command+A',
-      selector: 'selectAll:'
+      role: 'selectall'
     }]
   }, {
     label: 'View',

--- a/electron/menus/win-linux.js
+++ b/electron/menus/win-linux.js
@@ -1,33 +1,62 @@
-export default (app, window, openAbout) => (
+export const winLinuxMenu = (app, window, openAbout) => (
   [{
-    label: '&Daedalus',
+    label: 'Daedalus',
     submenu: [{
-      label: '&About',
+      label: 'About',
       click() {
         openAbout();
       }
     }, {
-      label: '&Close',
+      label: 'Close',
       accelerator: 'Ctrl+W',
       click() {
         app.quit();
       }
     }]
   }, {
-    label: '&View',
+    label: 'Edit',
+    submenu: [{
+      label: 'Undo',
+      accelerator: 'Ctrl+Z',
+      role: 'undo'
+    }, {
+      label: 'Redo',
+      accelerator: 'Shift+Ctrl+Z',
+      role: 'redo'
+    }, {
+      type: 'separator'
+    }, {
+      label: 'Cut',
+      accelerator: 'Ctrl+X',
+      role: 'cut'
+    }, {
+      label: 'Copy',
+      accelerator: 'Ctrl+C',
+      role: 'copy'
+    }, {
+      label: 'Paste',
+      accelerator: 'Ctrl+V',
+      role: 'paste'
+    }, {
+      label: 'Select All',
+      accelerator: 'Ctrl+A',
+      role: 'selectall'
+    }]
+  }, {
+    label: 'View',
     submenu: [
       {
-        label: '&Reload',
+        label: 'Reload',
         accelerator: 'Ctrl+R',
         click() { window.webContents.reload(); }
       },
       {
-        label: 'Toggle &Full Screen',
+        label: 'Toggle Full Screen',
         accelerator: 'F11',
         click() { window.setFullScreen(!window.isFullScreen()); }
       },
       {
-        label: 'Toggle &Developer Tools',
+        label: 'Toggle Developer Tools',
         accelerator: 'Alt+Ctrl+I',
         click() { window.toggleDevTools(); }
       }


### PR DESCRIPTION
This PR fixes broken copy&past context menu actions on Windows.
It also adds an `Edit` tab with various options to the application menu:

![screen shot 2018-03-28 at 13 08 26](https://user-images.githubusercontent.com/376611/38025660-6a64168e-3289-11e8-915d-8f4e4f32cba1.png)
