### PR TITLE
Chore/ddw 165 Daedalus logs should be in UTC instead of local time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog
 - Improve build system ([PR 692](https://github.com/input-output-hk/daedalus/pull/692))
 - New Edit section in system menu with copy & paste and related actions ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
 - Remove sending logs to remote server feature ([PR 818](https://github.com/input-output-hk/daedalus/pull/818))
+- Use UTC time in Daedalus logs ([PR 833](https://github.com/input-output-hk/daedalus/pull/833))
 
 ## 0.9.0
 =======

--- a/source/main/utils/setupLogging.js
+++ b/source/main/utils/setupLogging.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import log from 'electron-log';
+import moment from 'moment';
 import ensureDirectoryExists from './ensureDirectoryExists';
 import { pubLogsFolderPath, APP_NAME } from '../config';
 
@@ -12,5 +13,8 @@ export const setupLogging = () => {
   log.transports.file.level = 'debug';
   log.transports.file.maxSize = 20 * 1024 * 1024;
   log.transports.file.file = logFilePath;
-  log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms} {z}] [{level}] {text}';
+  log.transports.file.format = (msg) => {
+    const formattedDate = moment.utc(msg.date).format('YYYY-MM-DDTHH:mm:ss.0SSS');
+    return `[${formattedDate}Z] [${msg.level}] ${msg.data}`;
+  };
 };


### PR DESCRIPTION
This PR updates the date in Daedalus logs so that it is always shown in UTC instead of local time.

Before (local time - UTC+2):
```
[2018-04-03 21:37:34.0478] [debug] Local difficulty changed: 1124
```

After (UTC time - no timezone info:
```
[2018-04-03T19:37:34.0478Z] [debug] Local difficulty changed: 1124
```