### PR TITLE
[DDW-265] installers: fix network setting of staging build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,6 @@ steps:
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh --build-id $BUILDKITE_BUILD_NUMBER"'
     env:
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
-      NETWORK: mainnet
     agents:
       system: x86_64-darwin
   - label: 'daedalus-x86_64-linux'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ version: "{build}"
 
 environment:
   nodejs_version: "8"
-  NETWORK: "mainnet"
   AWS_ACCESS_KEY_ID:
     secure: O0+bBTm/Ud3pxP8nvC3ZuDSkmmlr+b8hVluqpRdJGBg=
   AWS_SECRET_ACCESS_KEY:

--- a/installers/Installer.hs
+++ b/installers/Installer.hs
@@ -4,6 +4,7 @@
 import           Data.Text
 import           Universum
 import qualified System.Info                      as Sys
+import           Turtle                              (export)
 
 import qualified MacInstaller                        (main)
 import qualified WindowsInstaller                    (main)
@@ -29,6 +30,7 @@ main = do
       checkAllConfigs          cfDhallRoot
     GenInstaller -> do
       putStrLn $ "Generating installer for " <>  Sys.os <> "-" <> Sys.arch
+      export "NETWORK" (clusterNetwork $ oCluster options')
       case os of
         Linux64 -> putStrLn ("Use default.nix, please." :: String)
         Macos64 ->     MacInstaller.main options'

--- a/installers/Types.hs
+++ b/installers/Types.hs
@@ -23,6 +23,7 @@ module Types
   , packageFileName
   , getDaedalusVersion
   , packageVersion
+  , clusterNetwork
   , withDir
   )
 where
@@ -85,6 +86,12 @@ tt :: FilePath -> Text
 tt = format fp
 
 
+
+-- | Value of the NETWORK variable used by the npm build.
+-- See also: the networkMap variable in yarn2nix.nix.
+clusterNetwork :: Cluster -> Text
+clusterNetwork Mainnet = "mainnet"
+clusterNetwork Staging = "testnet"
 
 packageFileName :: OS -> Cluster -> Version -> Text -> Maybe BuildJob -> FilePath
 packageFileName os cluster ver backend build = fromText (mconcat name) <.> ext


### PR DESCRIPTION
Since we now generate both mainnet and staging installers from a single CI build, the NETWORK environment variable can no longer be set in the CI pipeline config.
