### PR TITLE
[DEVOPS-776] make-installers: avoid GitHub rate limiting

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
     secure: DbpP02aDGoC3Tdsi3+ONm8ov0nuXzEF/Yi453SBKj38qjROzvPXo6qW44bYiKBf4
   CERT_PASS:
     secure: K+PY2zF/5qeJnnKhcCZaqLnVZuAXvuxCXosnzHdtje1C+BMLfAbCJZVt2wTMEyJT
+  GITHUB_OAUTH_TOKEN:
+    secure: DGcn22uSIJVzPP7A+kvZvOm4VOPkxShppsqOiAlj6PEYjg1u5A/RHx24lCp0zoHH
   # Avoid long paths on Windows
   STACK_ROOT: "c:\\sr"
 


### PR DESCRIPTION
To find `CardanoSL.zip` on Appveyor it uses the GitHub commit status API. This is subject to rate limiting. So provide an OAuth token in an environment variable.
