### PR TITLE
Chore/ddw 204 Update NTP Api endpoint handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog
 - Remove sending logs to remote server feature ([PR 818](https://github.com/input-output-hk/daedalus/pull/818))
 - Updated main and acceptane tests readme files with new acceptance tests setup information ([PR 831](https://github.com/input-output-hk/daedalus/pull/831))
 - Use UTC time in Daedalus logs ([PR 833](https://github.com/input-output-hk/daedalus/pull/833))
+- Updated error message on the NTP time synchronisation error screen ([PR 851](https://github.com/input-output-hk/daedalus/pull/851))
 
 ## 0.9.1
 =======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Changelog
 - Remove sending logs to remote server feature ([PR 818](https://github.com/input-output-hk/daedalus/pull/818))
 - Updated main and acceptane tests readme files with new acceptance tests setup information ([PR 831](https://github.com/input-output-hk/daedalus/pull/831))
 - Use UTC time in Daedalus logs ([PR 833](https://github.com/input-output-hk/daedalus/pull/833))
-- Updated error message on the NTP time synchronisation error screen ([PR 851](https://github.com/input-output-hk/daedalus/pull/851))
+- Updated error message on the NTP time synchronisation error screen ([PR 852](https://github.com/input-output-hk/daedalus/pull/852))
 
 ## 0.9.1
 =======

--- a/source/renderer/app/api/ada/index.js
+++ b/source/renderer/app/api/ada/index.js
@@ -770,7 +770,7 @@ export default class AdaApi {
     try {
       const response: AdaLocalTimeDifference = await getAdaLocalTimeDifference({ ca });
       Logger.debug('AdaApi::getLocalTimeDifference success: ' + stringifyData(response));
-      return response;
+      return Math.abs(response); // time offset direction is irrelevant to the UI
     } catch (error) {
       Logger.error('AdaApi::getLocalTimeDifference error: ' + stringifyError(error));
       throw new GenericApiError();

--- a/source/renderer/app/components/loading/Loading.js
+++ b/source/renderer/app/components/loading/Loading.js
@@ -74,7 +74,7 @@ type Props = {
   hasLoadedCurrentLocale: boolean,
   hasLoadedCurrentTheme: boolean,
   localTimeDifference: number,
-  allowedTimeDifference: number,
+  isSystemTimeCorrect: boolean,
   currentLocale: string,
   handleReportIssue: Function,
   onProblemSolutionClick: Function,
@@ -131,7 +131,7 @@ export default class Loading extends Component<Props, State> {
       hasLoadedCurrentLocale,
       hasLoadedCurrentTheme,
       localTimeDifference,
-      allowedTimeDifference,
+      isSystemTimeCorrect,
       currentLocale,
       handleReportIssue,
       onProblemSolutionClick,
@@ -227,7 +227,7 @@ export default class Loading extends Component<Props, State> {
                 <LoadingSpinner />
               </div>
             )}
-            {(localTimeDifference > allowedTimeDifference) && (
+            {!isSystemTimeCorrect && (
               <SystemTimeErrorOverlay
                 localTimeDifference={localTimeDifference}
                 currentLocale={currentLocale}

--- a/source/renderer/app/components/loading/SystemTimeErrorOverlay.js
+++ b/source/renderer/app/components/loading/SystemTimeErrorOverlay.js
@@ -63,7 +63,7 @@ export default class SystemTimeErrorOverlay extends Component<Props> {
         humanizedDurationLanguage = 'en';
     }
 
-    const behindTime = humanizeDuration(localTimeDifference / 1000, {
+    const timeOffset = humanizeDuration(localTimeDifference / 1000, {
       round: true, // round seconds to prevent e.g. 1 day 3 hours *11,56 seconds*
       language: humanizedDurationLanguage
     }).replace(/,/g, ''); // replace 1 day, 3 hours, 12 seconds* to clean period without comma
@@ -73,7 +73,7 @@ export default class SystemTimeErrorOverlay extends Component<Props> {
 
         <SVGInline svg={attentionIcon} className={styles.icon} />
 
-        <p><FormattedHTMLMessage {...messages.overlayText} values={{ behindTime }} /></p>
+        <p><FormattedHTMLMessage {...messages.overlayText} values={{ timeOffset }} /></p>
 
         <Button
           label={problemSolutionLink}

--- a/source/renderer/app/components/loading/SystemTimeErrorOverlay.js
+++ b/source/renderer/app/components/loading/SystemTimeErrorOverlay.js
@@ -17,7 +17,7 @@ const messages = defineMessages({
   },
   overlayText: {
     id: 'systemTime.error.overlayText',
-    defaultMessage: '!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are 2 hours 12 minutes 54 seconds behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:',
+    defaultMessage: '!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. Your time is off by 2 hours 12 minutes 54 seconds.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:',
     description: 'Text of Sync error overlay'
   },
   problemSolutionLink: {

--- a/source/renderer/app/containers/LoadingPage.js
+++ b/source/renderer/app/containers/LoadingPage.js
@@ -27,7 +27,7 @@ export default class LoadingPage extends Component<InjectedProps> {
     const {
       isConnecting, isSyncing, syncPercentage, isLoadingWallets,
       hasBeenConnected, hasBlockSyncingStarted, localTimeDifference,
-      ALLOWED_TIME_DIFFERENCE,
+      isSystemTimeCorrect,
     } = stores.networkStatus;
     const { hasLoadedCurrentLocale, hasLoadedCurrentTheme, currentLocale } = stores.profile;
     return (
@@ -37,7 +37,7 @@ export default class LoadingPage extends Component<InjectedProps> {
           apiIcon={cardanoLogo}
           isSyncing={isSyncing}
           localTimeDifference={localTimeDifference}
-          allowedTimeDifference={ALLOWED_TIME_DIFFERENCE}
+          isSystemTimeCorrect={isSystemTimeCorrect}
           isConnecting={isConnecting}
           syncPercentage={syncPercentage}
           isLoadingDataForNextScreen={isLoadingWallets}

--- a/source/renderer/app/containers/etc/LoadingPage.js
+++ b/source/renderer/app/containers/etc/LoadingPage.js
@@ -19,7 +19,7 @@ export default class LoadingPage extends Component<InjectedProps> {
     const {
       isConnecting, isSyncing, syncPercentage, isLoadingWallets,
       hasBeenConnected, hasBlockSyncingStarted, localTimeDifference,
-      ALLOWED_TIME_DIFFERENCE,
+      isSystemTimeCorrect,
     } = stores.networkStatus;
     const { hasLoadedCurrentLocale, hasLoadedCurrentTheme, currentLocale } = stores.profile;
     return (
@@ -29,7 +29,7 @@ export default class LoadingPage extends Component<InjectedProps> {
           apiIcon={mantisLogo}
           isSyncing={isSyncing}
           localTimeDifference={localTimeDifference}
-          allowedTimeDifference={ALLOWED_TIME_DIFFERENCE}
+          isSystemTimeCorrect={isSystemTimeCorrect}
           isConnecting={isConnecting}
           syncPercentage={syncPercentage}
           isLoadingDataForNextScreen={isLoadingWallets}

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -311,7 +311,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are 2 hours 12 minutes 54 seconds behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:",
+        "defaultMessage": "!!!Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. Your time is off by 2 hours 12 minutes 54 seconds.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:",
         "description": "Text of Sync error overlay",
         "end": {
           "column": 3,
@@ -2456,13 +2456,13 @@
         "description": "Headline for the \"Paper wallet create certificate instructions dialog\".",
         "end": {
           "column": 3,
-          "line": 16
+          "line": 15
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.headline",
         "start": {
           "column": 12,
-          "line": 12
+          "line": 11
         }
       },
       {
@@ -2470,13 +2470,13 @@
         "description": "Subtitle for the \"Paper wallet create certificate instructions dialog\".",
         "end": {
           "column": 3,
-          "line": 21
+          "line": 20
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.subtitle",
         "start": {
           "column": 12,
-          "line": 17
+          "line": 16
         }
       },
       {
@@ -2484,13 +2484,13 @@
         "description": "Instructions list label for the \"Paper wallet create certificate instructions dialog\".",
         "end": {
           "column": 3,
-          "line": 26
+          "line": 25
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.label",
         "start": {
           "column": 25,
-          "line": 22
+          "line": 21
         }
       },
       {
@@ -2498,13 +2498,13 @@
         "description": "Wallet certificate create instructions dialog definition 1.",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 30
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.definition1",
         "start": {
           "column": 31,
-          "line": 27
+          "line": 26
         }
       },
       {
@@ -2512,13 +2512,13 @@
         "description": "Wallet certificate create instructions dialog definition 2.",
         "end": {
           "column": 3,
-          "line": 36
+          "line": 35
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.definition2",
         "start": {
           "column": 31,
-          "line": 32
+          "line": 31
         }
       },
       {
@@ -2526,13 +2526,13 @@
         "description": "Wallet certificate create instructions dialog definition 3.",
         "end": {
           "column": 3,
-          "line": 41
+          "line": 40
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.definition3",
         "start": {
           "column": 31,
-          "line": 37
+          "line": 36
         }
       },
       {
@@ -2540,13 +2540,13 @@
         "description": "Wallet certificate create instructions dialog definition 4.",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 45
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.definition4",
         "start": {
           "column": 31,
-          "line": 42
+          "line": 41
         }
       },
       {
@@ -2554,13 +2554,13 @@
         "description": "Wallet certificate create instructions dialog definition 5.",
         "end": {
           "column": 3,
-          "line": 51
+          "line": 50
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.instructionsList.definition5",
         "start": {
           "column": 31,
-          "line": 47
+          "line": 46
         }
       },
       {
@@ -2568,13 +2568,13 @@
         "description": "Wallet certificate create instructions dialog - printing instructions.",
         "end": {
           "column": 3,
-          "line": 56
+          "line": 55
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.printingInstructions",
         "start": {
           "column": 24,
-          "line": 52
+          "line": 51
         }
       },
       {
@@ -2582,13 +2582,13 @@
         "description": "Wallet certificate create instructions dialog \"Cardano Explorer\" label",
         "end": {
           "column": 3,
-          "line": 61
+          "line": 60
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.cardanoExplorer",
         "start": {
           "column": 19,
-          "line": 57
+          "line": 56
         }
       },
       {
@@ -2596,13 +2596,13 @@
         "description": "\"Wallet certificate create instructions dialog\" print button label.",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 65
         },
         "file": "source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.js",
         "id": "paper.wallet.create.certificate.instructions.dialog.button.printLabel",
         "start": {
           "column": 20,
-          "line": 62
+          "line": 61
         }
       }
     ],

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -174,7 +174,7 @@
   "static.about.license": "MIT licence",
   "static.about.release.version": "0.9.1",
   "static.about.title": "Daedalus",
-  "systemTime.error.overlayText": "Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. You are {behindTime} behind.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:",
+  "systemTime.error.overlayText": "Attention, Daedalus is unable to sync with the blockchain because the time on your machine is different from the global time. Your time is off by {timeOffset}.<br>To synchronize the time and fix this issue, please visit the FAQ section of Daedalus website:",
   "systemTime.error.overlayTitle": "Unable to sync - incorrect time",
   "systemTime.error.problemSolutionLink": "daedaluswallet.io/faq",
   "test.environment.testnetLabel": "Release candidate",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -174,7 +174,7 @@
   "static.about.license": "MIT licence",
   "static.about.release.version": "0.9.1",
   "static.about.title": "ダイダロス",
-  "systemTime.error.overlayText": "注意：お使いのマシンの時刻が標準時刻と一致していないために、ダイダロスは同期することができません。 あなたのマシンの時間は {behindTime} 遅れています。<br>この問題を解決するには、DaedalusのウェブサイトのFAQセクションを参照してください:",
+  "systemTime.error.overlayText": "注意：お使いのマシンの時刻が標準時刻と一致していないために、ダイダロスは同期することができません。 あなたのマシンの時間は {timeOffset} 遅れています。<br>この問題を解決するには、DaedalusのウェブサイトのFAQセクションを参照してください:",
   "systemTime.error.overlayTitle": "同期できません - 時刻の不一致",
   "systemTime.error.problemSolutionLink": "daedaluswallet.io/ja/faq",
   "test.environment.testnetLabel": "リリース候補版",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -174,7 +174,7 @@
   "static.about.license": "MIT licence",
   "static.about.release.version": "0.9.1",
   "static.about.title": "ダイダロス",
-  "systemTime.error.overlayText": "注意：お使いのマシンの時刻が標準時刻と一致していないために、ダイダロスは同期することができません。 あなたのマシンは {behindTime} 遅れています。この問題を解決するには、DaedalusのウェブサイトのFAQセクションをご覧ください:",
+  "systemTime.error.overlayText": "注意：お使いのマシンの時刻が標準時刻と一致していないために、ダイダロスは同期することができません。 あなたのマシンの時間は {behindTime} 遅れています。<br>この問題を解決するには、DaedalusのウェブサイトのFAQセクションを参照してください:",
   "systemTime.error.overlayTitle": "同期できません - 時刻の不一致",
   "systemTime.error.problemSolutionLink": "daedaluswallet.io/ja/faq",
   "test.environment.testnetLabel": "リリース候補版",

--- a/source/renderer/app/stores/NetworkStatusStore.js
+++ b/source/renderer/app/stores/NetworkStatusStore.js
@@ -14,7 +14,8 @@ let cachedDifficulties = null;
 // Maximum number of out-of-sync blocks above which we consider to be out-of-sync
 const OUT_OF_SYNC_BLOCKS_LIMIT = 6;
 const SYNC_PROGRESS_INTERVAL = 2000;
-const TIME_DIFF_POLL_INTERVAL = 60 * 60 * 1000; // 60 minutes
+const TIME_DIFF_POLL_INTERVAL = 30 * 60 * 1000; // 30 minutes
+const ALLOWED_TIME_DIFFERENCE = 15 * 1000000; // 15 seconds
 const ALLOWED_NETWORK_DIFFICULTY_STALL = 2 * 60 * 1000; // 2 minutes
 
 const STARTUP_STAGES = {
@@ -29,8 +30,6 @@ export default class NetworkStatusStore extends Store {
   _startTime = Date.now();
   _startupStage = STARTUP_STAGES.CONNECTING;
   _lastNetworkDifficultyChange = 0;
-
-  ALLOWED_TIME_DIFFERENCE = 15 * 1000000; // 15 seconds
 
   @observable isConnected = false;
   @observable hasBeenConnected = false;
@@ -133,7 +132,7 @@ export default class NetworkStatusStore extends Store {
     if (!environment.isAdaApi()) return true;
     return (
       this.localTimeDifferenceRequest.wasExecuted &&
-      this.localTimeDifferenceRequest.result <= this.ALLOWED_TIME_DIFFERENCE
+      this.localTimeDifferenceRequest.result <= ALLOWED_TIME_DIFFERENCE
     );
   }
 
@@ -276,7 +275,7 @@ export default class NetworkStatusStore extends Store {
 
   _redirectToSyncingWhenLocalTimeDifferent = () => {
     if (
-      this.localTimeDifference > this.ALLOWED_TIME_DIFFERENCE &&
+      !this.isSystemTimeCorrect &&
       !this.isSynced &&
       !this.isSetupPage
     ) {


### PR DESCRIPTION
This PR updates the error message shown on the NTP time synchronisation error screen.
The message now covers both possible error cases - being `behind` and `ahead` of actual time.
Handling for positive and negative time offset is added and both are handled the same way (absolute time offset is used). The polling interval for NTP time check has been reduced from 60 to 30 mins.

![screen shot 2018-04-11 at 12 24 59](https://user-images.githubusercontent.com/376611/38610932-a93f63f0-3d82-11e8-8378-5f5da02a3064.png)

![screen shot 2018-04-13 at 12 45 08](https://user-images.githubusercontent.com/376611/38612237-58abdffa-3d86-11e8-8cba-5f277c724fed.png)
