### PR TITLE
[DEVOPS-775] create the shortcut on the desktop after copying the binaries and creating certs

### DIFF
--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -134,7 +134,6 @@ writeInstallerNSIS fullVersion = do
                 createDirectory "$APPDATA\\Daedalus\\Secrets-1.0"
                 createDirectory "$APPDATA\\Daedalus\\Logs"
                 createDirectory "$APPDATA\\Daedalus\\Logs\\pub"
-                createShortcut "$DESKTOP\\Daedalus.lnk" daedalusShortcut
                 file [] "cardano-node.exe"
                 file [] "cardano-launcher.exe"
                 file [] "log-config-prod.yaml"
@@ -158,6 +157,8 @@ writeInstallerNSIS fullVersion = do
                     ]
 
                 execWait "build-certificates-win64.bat \"$INSTDIR\" >\"%APPDATA%\\Daedalus\\Logs\\build-certificates.log\" 2>&1"
+
+                createShortcut "$DESKTOP\\Daedalus.lnk" daedalusShortcut
 
                 -- Uninstaller
                 writeRegStr HKLM "Software/Microsoft/Windows/CurrentVersion/Uninstall/Daedalus" "InstallLocation" "$INSTDIR\\Daedalus"


### PR DESCRIPTION
This PR fixes the broken Daedalus shortcut icon on Windows platform:

![icons](https://user-images.githubusercontent.com/376611/38332361-17ab2446-3856-11e8-8ae4-203481c50f13.png)
