### PR TITLE
[DEVOPS-807] Installer filename consistency and bump version 1.1 -> 1.2.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: 'daedalus-x86_64-darwin'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.1.1
+      VERSION: 1.2.0
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       NETWORK: mainnet
     agents:
@@ -10,12 +10,12 @@ steps:
   - label: 'daedalus-x86_64-linux'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.1.0
+      VERSION: 1.2.0
     agents:
       system: x86_64-linux
   - label: 'daedalus-x86_64-linux-nix'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-nix.sh $VERSION $BUILDKITE_BUILD_NUMBER"'
     env:
-      VERSION: 1.1.1
+      VERSION: 1.2.0
     agents:
       system: x86_64-linux

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@ steps:
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
       VERSION: 1.1.1
-      CARDANO_SL_BRANCH: release/1.1.1
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       NETWORK: mainnet
     agents:
@@ -18,6 +17,5 @@ steps:
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-nix.sh $VERSION $BUILDKITE_BUILD_NUMBER"'
     env:
       VERSION: 1.1.1
-      CARDANO_SL_BRANCH: release/1.1.1
     agents:
       system: x86_64-linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ artifacts:
   - path: release\win32-x64\Daedalus-win32-x64
     name: Daedalus Electron application
     type: zip
-  - path: installers\daedalus-win64-*-installer.exe
+  - path: installers\daedalus-*.exe
     name: Daedalus Win64 Installer
   - path: installers\launcher-config-*.yaml
     name: Cardano launcher configuration

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.{build}
+version: 1.2.0.{build}
 
 environment:
   nodejs_version: "8"

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -120,7 +120,7 @@ writeInstallerNSIS (Version fullVersion') clusterName = do
         _ <- constantStr "Version" (str fullVersion)
         _ <- constantStr "Cluster" (str $ unpack $ lshowText clusterName)
         name "Daedalus ($Version)"                  -- The name of the installer
-        outFile "daedalus-win64-$Version-$Cluster-installer.exe"           -- Where to produce the installer
+        outFile "daedalus-0.10.0-cardano-sl-$Version-$Cluster-windows.exe"           -- Where to produce the installer
         unsafeInjectGlobal $ "!define MUI_ICON \"icons\\64x64.ico\""
         unsafeInjectGlobal $ "!define MUI_HEADERIMAGE"
         unsafeInjectGlobal $ "!define MUI_HEADERIMAGE_BITMAP \"icons\\installBanner.bmp\""

--- a/release.nix
+++ b/release.nix
@@ -5,7 +5,7 @@ let
     installer = wrappedBundle newBundle pkgs cluster;
   };
   wrappedBundle = newBundle: pkgs: cluster: let
-    fn = "Daedalus-${cluster}-installer-${version}.${buildNr}.bin";
+    fn = "daedalus-0.10.0-cardano-sl-${version}.${buildNr}-${cluster}-linux.bin";
   in pkgs.runCommand "daedaus-installer" {} ''
     mkdir -pv $out/nix-support
     cp ${newBundle} $out/${fn}

--- a/release.nix
+++ b/release.nix
@@ -1,4 +1,4 @@
-{ version ? "1.1.0", buildNr ? "nix" }:
+{ version ? "1.2.0", buildNr ? "nix" }:
 let
   makeJobs = cluster: with import ./. { inherit cluster; version = "${version}.${buildNr}"; }; {
     inherit daedalus;

--- a/scripts/build-installer-nix.sh
+++ b/scripts/build-installer-nix.sh
@@ -13,7 +13,7 @@ nix-build default.nix -A rawapp.deps -o node_modules.root -Q
 echo '~~~ Building mainnet installer'
 nix-build release.nix -A mainnet.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER --argstr version $VERSION
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
-  buildkite-agent artifact upload result/Daedalus*installer*.bin --job $BUILDKITE_JOB_ID
+  buildkite-agent artifact upload result/daedalus*.bin --job $BUILDKITE_JOB_ID
   daedalus_config=$(nix-build -A daedalus.cfg --no-out-link                           ./default.nix)
   for cf in launcher-config wallet-topology
   do cp ${daedalus_config}/etc/$cf.yaml  $cf-mainnet.linux.yaml
@@ -24,7 +24,7 @@ fi
 echo '~~~ Building staging installer'
 nix-build release.nix -A staging.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER --argstr version $VERSION
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
-  buildkite-agent artifact upload result/Daedalus*installer*.bin --job $BUILDKITE_JOB_ID
+  buildkite-agent artifact upload result/daedalus*.bin --job $BUILDKITE_JOB_ID
   daedalus_config=$(nix-build -A daedalus.cfg --no-out-link --argstr cluster staging ./default.nix)
   for cf in launcher-config wallet-topology
   do cp ${daedalus_config}/etc/$cf.yaml  $cf-staging.linux.yaml

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -128,7 +128,7 @@ cd installers
     do
           echo "~~~ Generating installer for cluster ${cluster}.."
           export DAEDALUS_CLUSTER=${cluster}
-                    INSTALLER_PKG="Daedalus-installer-${DAEDALUS_VERSION}-${cluster}.pkg"
+                    INSTALLER_PKG="daedalus-0.10.0-cardano-sl-${DAEDALUS_VERSION}-${cluster}-macos.pkg"
 
           INSTALLER_CMD="$INSTALLER/bin/make-installer ${pull_request} ${test_installer}"
           INSTALLER_CMD+="  --cardano          ${DAEDALUS_BRIDGE}"

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -143,7 +143,7 @@ FOR %%C IN (%CLUSTERS:"=%) DO (
   @echo ###
   @echo ##############################################################################
 
-  make-installer %XARGS:"=% -c %%C -o daedalus-win64-%DAEDALUS_VERSION%-%%C-installer.exe
+  make-installer %XARGS:"=% -c %%C -o daedalus-0.10.0-cardano-sl-%DAEDALUS_VERSION%-%%C-windows.exe
   copy  /y launcher-config.yaml launcher-config-%%C.win64.yaml
   copy  /y wallet-topology.yaml wallet-topology-%%C.win64.yaml
   @if %errorlevel% neq 0 ( @echo FATAL: persistent failure while building installer


### PR DESCRIPTION
This is a proposed RC bugfix with the full fix going on the develop branch. The change only affects CI.

It changes the AppVeyor config so that Windows installer filename is up to date with the cardano-sl version of this release.
