### PR TITLE
[DDW-253] installer configs: Work around macOS 10.11 launcher error

### DIFF
--- a/installers/dhall/linux64.dhall
+++ b/installers/dhall/linux64.dhall
@@ -17,6 +17,7 @@ in
   , nodeLogPath         = "${dataDir}/${cluster.name}/Logs/cardano-node.log"
 
   , walletPath          = "daedalus-frontend"
+  , walletLogging       = False
 
   -- todo, find some way to disable updates when unsandboxed?
   , updaterPath         = "/bin/update-runner"

--- a/installers/dhall/macos64.dhall
+++ b/installers/dhall/macos64.dhall
@@ -19,6 +19,7 @@ in
   , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"
 
   , walletPath          = "./Frontend"
+  , walletLogging       = True
 
   , updaterPath         = "/usr/bin/open"
   , updaterArgs         = ["-FW"]

--- a/installers/dhall/os.type
+++ b/installers/dhall/os.type
@@ -13,6 +13,7 @@
   , nodeLogConfig       : Text
   , nodeLogPath         : Text
   , walletPath          : Text
+  , walletLogging       : Bool
   , updaterPath         : Text
   , updaterArgs         : List Text
   , updateArchive       : Optional Text

--- a/installers/dhall/win64.dhall
+++ b/installers/dhall/win64.dhall
@@ -19,6 +19,7 @@ in
   , nodeLogPath         = "${dataDir}\\Logs\\cardano-node.log"
 
   , walletPath          = "\${DAEDALUS_DIR}\\Daedalus.exe"
+  , walletLogging       = False
 
   , updaterPath         = "${dataDir}\\Installer.exe"
   , updaterArgs         = [] : List Text


### PR DESCRIPTION
For some reason, on macOS 10.11 electron won't start if its stdout is closed.

For example, this won't work:

    /Applications/Daedalus.app/Contents/MacOS/Frontend 1>&- 2>&-

And it happens that cardano-launcher closes stdout, unless walletLogging in the launcher config is true.

So, only for macOS, enable the walletLogging option.
