### PR TITLE
Chore/ddw 146 "Attach logs" should be on by default for support requests

### DIFF
--- a/source/renderer/app/actions/profile-actions.js
+++ b/source/renderer/app/actions/profile-actions.js
@@ -11,7 +11,7 @@ export default class ProfileActions {
   resetBugReportDialog: Action<any> = new Action();
   setSendLogsChoice: Action<{ sendLogs: boolean }> = new Action();
   sendBugReport: Action<{
-    email: string, subject: ?string, problem: ?string, compressedLog: ?string,
+    email: string, subject: string, problem: string, compressedLog: ?string,
   }> = new Action();
   updateLocale: Action<{ locale: string }> = new Action();
   updateTheme: Action<{ theme: string }> = new Action();

--- a/source/renderer/app/components/profile/bug-report/BugReportDialog.js
+++ b/source/renderer/app/components/profile/bug-report/BugReportDialog.js
@@ -131,7 +131,6 @@ type Props = {
 
 type State = {
   showLogs: boolean,
-  canLoadLogs: boolean,
 };
 
 @observer
@@ -142,9 +141,12 @@ export default class BugReportDialog extends Component<Props, State> {
   };
 
   state = {
-    showLogs: false,
-    canLoadLogs: true,
+    showLogs: true,
   };
+
+  componentWillMount() {
+    this.props.onGetLogs();
+  }
 
   componentWillReceiveProps(nextProps: Object) {
     const commpressionFilesChanged = this.props.compressedLog !== nextProps.compressedLog;
@@ -225,13 +227,7 @@ export default class BugReportDialog extends Component<Props, State> {
   };
 
   handleLogsSwitchToggle = (value: boolean) => {
-    // prevent multiple logs loading on same dialog, re-enable on open/close dialog
-    if (this.state.canLoadLogs) {
-      this.props.onGetLogs();
-      this.setState({ showLogs: value, canLoadLogs: false });
-    } else {
-      this.setState({ showLogs: value });
-    }
+    this.setState({ showLogs: value });
   };
 
   render() {

--- a/source/renderer/app/containers/profile/dialogs/BugReportDialogContainer.js
+++ b/source/renderer/app/containers/profile/dialogs/BugReportDialogContainer.js
@@ -14,7 +14,7 @@ export default class BugReportDialogContainer extends Component<InjectedProps> {
   static defaultProps = { actions: null, stores: null };
 
   onSubmit = (values: {
-    email: string, subject: ?string, problem: ?string, compressedLog: ?string
+    email: string, subject: string, problem: string, compressedLog: ?string
   }) => {
     this.props.actions.profile.sendBugReport.trigger(values);
   };

--- a/source/renderer/app/stores/ProfileStore.js
+++ b/source/renderer/app/stores/ProfileStore.js
@@ -282,8 +282,8 @@ export default class SettingsStore extends Store {
 
   _sendBugReport = action(({ email, subject, problem, compressedLog } : {
     email: string,
-    subject: ?string,
-    problem: ?string,
+    subject: string,
+    problem: string,
     compressedLog: ?string,
   }) => {
     this.sendBugReport.execute({


### PR DESCRIPTION
This PR sets the "Attach logs" switch by default to true within the support dialog:

![screen shot 2018-04-03 at 16 51 57](https://user-images.githubusercontent.com/376611/38256760-549ffd24-375f-11e8-9a1c-913edada3728.png)

...it also fixed several flow-type issues.