### PR TITLE
Fix/ddw 242 Step for active restore notification is too fragile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### Chores
 
 - Refactored various magic numbers & strings into constants ([PR 881](https://github.com/input-output-hk/daedalus/pull/881))
+- Fixed wallet restoration and import fragile acceptance tests steps definitions ([PR 885](https://github.com/input-output-hk/daedalus/pull/885))
 
 ## 0.10.0
 

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -18,7 +18,10 @@ import sidebar from '../support/helpers/sidebar-helpers';
 import addWalletPage from '../support/helpers/add-wallet-page-helpers';
 import importWalletDialog from '../support/helpers/dialogs/import-wallet-dialog-helpers';
 import i18n from '../support/helpers/i18n-helpers';
-import { waitForActiveRestoreNotification } from '../support/helpers/notifications-helpers';
+import {
+  isActiveWalletBeingRestored,
+  waitForActiveRestoreNotification
+} from '../support/helpers/notifications-helpers';
 
 const defaultWalletKeyFilePath = path.resolve(__dirname, '../support/default-wallet.key');
 const defaultWalletJSONFilePath = path.resolve(__dirname, '../support/default-wallet.json');
@@ -352,7 +355,10 @@ Then(/^I should not see the restore wallet dialog anymore$/, function () {
 });
 
 Then(/^I should see the restore status notification while import is running$/, async function () {
-  await waitForActiveRestoreNotification(this.client);
+  // Only check the rendered DOM if the restore is still in progress
+  if (await isActiveWalletBeingRestored(this.client)) {
+    await waitForActiveRestoreNotification(this.client);
+  }
 });
 
 Then(/^I should not see the restore status notification once import is finished$/, async function () {
@@ -360,7 +366,10 @@ Then(/^I should not see the restore status notification once import is finished$
 });
 
 Then(/^I should see the restore status notification while restore is running$/, async function () {
-  await waitForActiveRestoreNotification(this.client);
+  // Only check the rendered DOM if the restore is still in progress
+  if (await isActiveWalletBeingRestored(this.client)) {
+    await waitForActiveRestoreNotification(this.client);
+  }
 });
 
 Then(/^I should not see the restore status notification once restore is finished$/, async function () {

--- a/features/support/helpers/notifications-helpers.js
+++ b/features/support/helpers/notifications-helpers.js
@@ -7,6 +7,6 @@ export const isActiveWalletBeingRestored = async (client) => {
   return result.value;
 };
 
-export const waitForActiveRestoreNotification = (client, { isHidden } = {}) => {
-  return client.waitForVisible('.ActiveRestoreNotification', null, isHidden);
-};
+export const waitForActiveRestoreNotification = (client, { isHidden } = {}) => (
+  client.waitForVisible('.ActiveRestoreNotification', null, isHidden)
+);

--- a/features/support/helpers/notifications-helpers.js
+++ b/features/support/helpers/notifications-helpers.js
@@ -1,3 +1,12 @@
-export const waitForActiveRestoreNotification = (client, { isHidden } = {}) => (
-  client.waitForVisible('.ActiveRestoreNotification', null, isHidden)
-);
+import { syncStateTags } from '../../../source/renderer/app/domains/Wallet';
+
+export const isActiveWalletBeingRestored = async (client) => {
+  const result = await client.execute((expectedSyncTag) => (
+    daedalus.stores.ada.wallets.active.syncState.tag === expectedSyncTag
+  ), syncStateTags.RESTORING);
+  return result.value;
+};
+
+export const waitForActiveRestoreNotification = (client, { isHidden } = {}) => {
+  return client.waitForVisible('.ActiveRestoreNotification', null, isHidden);
+};


### PR DESCRIPTION
This PR fixes the fragile step definition by checking the actual sync status of the active wallet before testing the DOM. If the restoration was too fast, the sync status will not be 'restoring'  anymore and thus we can't test the DOM anymore.

<img width="516" alt="screenshot 2018-04-23 um 18 02 52" src="https://user-images.githubusercontent.com/172414/39138743-d78a9ac0-4720-11e8-9033-b5f6e159e1dc.png">
