### PR TITLE
Fix/ddw 155 Transaction with 0 confirmations should be in pending

### DIFF
--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -201,7 +201,7 @@ export default class Transaction extends Component<Props, State> {
                 , {moment(data.date).format('hh:mm:ss A')}
               </div>
 
-              {state === transactionStates.OK ? (
+              {(state === transactionStates.OK) && (data.numberOfConfirmations > 0) ? (
                 <div className={styles[assuranceLevel]}>{status}</div>
               ) : (
                 <div className={styles[`${state}Label`]}>
@@ -231,7 +231,7 @@ export default class Transaction extends Component<Props, State> {
               <h2>
                 {intl.formatMessage(messages[
                   environment.isEtcApi() ? 'fromAddress' : 'fromAddresses'
-                  ])}
+                ])}
               </h2>
               {data.addresses.from.map((address, addressIndex) => (
                 <span key={`${data.id}-from-${address}-${addressIndex}`} className={styles.address}>{address}</span>
@@ -239,7 +239,7 @@ export default class Transaction extends Component<Props, State> {
               <h2>
                 {intl.formatMessage(messages[
                   environment.isEtcApi() ? 'toAddress' : 'toAddresses'
-                  ])}
+                ])}
               </h2>
               {data.addresses.to.map((address, addressIndex) => (
                 <span key={`${data.id}-to-${address}-${addressIndex}`} className={styles.address}>{address}</span>


### PR DESCRIPTION
This PR fixes an issue where transaction with 0 confirmations shows in `low` transaction assurance state instead of `transaction pending` state.