### PR TITLE
Feature/ddw 228 Wallet restore indicator in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 - Added "Show more transactions" button on the summary screen ([PR 848](https://github.com/input-output-hk/daedalus/pull/848))
 - Setting spending password to "ON" by default ([PR 856](https://github.com/input-output-hk/daedalus/pull/856))
 - Asynchronous wallet restoration ([PR 849](https://github.com/input-output-hk/daedalus/pull/849))
+- Added wallet restore indicator in the sidebar ([PR 862](https://github.com/input-output-hk/daedalus/pull/862))
 
 ### Fixes
 

--- a/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.js
+++ b/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import classNames from 'classnames';
+import ProgressBar from '../../widgets/ProgressBar';
 import styles from './SidebarWalletMenuItem.scss';
 
 type Props = {
@@ -10,22 +11,34 @@ type Props = {
   active: boolean,
   className: string,
   onClick: Function,
+  isRestoreActive: boolean,
+  restoreProgress: number,
 };
 
 @observer
 export default class SidebarWalletMenuItem extends Component<Props> {
   render() {
-    const { title, info, active, className, onClick } = this.props;
+    const {
+      title, info, active, className,
+      onClick, isRestoreActive, restoreProgress,
+    } = this.props;
+
     const componentStyles = classNames([
       styles.component,
       active ? styles.active : null,
       className,
     ]);
+
+    console.debug(isRestoreActive, restoreProgress);
+
     return (
       <button className={componentStyles} onClick={onClick}>
         <span className={styles.meta}>
           <span className={styles.title}>{title}</span>
           <span className={styles.info}>{info}</span>
+          {isRestoreActive ? (
+            <ProgressBar progress={restoreProgress} />
+          ) : null}
         </span>
       </button>
     );

--- a/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.js
+++ b/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.js
@@ -29,8 +29,6 @@ export default class SidebarWalletMenuItem extends Component<Props> {
       className,
     ]);
 
-    console.debug(isRestoreActive, restoreProgress);
-
     return (
       <button className={componentStyles} onClick={onClick}>
         <span className={styles.meta}>

--- a/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.scss
+++ b/source/renderer/app/components/sidebar/wallets/SidebarWalletMenuItem.scss
@@ -30,8 +30,19 @@
 .meta {
   display: flex;
   flex-direction: column;
+  position: relative;
   text-align: left;
   width: 100%;
+
+  :global {
+    .ProgressBar_component {
+      left: 0;
+      margin-top: 6.5px;
+      position: absolute;
+      right: 0;
+      top: 100%;
+    }
+  }
 }
 
 .title {
@@ -39,6 +50,7 @@
   font-family: var(--font-regular);
   font-size: 18px;
   line-height: 1.5em;
+  margin-top: -5.5px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/source/renderer/app/components/sidebar/wallets/SidebarWalletsMenu.js
+++ b/source/renderer/app/components/sidebar/wallets/SidebarWalletsMenu.js
@@ -35,6 +35,7 @@ export default class SidebarWalletsMenu extends Component<Props> {
   render() {
     const { intl } = this.context;
     const { wallets, onAddWallet, isActiveWallet, onWalletItemClick } = this.props;
+
     return (
       <SidebarSubMenu visible={this.props.visible}>
         <div className={styles.wallets}>
@@ -46,6 +47,8 @@ export default class SidebarWalletsMenu extends Component<Props> {
               onClick={() => onWalletItemClick(wallet.id)}
               key={wallet.id}
               className={`Wallet_${wallet.id}`}
+              isRestoreActive={wallet.isRestoreActive}
+              restoreProgress={wallet.restoreProgress}
             />
           ))}
         </div>

--- a/source/renderer/app/components/widgets/ProgressBar.js
+++ b/source/renderer/app/components/widgets/ProgressBar.js
@@ -1,0 +1,26 @@
+// @flow
+import React, { Component } from 'react';
+import { observer } from 'mobx-react';
+import styles from './ProgressBar.scss';
+
+type Props = {
+  progress: number,
+};
+
+@observer
+export default class ProgressBar extends Component<Props> {
+
+  static defaultProps = {
+    progress: 0,
+  };
+
+  render() {
+    const { progress } = this.props;
+    return (
+      <div className={styles.component}>
+        <div className={styles.progress} style={{ width: `${progress}%` }} />
+      </div>
+    );
+  }
+
+}

--- a/source/renderer/app/components/widgets/ProgressBar.scss
+++ b/source/renderer/app/components/widgets/ProgressBar.scss
@@ -1,0 +1,13 @@
+.component {
+  background: var(--theme-progress-bar-background-color);
+  height: 2px;
+  position: relative;
+}
+
+.progress {
+  background: var(--theme-progress-bar-foreground-color);
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+}

--- a/source/renderer/app/stores/SidebarStore.js
+++ b/source/renderer/app/stores/SidebarStore.js
@@ -1,8 +1,10 @@
 // @flow
 import { observable, action, computed } from 'mobx';
+import { get } from 'lodash';
 import Store from './lib/Store';
 import resolver from '../utils/imports';
 import environment from '../../../common/environment';
+import { syncStateTags } from '../domains/Wallet';
 
 const sidebarConfig = resolver('config/sidebarConfig');
 const { formattedWalletAmount } = resolver('utils/formatters');
@@ -33,6 +35,8 @@ export default class SidebarStore extends Store {
       title: w.name,
       info: formattedWalletAmount(w.amount),
       isConnected: networkStatus.isConnected,
+      isRestoreActive: get(w, 'syncState.tag') === syncStateTags.RESTORING,
+      restoreProgress: get(w, 'syncState.data.percentage.quantity', 0),
     }));
   }
 
@@ -85,4 +89,6 @@ export type SidebarWalletType = {
   title: string,
   info: string,
   isConnected: bool,
+  isRestoreActive: bool,
+  restoreProgress: number,
 };

--- a/source/renderer/app/themes/daedalus/cardano.js
+++ b/source/renderer/app/themes/daedalus/cardano.js
@@ -295,4 +295,7 @@ export default {
   '--theme-password-toggler-color': '#5e6066',
 
   '--theme-loading-spinner-color': '#5e6066',
+
+  '--theme-progress-bar-background-color': 'rgba(255, 255, 255, 0.3)',
+  '--theme-progress-bar-foreground-color': 'rgba(255, 255, 255, 0.7)',
 };

--- a/source/renderer/app/themes/daedalus/dark-blue.js
+++ b/source/renderer/app/themes/daedalus/dark-blue.js
@@ -295,4 +295,7 @@ export default {
   '--theme-password-toggler-color': '#8793a1',
 
   '--theme-loading-spinner-color': '#e9f4fe',
+
+  '--theme-progress-bar-background-color': 'rgba(233, 244, 254, 0.3)',
+  '--theme-progress-bar-foreground-color': 'rgba(233, 244, 254, 0.7)',
 };

--- a/source/renderer/app/themes/daedalus/light-blue.js
+++ b/source/renderer/app/themes/daedalus/light-blue.js
@@ -295,4 +295,7 @@ export default {
   '--theme-password-toggler-color': '#5e6066',
 
   '--theme-loading-spinner-color': '#5e6066',
+
+  '--theme-progress-bar-background-color': 'rgba(255, 255, 255, 0.3)',
+  '--theme-progress-bar-foreground-color': 'rgba(255, 255, 255, 0.7)',
 };


### PR DESCRIPTION
This PR adds a linear progress bar restore indicator in the sidebar. This way it is straight away visible if user has an active wallet restore running or not.

![screen shot 2018-04-12 at 13 59 48](https://user-images.githubusercontent.com/376611/38676113-4f5412ae-3e5a-11e8-8dcd-a190e7ccaddb.png)

![screen shot 2018-04-12 at 13 59 39](https://user-images.githubusercontent.com/376611/38676118-51f98eee-3e5a-11e8-952d-58c7b181041c.png)

![screen shot 2018-04-12 at 14 00 00](https://user-images.githubusercontent.com/376611/38676124-5429e3c6-3e5a-11e8-81fe-faaf01a21d9a.png)

