### PR TITLE
[DDW-231] log expected errors as debug messages only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog
 - Fixed wallet restoration and import fragile acceptance tests steps definitions ([PR 885](https://github.com/input-output-hk/daedalus/pull/885))
 - Improved request body length calculation ([PR 892](https://github.com/input-output-hk/daedalus/pull/892))
 - Added "Author" and "Status" information to all Daedalus README files ([PR 901](https://github.com/input-output-hk/daedalus/pull/901))
+- Log expected errors as debug messages only ([PR 916](https://github.com/input-output-hk/daedalus/pull/916))
 
 ## 0.10.0
 

--- a/source/renderer/app/api/ada/index.js
+++ b/source/renderer/app/api/ada/index.js
@@ -321,7 +321,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::createTransaction success: ' + stringifyData(response));
       return _createTransactionFromServerData(response);
     } catch (error) {
-      Logger.error('AdaApi::createTransaction error: ' + stringifyError(error));
+      Logger.debug('AdaApi::createTransaction error: ' + stringifyError(error));
       // eslint-disable-next-line max-len
       if (error.message.includes('It\'s not allowed to send money to the same address you are sending from')) {
         throw new NotAllowedToSendMoneyToSameAddressError();
@@ -351,7 +351,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::calculateTransactionFee success: ' + stringifyData(response));
       return _createTransactionFeeFromServerData(response);
     } catch (error) {
-      Logger.error('AdaApi::calculateTransactionFee error: ' + stringifyError(error));
+      Logger.debug('AdaApi::calculateTransactionFee error: ' + stringifyError(error));
       // eslint-disable-next-line max-len
       if (error.message.includes('not enough money on addresses which are not included in output addresses set')) {
         throw new AllFundsAlreadyAtReceiverAddressError();
@@ -373,7 +373,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::createAddress success: ' + stringifyData(response));
       return _createAddressFromServerData(response);
     } catch (error) {
-      Logger.error('AdaApi::createAddress error: ' + stringifyError(error));
+      Logger.debug('AdaApi::createAddress error: ' + stringifyError(error));
       if (error.message.includes('Passphrase doesn\'t match')) {
         throw new IncorrectWalletPasswordError();
       }
@@ -464,7 +464,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::getWalletRecoveryPhraseFromCertificate success');
       return Promise.resolve(response);
     } catch (error) {
-      Logger.error('AdaApi::getWalletRecoveryPhraseFromCertificate error: ' + stringifyError(error));
+      Logger.debug('AdaApi::getWalletRecoveryPhraseFromCertificate error: ' + stringifyError(error));
       return Promise.reject(new InvalidMnemonicError());
     }
   }
@@ -493,7 +493,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::restoreWallet success');
       return _createWalletFromServerData(wallet);
     } catch (error) {
-      Logger.error('AdaApi::restoreWallet error: ' + stringifyError(error));
+      Logger.debug('AdaApi::restoreWallet error: ' + stringifyError(error));
       // TODO: backend will return something different here, if multiple wallets
       // are restored from the key and if there are duplicate wallets we will get
       // some kind of error and present the user with message that some wallets
@@ -519,7 +519,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::importWalletFromKey success');
       return _createWalletFromServerData(importedWallet);
     } catch (error) {
-      Logger.error('AdaApi::importWalletFromKey error: ' + stringifyError(error));
+      Logger.debug('AdaApi::importWalletFromKey error: ' + stringifyError(error));
       if (error.message.includes('already exists')) {
         throw new WalletAlreadyImportedError();
       }
@@ -542,7 +542,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::importWalletFromFile success');
       return _createWalletFromServerData(importedWallet);
     } catch (error) {
-      Logger.error('AdaApi::importWalletFromFile error: ' + stringifyError(error));
+      Logger.debug('AdaApi::importWalletFromFile error: ' + stringifyError(error));
       if (error.message.includes('already exists')) {
         throw new WalletAlreadyImportedError();
       }
@@ -566,7 +566,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::redeemAda success');
       return _createTransactionFromServerData(response);
     } catch (error) {
-      Logger.error('AdaApi::redeemAda error: ' + stringifyError(error));
+      Logger.debug('AdaApi::redeemAda error: ' + stringifyError(error));
       if (error.message.includes('Passphrase doesn\'t match')) {
         throw new IncorrectWalletPasswordError();
       }
@@ -595,7 +595,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::redeemAdaPaperVend success');
       return _createTransactionFromServerData(response);
     } catch (error) {
-      Logger.error('AdaApi::redeemAdaPaperVend error: ' + stringifyError(error));
+      Logger.debug('AdaApi::redeemAdaPaperVend error: ' + stringifyError(error));
       if (error.message.includes('Passphrase doesn\'t match')) {
         throw new IncorrectWalletPasswordError();
       }
@@ -704,7 +704,7 @@ export default class AdaApi {
       }
       return { localDifficulty, networkDifficulty };
     } catch (error) {
-      Logger.error('AdaApi::syncProgress error: ' + stringifyError(error));
+      Logger.debug('AdaApi::syncProgress error: ' + stringifyError(error));
       throw new GenericApiError();
     }
   };
@@ -740,7 +740,7 @@ export default class AdaApi {
       Logger.debug('AdaApi::updateWalletPassword success');
       return true;
     } catch (error) {
-      Logger.error('AdaApi::updateWalletPassword error: ' + stringifyError(error));
+      Logger.debug('AdaApi::updateWalletPassword error: ' + stringifyError(error));
       if (error.message.includes('Invalid old passphrase given')) {
         throw new IncorrectWalletPasswordError();
       }

--- a/source/renderer/app/api/etc/index.js
+++ b/source/renderer/app/api/etc/index.js
@@ -104,7 +104,7 @@ export default class EtcApi {
         networkDifficulty: response ? parseInt(response.highestBlock, 16) : 100,
       };
     } catch (error) {
-      Logger.error('EtcApi::getSyncProgress error: ' + stringifyError(error));
+      Logger.debug('EtcApi::getSyncProgress error: ' + stringifyError(error));
       throw new GenericApiError();
     }
   }
@@ -177,7 +177,7 @@ export default class EtcApi {
         total: transactions.length,
       };
     } catch (error) {
-      Logger.error('EtcApi::getTransactions error: ' + stringifyError(error));
+      Logger.debug('EtcApi::getTransactions error: ' + stringifyError(error));
       throw new GenericApiError();
     }
   };
@@ -250,7 +250,7 @@ export default class EtcApi {
       Logger.debug('EtcApi::createTransaction success: ' + stringifyData(txHash));
       return _createTransaction(senderAccount, txHash);
     } catch (error) {
-      Logger.error('EtcApi::createTransaction error: ' + stringifyError(error));
+      Logger.debug('EtcApi::createTransaction error: ' + stringifyError(error));
       if (error.message.includes('Could not decrypt key with given passphrase')) {
         throw new IncorrectWalletPasswordError();
       }
@@ -290,7 +290,7 @@ export default class EtcApi {
       });
       return true;
     } catch (error) {
-      Logger.error('EtcApi::updateWalletPassword error: ' + stringifyError(error));
+      Logger.debug('EtcApi::updateWalletPassword error: ' + stringifyError(error));
       if (error.message.includes('Could not decrypt key with given passphrase')) {
         throw new IncorrectWalletPasswordError();
       }
@@ -321,7 +321,7 @@ export default class EtcApi {
       Logger.debug('EtcApi::restoreWallet success: ' + stringifyData(wallet));
       return wallet;
     } catch (error) {
-      Logger.error('EtcApi::restoreWallet error: ' + stringifyError(error));
+      Logger.debug('EtcApi::restoreWallet error: ' + stringifyError(error));
       if (error.message.includes('account already exists')) {
         throw new WalletAlreadyRestoredError();
       }


### PR DESCRIPTION
This PR improves our error handling by logging expected error cases only as debug messages instead of spamming our dev console.

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`npm run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`npm run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`npm run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`npm run flow-test`)
- [ ] There are no *lint* errors or warnings (`npm run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `npm run manage-translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`npm run storybook`)
- [ ] In case of npm dependency changes both `package-lock.json` and `yarn.lock` files are updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
