### PR TITLE
Fix/ddw 212 Fix missing application menu on Windows build

### DIFF
--- a/electron/menus/win-linux.js
+++ b/electron/menus/win-linux.js
@@ -1,4 +1,4 @@
-export const winLinuxMenu = (app, window, openAbout) => (
+export default (app, window, openAbout) => (
   [{
     label: 'Daedalus',
     submenu: [{


### PR DESCRIPTION
This PR fixes missing application menu (Daedalus/Edit/View) on Windows build.

**Before the fix:**
![screen shot 2018-04-04 at 18 08 40](https://user-images.githubusercontent.com/376611/38319893-4ef4e338-3833-11e8-9488-28f62adbc3f5.png)

**After the fix:**
![screen shot 2018-04-04 at 18 07 33](https://user-images.githubusercontent.com/376611/38319898-54cd8aee-3833-11e8-9e93-829770fb6e84.png)

