### PR TITLE
[CSL-2435] Use 'TextEncoder' to measure correct length of UTF-8 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog
 - Updated moment.js dependency to the latest version which fixes ReDOS vulnerability ([PR 782](https://github.com/input-output-hk/daedalus/pull/782))
 - Fixed bug causing only 5 transactions to be shown on the transaction list screen ([PR 778](https://github.com/input-output-hk/daedalus/pull/778))
 - Fixed broken copy & paste context menu actions on Windows ([PR 817](https://github.com/input-output-hk/daedalus/pull/817))
+- Fixed non-latin character in wallet name bug ([PR 839](https://github.com/input-output-hk/daedalus/pull/839))
 
 ### Chores
 

--- a/features/wallet-settings.feature
+++ b/features/wallet-settings.feature
@@ -59,6 +59,15 @@ Feature: Wallet Settings
     And I click outside "name" input field
     Then I should see new wallet name "first Edited"
 
+  Scenario: User renames Wallet to a name which includes non-latin characters
+    Given I am on the "first" wallet "settings" screen
+    And I click on "name" input field
+    And I enter new wallet name:
+    | name     |
+    | キュビズム |
+    And I click outside "name" input field
+    Then I should see new wallet name "キュビズム"
+
   Scenario: User changes Wallet assurance level
     Given I am on the "first" wallet "settings" screen
     And I open "Transaction assurance security level" selection dropdown

--- a/source/renderer/app/api/ada/lib/request.js
+++ b/source/renderer/app/api/ada/lib/request.js
@@ -54,7 +54,7 @@ function typedRequest<Response>(
       hasRequestBody = true;
       requestBody = JSON.stringify(rawBodyParams);
       options.headers = {
-        'Content-Length': requestBody.length,
+        'Content-Length': (new TextEncoder()).encode(requestBody).length,
         'Content-Type': 'application/json',
       };
     }


### PR DESCRIPTION
JavaScript length method (with ES6) actually counts unicode punycodes of the UTF-16 encoding of the given string. Apart from messing up with surrogate pairs (counting for instance 💩 as two characters because encoded with a pair or punycodes), it also leads to unexpected results when characters have a different UTF-8 and UTF-16 encoding. 

Since requests are made using UTF-8 encoding, the `Content-Length` of these requests should match the actual length when payloads are UTF-8 encoded.