### PR TITLE
Chore/ddw 258 Add owner info to all Daedalus GitHub documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Changelog
 - Added acceptance tests for displaying transactions in various contexts ([PR 870](https://github.com/input-output-hk/daedalus/pull/870))
 - Refactored various magic numbers & strings into constants ([PR 881](https://github.com/input-output-hk/daedalus/pull/881))
 - Fixed wallet restoration and import fragile acceptance tests steps definitions ([PR 885](https://github.com/input-output-hk/daedalus/pull/885))
+- Added "Author" and "Status" information to all Daedalus README files ([PR 901](https://github.com/input-output-hk/daedalus/pull/901))
 
 ## 0.10.0
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<sub><sup>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sup></sub>
+
 # Daedalus
 [![Build status](https://badge.buildkite.com/e173494257519752d79bb52c7859df6277c6d759b217b68384.svg?branch=master)](https://buildkite.com/input-output-hk/daedalus)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/github/input-output-hk/daedalus?branch=master&svg=true)](https://ci.appveyor.com/project/input-output/daedalus)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<sub><sup>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sup></sub>
+<sub>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sub>
 
 # Daedalus
 [![Build status](https://badge.buildkite.com/e173494257519752d79bb52c7859df6277c6d759b217b68384.svg?branch=master)](https://buildkite.com/input-output-hk/daedalus)

--- a/features/README.md
+++ b/features/README.md
@@ -1,4 +1,4 @@
-<sub><sup>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sup></sub>
+<sub>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sub>
 
 # Running Daedalus acceptance tests
 

--- a/features/README.md
+++ b/features/README.md
@@ -1,3 +1,5 @@
+<sub><sup>Author: [Nikola Glumac](https://github.com/nikolaglumac)<br/>Status: Active</sup></sub>
+
 # Running Daedalus acceptance tests
 
 


### PR DESCRIPTION
This PR adds `Author` and `Status` information to all Daedalus GitHub README files:
- Main [README file](https://github.com/input-output-hk/daedalus/blob/chore/ddw-258-add-owner-info-to-all-daedalus-github-documents/README.md)
- Features [README file](https://github.com/input-output-hk/daedalus/blob/chore/ddw-258-add-owner-info-to-all-daedalus-github-documents/features/README.md)

## Screenshots:

![screen shot 2018-05-03 at 13 54 24](https://user-images.githubusercontent.com/376611/39575070-89fa7d28-4ed9-11e8-9297-debc78a03773.png)

![screen shot 2018-05-03 at 13 54 36](https://user-images.githubusercontent.com/376611/39575074-8ba48470-4ed9-11e8-8c19-838fb0341b5e.png)


---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
