### PR TITLE
Fix/ddw 247 Fix paper wallet QR code issues on Confirmation dialog

### DIFF
--- a/source/renderer/app/components/wallet/paper-wallet-certificate/CompletionDialog.js
+++ b/source/renderer/app/components/wallet/paper-wallet-certificate/CompletionDialog.js
@@ -127,7 +127,7 @@ export default class CompletionDialog extends Component<Props> {
               value={walletCertificateAddress}
               bgColor={qrCodeBackgroundColor}
               fgColor={qrCodeForegroundColor}
-              size={160}
+              size={152}
             />
           </div>
 


### PR DESCRIPTION
This PR fixes issues with recognition of QR code displayed on the last dialog within the Paper wallet certificate generator feature. In order to increase compatibility the size of the QR code had to be slightly reduced to match the size of the QR code we already use on the Receive screen (and we are 100% sure that this one works correctly).