### PR TITLE
[DEVOPS-788] buildkite: Put linux installers in public S3 bucket

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,5 @@
+env:
+  ARTIFACT_BUCKET: s3://ci-output-sink
 steps:
   - label: 'daedalus-x86_64-darwin'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh --build-id $BUILDKITE_BUILD_NUMBER"'

--- a/scripts/build-installer-nix.sh
+++ b/scripts/build-installer-nix.sh
@@ -4,29 +4,37 @@ set -ex
 
 BUILDKITE_BUILD_NUMBER=$1
 
+upload_artifacts() {
+    buildkite-agent artifact upload "$@" --job $BUILDKITE_JOB_ID
+}
+
+upload_artifacts_public() {
+    buildkite-agent artifact upload "$@" ${ARTIFACT_BUCKET:-} --job $BUILDKITE_JOB_ID
+}
+
 rm -rf dist || true
 
 echo '~~~ Pre-building node_modules with nix'
 nix-build default.nix -A rawapp.deps -o node_modules.root -Q
 
 echo '~~~ Building mainnet installer'
-nix-build release.nix -A mainnet.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER
+nix-build release.nix -A mainnet.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER -o csl-daedalus
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
-  buildkite-agent artifact upload result/daedalus*.bin --job $BUILDKITE_JOB_ID
+  upload_artifacts_public csl-daedalus/daedalus*.bin
   daedalus_config=$(nix-build -A daedalus.cfg --no-out-link                           ./default.nix)
   for cf in launcher-config wallet-topology
   do cp ${daedalus_config}/etc/$cf.yaml  $cf-mainnet.linux.yaml
-     buildkite-agent artifact upload $cf-mainnet.linux.yaml --job $BUILDKITE_JOB_ID
+     upload_artifacts $cf-mainnet.linux.yaml
   done
 fi
 
 echo '~~~ Building staging installer'
-nix-build release.nix -A staging.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER
+nix-build release.nix -A staging.installer --argstr buildNr $BUILDKITE_BUILD_NUMBER -o csl-daedalus
 if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
-  buildkite-agent artifact upload result/daedalus*.bin --job $BUILDKITE_JOB_ID
+  upload_artifacts_public csl-daedalus/daedalus*.bin
   daedalus_config=$(nix-build -A daedalus.cfg --no-out-link --argstr cluster staging ./default.nix)
   for cf in launcher-config wallet-topology
   do cp ${daedalus_config}/etc/$cf.yaml  $cf-staging.linux.yaml
-     buildkite-agent artifact upload $cf-staging.linux.yaml --job $BUILDKITE_JOB_ID
+     upload_artifacts $cf-staging.linux.yaml
   done
 fi

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -104,7 +104,13 @@ fi
 export PATH=$HOME/.local/bin:$PATH
 if [ -n "${NIX_SSL_CERT_FILE-}" ]; then export SSL_CERT_FILE=$NIX_SSL_CERT_FILE; fi
 
-ARTIFACT_BUCKET=ci-output-sink
+upload_artifacts() {
+    buildkite-agent artifact upload "$@" --job $BUILDKITE_JOB_ID
+}
+
+upload_artifacts_public() {
+    buildkite-agent artifact upload "$@" ${ARTIFACT_BUCKET:-} --job $BUILDKITE_JOB_ID
+}
 
 # Build/get cardano bridge which is used by make-installer
 DAEDALUS_BRIDGE=$(nix-build --no-out-link cardano-sl.nix -A daedalus-bridge)
@@ -134,11 +140,11 @@ cd installers
                   then
                           echo "~~~ Uploading the installer package.."
                           export PATH=${BUILDKITE_BIN_PATH:-}:$PATH
-                          buildkite-agent artifact upload "${APP_NAME}/*" s3://${ARTIFACT_BUCKET} --job $BUILDKITE_JOB_ID
+                          upload_artifacts_public "${APP_NAME}/*"
                           mv "launcher-config.yaml" "launcher-config-${cluster}.macos64.yaml"
                           mv "wallet-topology.yaml" "wallet-topology-${cluster}.macos64.yaml"
-                          buildkite-agent artifact upload "launcher-config-${cluster}.macos64.yaml" s3://${ARTIFACT_BUCKET} --job $BUILDKITE_JOB_ID
-                          buildkite-agent artifact upload "wallet-topology-${cluster}.macos64.yaml" s3://${ARTIFACT_BUCKET} --job $BUILDKITE_JOB_ID
+                          upload_artifacts "launcher-config-${cluster}.macos64.yaml"
+                          upload_artifacts "wallet-topology-${cluster}.macos64.yaml"
                           rm -rf "${APP_NAME}"
                   fi
           else


### PR DESCRIPTION
This makes it possible to download all the installer artifacts without being logged into Buildkite.
