### PR TITLE
Fix/ddw 150 Send manual bug report wrong text color in Dark blue theme

### DIFF
--- a/source/renderer/app/components/profile/bug-report/BugReportDialog.scss
+++ b/source/renderer/app/components/profile/bug-report/BugReportDialog.scss
@@ -14,6 +14,7 @@
 
 .bugReportAlternativeText {
   margin-top: 14px;
+
   ol {
     list-style: decimal;
     margin-left: 20px;
@@ -21,12 +22,13 @@
   }
 
   p, li {
+    color: var(--theme-instructions-text-color);
     font-family: var(--font-light);
     font-size: 16px;
     font-weight: 300;
     line-height: 1.38;
     margin-bottom: 6px;
-    color: #5e6066;
+
     strong {
       font-weight: 500;
     }


### PR DESCRIPTION
This PR fixes text color issues within Manual bug report dialog in Dark blue theme.
The color for this part of UI was hardcoded which means all 3 themes used the same value (appropriate for Light blue theme).

![screen shot 2018-04-03 at 13 05 02](https://user-images.githubusercontent.com/376611/38245886-3b63abd6-3740-11e8-88c3-d86e23808c11.png)
