### PR TITLE
[DEVOPS-771] AppVeyor: remove 1.0. prefix from build version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+version: "{build}"
+
 environment:
   nodejs_version: "8"
   NETWORK: "mainnet"


### PR DESCRIPTION
The installer filenames have correct versions derived from cabal files and `package.json`.

PR #874 removed all versions from `appveyor.yml`. However the AppVeyor "build version" defaults to `1.0.{build}` which is almost always wrong. So this change removes the `1.0.` prefix.
