### PR TITLE
cardano-sl:  bump to 44fa9a8b/release/1.2.0

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
     "url": "https://github.com/input-output-hk/cardano-sl",
     "fetchSubmodules": "true",
-    "rev": "302429f7e7da925faa5cc260a1814c4b77ff2a4f",
-    "sha256": "1s5v2abfkyyv8n4mdyj029kpng4pbbkdl2d19wwagcmyl1zc3br0"
+    "rev": "44fa9a8b03cea0555abaec80b170c04aff5de330",
+    "sha256": "09s2wg80yd69nrrkf7rjhcdh3cq8f2blbzglbynz7qhk8ahaw7v5"
 }


### PR DESCRIPTION
This PR bumps `Cardano SL` version used in Daedalus to the latest `release/1.2.0` revision.