### PR TITLE
Fix/ddw 244 Delete logs.zip on support dialog mount

### DIFF
--- a/source/renderer/app/actions/profile-actions.js
+++ b/source/renderer/app/actions/profile-actions.js
@@ -7,7 +7,7 @@ export default class ProfileActions {
   acceptTermsOfUse: Action<any> = new Action();
   compressLogs: Action<{ logs: Object }> = new Action();
   getLogs: Action<any> = new Action();
-  downloadLogs: Action<{ destination: string }> = new Action();
+  downloadLogs: Action<{ destination: string, fresh?: boolean }> = new Action();
   deleteCompressedLogs: Action<any> = new Action();
   resetBugReportDialog: Action<any> = new Action();
   sendBugReport: Action<{

--- a/source/renderer/app/actions/profile-actions.js
+++ b/source/renderer/app/actions/profile-actions.js
@@ -8,6 +8,7 @@ export default class ProfileActions {
   compressLogs: Action<{ logs: Object }> = new Action();
   getLogs: Action<any> = new Action();
   downloadLogs: Action<{ destination: string }> = new Action();
+  deleteCompressedLogs: Action<any> = new Action();
   resetBugReportDialog: Action<any> = new Action();
   sendBugReport: Action<{
     email: string, subject: string, problem: string, compressedLog: ?string,

--- a/source/renderer/app/components/profile/bug-report/BugReportDialog.js
+++ b/source/renderer/app/components/profile/bug-report/BugReportDialog.js
@@ -152,7 +152,6 @@ export default class BugReportDialog extends Component<Props, State> {
 
   componentWillReceiveProps(nextProps: Object) {
     const commpressionFilesChanged = this.props.compressedLog !== nextProps.compressedLog;
-
     if (nextProps.compressedLog && commpressionFilesChanged && !nextProps.isDownloading) {
       // proceed to submit when ipc rendered successfully return compressed files
       this.submit(nextProps.compressedLog);

--- a/source/renderer/app/components/profile/bug-report/BugReportDialog.js
+++ b/source/renderer/app/components/profile/bug-report/BugReportDialog.js
@@ -123,6 +123,7 @@ type Props = {
   onDownload: Function,
   onGetLogs: Function,
   onCompressLogs: Function,
+  onDeleteCompressedLogs: Function,
   isSubmitting: boolean,
   isCompressing: boolean,
   isDownloading?: boolean,
@@ -146,6 +147,7 @@ export default class BugReportDialog extends Component<Props, State> {
 
   componentWillMount() {
     this.props.onGetLogs();
+    this.props.onDeleteCompressedLogs();
   }
 
   componentWillReceiveProps(nextProps: Object) {

--- a/source/renderer/app/containers/profile/dialogs/BugReportDialogContainer.js
+++ b/source/renderer/app/containers/profile/dialogs/BugReportDialogContainer.js
@@ -36,7 +36,7 @@ export default class BugReportDialogContainer extends Component<InjectedProps> {
 
   render() {
     const { actions, stores } = this.props;
-    const { getLogs, compressLogs } = actions.profile;
+    const { getLogs, compressLogs, deleteCompressedLogs } = actions.profile;
     const {
       logFiles,
       compressedLog,
@@ -63,6 +63,9 @@ export default class BugReportDialogContainer extends Component<InjectedProps> {
         }}
         onCompressLogs={(logs) => {
           compressLogs.trigger({ logs });
+        }}
+        onDeleteCompressedLogs={() => {
+          deleteCompressedLogs.trigger();
         }}
       />
     );

--- a/source/renderer/app/containers/settings/categories/SupportSettingsPage.js
+++ b/source/renderer/app/containers/settings/categories/SupportSettingsPage.js
@@ -28,7 +28,7 @@ export default class SupportSettingsPage extends Component<InjectedProps> {
     const destination = remote.dialog.showSaveDialog({
       defaultPath: 'logs.zip',
     });
-    if (destination) this.props.actions.profile.downloadLogs.trigger({ destination });
+    if (destination) this.props.actions.profile.downloadLogs.trigger({ destination, fresh: true });
   };
 
   render() {

--- a/source/renderer/app/stores/ProfileStore.js
+++ b/source/renderer/app/stores/ProfileStore.js
@@ -201,13 +201,13 @@ export default class SettingsStore extends Store {
     this.actions.dialogs.closeActiveDialog.trigger();
   };
 
-  _downloadLogs = action(({ destination }) => {
+  _downloadLogs = action(({ destination, fresh }) => {
     this.compressedFileDownload = {
       inProgress: true,
       destination,
     };
 
-    if (this.compressedLog) {
+    if (this.compressedLog && fresh !== true) {
       // logs already compressed, trigger download
       ipcRenderer.send(DOWNLOAD_LOGS.REQUEST, this.compressedLog, destination);
     } else {
@@ -263,8 +263,8 @@ export default class SettingsStore extends Store {
 
   _deleteCompressedFiles = action(() => {
     if (this.compressedLog) {
-      this.compressedLog = null;
       ipcRenderer.send(DELETE_COMPRESSED_LOGS.REQUEST, this.compressedLog);
+      this.compressedLog = null;
     }
   });
 

--- a/source/renderer/app/stores/ProfileStore.js
+++ b/source/renderer/app/stores/ProfileStore.js
@@ -207,8 +207,8 @@ export default class SettingsStore extends Store {
       destination,
     };
 
-    // logs already compressed, download
     if (this.compressedLog) {
+      // logs already compressed, trigger download
       ipcRenderer.send(DOWNLOAD_LOGS.REQUEST, this.compressedLog, destination);
     } else {
       // start process: getLogs -> compressLogs -> downloadLogs (again)
@@ -249,7 +249,7 @@ export default class SettingsStore extends Store {
     subject: string,
     problem: string,
     compressedLog: ?string,
-  }) =>  {
+  }) => {
     this.sendBugReport.execute({
       email, subject, problem, compressedLog,
     })
@@ -262,10 +262,9 @@ export default class SettingsStore extends Store {
   });
 
   _deleteCompressedFiles = action(() => {
-    // trigger ipc renderer to delete compressed temp files if exists
     if (this.compressedLog) {
-      ipcRenderer.send(DELETE_COMPRESSED_LOGS.REQUEST, this.compressedLog);
       this.compressedLog = null;
+      ipcRenderer.send(DELETE_COMPRESSED_LOGS.REQUEST, this.compressedLog);
     }
   });
 


### PR DESCRIPTION
This PR fixes few issues:
- **General > Support** page "Download logs" link now on every click packs fresh `logs.zip` file which is then downloaded to the user's machine
- **Support Request** dialog now on *will-mount* event deletes existing `logs.zip` file in order to pack a fresh one on dialog submit (if user selected to attach the logs)