### PR TITLE
Chore/ddw 156 Clicking outside of the dialogs should not close them during wallet creation

### DIFF
--- a/source/renderer/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
+++ b/source/renderer/app/components/wallet/backup-recovery/WalletBackupPrivacyWarningDialog.js
@@ -77,7 +77,7 @@ export default class WalletBackupPrivacyWarningDialog extends Component<Props> {
         className={dialogClasses}
         title={intl.formatMessage(globalMessages.recoveryPhraseDialogTitle)}
         actions={actions}
-        closeOnOverlayClick
+        closeOnOverlayClick={false}
         onClose={onCancelBackup}
         closeButton={<DialogCloseButton onClose={onCancelBackup} />}
       >

--- a/source/renderer/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
+++ b/source/renderer/app/components/wallet/backup-recovery/WalletRecoveryPhraseDisplayDialog.js
@@ -63,7 +63,7 @@ export default class WalletRecoveryPhraseDisplayDialog extends Component<Props> 
         title={intl.formatMessage(globalMessages.recoveryPhraseDialogTitle)}
         actions={actions}
         onClose={onCancelBackup}
-        closeOnOverlayClick
+        closeOnOverlayClick={false}
         closeButton={<DialogCloseButton onClose={onCancelBackup} />}
       >
         <WalletRecoveryInstructions

--- a/source/renderer/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
+++ b/source/renderer/app/components/wallet/backup-recovery/WalletRecoveryPhraseEntryDialog.js
@@ -115,7 +115,7 @@ export default class WalletRecoveryPhraseEntryDialog extends Component<Props> {
         className={dialogClasses}
         title={intl.formatMessage(globalMessages.recoveryPhraseDialogTitle)}
         actions={actions}
-        closeOnOverlayClick
+        closeOnOverlayClick={false}
         onClose={onCancelBackup}
         closeButton={<DialogCloseButton onClose={onCancelBackup} />}
         backButton={!isValid ? <DialogBackButton onBack={onRestartBackup} /> : null}


### PR DESCRIPTION
This PR prevents the closing of the wallet backup dialogs on a click outside of the dialog content.