### PR TITLE
[DDW-217] add file size limit to url loader

### DIFF
--- a/source/renderer/webpack.config.js
+++ b/source/renderer/webpack.config.js
@@ -55,6 +55,9 @@ module.exports = {
         exclude: /\.inline\.svg$/,
         use: {
           loader: 'url-loader',
+          options: {
+            limit: '50000', // inline max 50kb
+          }
         }
       },
       {
@@ -84,6 +87,7 @@ module.exports = {
     }),
     new AutoDllPlugin({
       filename: 'vendor.dll.js',
+      context: path.join(__dirname, '..'),
       entry: {
         vendor: [
           'aes-js',


### PR DESCRIPTION
This PR fixes our issue with huge build file sizes by limiting what goes into the JS bundle via the webpack url-loader.