### PR TITLE
Chore/ddw 171 Print Daedalus version in application title

### DIFF
--- a/source/common/environment.js
+++ b/source/common/environment.js
@@ -1,6 +1,7 @@
 // @flow
 import os from 'os';
 import { remote } from 'electron';
+import { version } from '../../package.json';
 
 const environment = Object.assign({
   DEVELOPMENT: 'development',
@@ -19,6 +20,7 @@ const environment = Object.assign({
   isEtcApi: () => environment.API === 'etc',
   build: process.env.DAEDALUS_VERSION || 'dev',
   platform: os.platform(),
+  version,
 }, remote ? remote.getGlobal('env') : process.env);
 
 export default environment;

--- a/source/main/windows/main.js
+++ b/source/main/windows/main.js
@@ -42,7 +42,10 @@ export const createMainWindow = () => {
 
   window.loadURL(`file://${__dirname}/../renderer/index.html`);
   window.on('page-title-updated', event => { event.preventDefault(); });
-  window.setTitle(`Daedalus (${environment.build}) ${environment.current}`);
+
+  let title = `Daedalus (${environment.version}#${environment.build})`;
+  if (!environment.isProduction()) title += ` ${environment.current}`;
+  window.setTitle(title);
 
   window.webContents.on('context-menu', (e, props) => {
     const contextMenuOptions = [

--- a/source/renderer/app/components/static/About.js
+++ b/source/renderer/app/components/static/About.js
@@ -21,11 +21,6 @@ const messages = defineMessages({
     defaultMessage: '!!!Daedalus',
     description: 'About "title"',
   },
-  aboutReleaseVersion: {
-    id: 'static.about.release.version',
-    defaultMessage: '!!!0.8.2',
-    description: 'Label for "App Release Version"',
-  },
   aboutContentDaedalusHeadline: {
     id: 'static.about.content.daedalus.headline',
     defaultMessage: '!!!Daedalus Team:',
@@ -101,7 +96,7 @@ export default class About extends Component<any> {
         platform = '';
     }
 
-    const build = environment.build;
+    const { version, build } = environment;
     const apiName = intl.formatMessage(environmentSpecificMessages[environment.API].apiName);
     const apiVersion = intl.formatMessage(environmentSpecificMessages[environment.API].apiVersion);
     const apiIcon = environment.isAdaApi() ? cardanoIcon : mantisIcon;
@@ -125,7 +120,7 @@ export default class About extends Component<any> {
             <div className={styles.daedalusTitle}>
               {intl.formatMessage(messages.aboutTitle)}
               <span className={styles.daedalusVersion}>
-                {intl.formatMessage(messages.aboutReleaseVersion)}
+                {version}
               </span>
             </div>
             <div className={styles.daedalusBuildInfo}>

--- a/source/renderer/app/i18n/locales/de-DE.json
+++ b/source/renderer/app/i18n/locales/de-DE.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "!!!Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.license": "!!!MIT licence",
-  "static.about.release.version": "0.8.2",
   "static.about.title": "!!!Daedalus",
   "systemTime.error.overlayText": "!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are {behindTime} behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website (daedaluswallet.io/faq).",
   "systemTime.error.overlayTitle": "!!!Unable to sync - incorrect time",

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -1160,31 +1160,17 @@
         }
       },
       {
-        "defaultMessage": "!!!0.8.2",
-        "description": "Label for \"App Release Version\"",
+        "defaultMessage": "!!!Daedalus Team:",
+        "description": "About page daedalus team headline",
         "end": {
           "column": 3,
           "line": 28
         },
         "file": "source/renderer/app/components/static/About.js",
-        "id": "static.about.release.version",
-        "start": {
-          "column": 23,
-          "line": 24
-        }
-      },
-      {
-        "defaultMessage": "!!!Daedalus Team:",
-        "description": "About page daedalus team headline",
-        "end": {
-          "column": 3,
-          "line": 33
-        },
-        "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.daedalus.headline",
         "start": {
           "column": 32,
-          "line": 29
+          "line": 24
         }
       },
       {
@@ -1192,13 +1178,13 @@
         "description": "About page cardano team headline",
         "end": {
           "column": 3,
-          "line": 38
+          "line": 33
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.cardano.headline",
         "start": {
           "column": 31,
-          "line": 34
+          "line": 29
         }
       },
       {
@@ -1206,13 +1192,13 @@
         "description": "About page mantis team headline",
         "end": {
           "column": 3,
-          "line": 43
+          "line": 38
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.mantis.headline",
         "start": {
           "column": 30,
-          "line": 39
+          "line": 34
         }
       },
       {
@@ -1220,13 +1206,13 @@
         "description": "About page daedalus team members",
         "end": {
           "column": 3,
-          "line": 48
+          "line": 43
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.daedalus.members",
         "start": {
           "column": 31,
-          "line": 44
+          "line": 39
         }
       },
       {
@@ -1234,13 +1220,13 @@
         "description": "About page cardano team members",
         "end": {
           "column": 3,
-          "line": 53
+          "line": 48
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.cardano.members",
         "start": {
           "column": 30,
-          "line": 49
+          "line": 44
         }
       },
       {
@@ -1248,13 +1234,13 @@
         "description": "About page mantis team members",
         "end": {
           "column": 3,
-          "line": 58
+          "line": 53
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.content.mantis.members",
         "start": {
           "column": 29,
-          "line": 54
+          "line": 49
         }
       },
       {
@@ -1262,13 +1248,13 @@
         "description": "About \"copyright\"",
         "end": {
           "column": 3,
-          "line": 63
+          "line": 58
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.copyright",
         "start": {
           "column": 18,
-          "line": 59
+          "line": 54
         }
       },
       {
@@ -1276,13 +1262,13 @@
         "description": "About page license name",
         "end": {
           "column": 3,
-          "line": 68
+          "line": 63
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.license",
         "start": {
           "column": 15,
-          "line": 64
+          "line": 59
         }
       },
       {
@@ -1290,13 +1276,13 @@
         "description": "About page build information",
         "end": {
           "column": 3,
-          "line": 73
+          "line": 68
         },
         "file": "source/renderer/app/components/static/About.js",
         "id": "static.about.buildInfo",
         "start": {
           "column": 18,
-          "line": 69
+          "line": 64
         }
       }
     ],

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "Input Output HK Limited. Licensed under",
   "static.about.license": "MIT licence",
-  "static.about.release.version": "0.9.0",
   "static.about.title": "Daedalus",
   "systemTime.error.overlayText": "Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are {behindTime} behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:",
   "systemTime.error.overlayTitle": "Unable to sync - incorrect time",

--- a/source/renderer/app/i18n/locales/hr-HR.json
+++ b/source/renderer/app/i18n/locales/hr-HR.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "!!!Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.license": "!!!MIT licence",
-  "static.about.release.version": "0.8.2",
   "static.about.title": "!!!Daedalus",
   "systemTime.error.overlayText": "!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are {behindTime} behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website (daedaluswallet.io/faq).",
   "systemTime.error.overlayTitle": "!!!Unable to sync - incorrect time",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "Input Output HK Limited. Licensed under",
   "static.about.license": "MIT licence",
-  "static.about.release.version": "0.9.0",
   "static.about.title": "ダイダロス",
   "systemTime.error.overlayText": "注意：お使いのマシンの時刻が標準時刻と一致していないために、ダイダロスは同期することができません。 あなたのマシンは {behindTime} 遅れています。この問題を解決するには、DaedalusのウェブサイトのFAQセクションをご覧ください:",
   "systemTime.error.overlayTitle": "同期できません - 時刻の不一致",

--- a/source/renderer/app/i18n/locales/ko-KR.json
+++ b/source/renderer/app/i18n/locales/ko-KR.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "!!!Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.license": "!!!MIT licence",
-  "static.about.release.version": "0.8.2",
   "static.about.title": "!!!Daedalus",
   "systemTime.error.overlayText": "!!!ATTENTION: Time of your machine is different from global time. You are {behindTime} seconds behind. You need to fix issue, because you are gonna be unable to sync system!",
   "systemTime.error.overlayTitle": "!!!Unable to sync - incorrect time",

--- a/source/renderer/app/i18n/locales/zh-CN.json
+++ b/source/renderer/app/i18n/locales/zh-CN.json
@@ -146,7 +146,6 @@
   "static.about.content.mantis.members": "!!!Adam Smolarek, Alan McSherry, Alan Verbner, Alejandro Garcia, Charles Hoskinson, Domen Kožar, Eileen Fitzgerald, Hiroto Shioi, Jane Wild, Jan Ziniewicz, Javier Diaz, Jeremy Wood, Laurie Wang, Łukasz Gąsior, Konrad Staniec, Michael Bishop, Mirko Alić, Nicolás Tallar, Radek Tkaczyk, Serge Kosyrev",
   "static.about.copyright": "!!!2016–2017 IOHK. All rights reserved.",
   "static.about.license": "!!!MIT licence",
-  "static.about.release.version": "0.8.2",
   "static.about.title": "!!!Daedalus",
   "systemTime.error.overlayText": "!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are {behindTime} behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website (daedaluswallet.io/faq).",
   "systemTime.error.overlayTitle": "!!!Unable to sync - incorrect time",


### PR DESCRIPTION
This PR adds Daedalus version into application title. The title will no longer show `current` environment in production.
It also removes version info from localization files and refactors the code to use `environment.version` which is derived from `package.json` version info. This simplifies the version changes as you only need to update the one in `package.json`.

![screen shot 2018-04-03 at 14 01 07](https://user-images.githubusercontent.com/376611/38248329-49d56bb6-3748-11e8-8dcc-575fb17e1e45.png)
