### PR TITLE
[DEVOPS-758] CI Bump version to 1.1.1 and use cardano-sl master branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,8 +2,8 @@ steps:
   - label: 'daedalus-x86_64-darwin'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION $CARDANO_SL_BRANCH  --build-id $BUILDKITE_BUILD_NUMBER --pr-id $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.1.0
-      CARDANO_SL_BRANCH: release/1.1.0
+      VERSION: 1.1.1
+      CARDANO_SL_BRANCH: master
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       NETWORK: mainnet
     agents:
@@ -11,7 +11,7 @@ steps:
   - label: 'daedalus-x86_64-linux'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION $CARDANO_SL_BRANCH  --build-id $BUILDKITE_BUILD_NUMBER --pr-id $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.1.0
-      CARDANO_SL_BRANCH: release/1.1.0
+      VERSION: 1.1.1
+      CARDANO_SL_BRANCH: master
     agents:
       system: x86_64-linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
     osx_image: xcode8.3
 env:
   global:
-    - VERSION=1.1
+    - VERSION=1.1.1
     - NETWORK=mainnet
-    - CARDANO_SL_BRANCH=release/1.1.0
+    - CARDANO_SL_BRANCH=master
       # NOTE: when bumping nixpkgs, also update default.nix
     - NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/fb235c98d839ae37a639695ad088d19ef8382608.tar.gz
     # AWS access key

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER aws s3 cp --region eu-central-1 s3://iohk-private-2/iohk-windows-certificate-4.p12 C:/iohk-windows-certificate.p12
 
 test_script:
-  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% release/1.1.0
+  - scripts\build-installer-win64.bat %APPVEYOR_BUILD_VERSION% master
 
 artifacts:
   - path: release\win32-x64\Daedalus-win32-x64


### PR DESCRIPTION
- Bumped version 1.1.0 -> 1.1.1.

- Now that cardano-sl is fully using git flow, the master branch will correspond to the latest production release.

- Windows installer version remains as `1.1.{build}`
