### PR TITLE
[DEVOPS-872] disable allow skip files and adds a launcher lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 - Fixed presentation bug that caused only ten wallets to be shown in the wallets list, even though there were more than ten wallets in the application ([PR 958](https://github.com/input-output-hk/daedalus/pull/958))
 - Fixed reporting server URL used for submitting support requests for the Linux build of Daedalus ([PR 959](https://github.com/input-output-hk/daedalus/pull/959))
 - Fixed missing launcher log file ([PR 963](https://github.com/input-output-hk/daedalus/pull/963))
+- Fixed issue with multiple cardano-node processes running and windows allowing skipping of files in installer ([PR 953](https://github.com/input-output-hk/daedalus/pull/953)) 
 
 ## 0.10.0
 =======

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "55dce875afa9eb931fb4253a1d6c0bfca489b2cb",
-  "sha256": "03lfjbs1j8y2m49bbcadr47mld9hk27ijznb2x6m4zh2k3zl4wps",
+  "rev": "278fd9cf5e706b7f1992441546b01b6471134288",
+  "sha256": "17pg456gqsy4fvknrb9avqfl1llb47pffq33vz01fn5rrk08m1iq",
   "fetchSubmodules": true
 }

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -142,6 +142,7 @@ writeInstallerNSIS (Version fullVersion') clusterName = do
 
         _ <- section "" [Required] $ do
                 setOutPath "$INSTDIR"        -- Where to install files in this section
+                unsafeInject "AllowSkipFiles off"
                 writeRegStr HKLM "Software/Daedalus" "Install_Dir" "$INSTDIR" -- Used by launcher batch script
                 createDirectory "$APPDATA\\Daedalus\\Secrets-1.0"
                 createDirectory "$APPDATA\\Daedalus\\Logs"

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -16,7 +16,7 @@ import           Development.NSIS (Attrib (IconFile, IconIndex, RebootOK, Recurs
                                    HKEY (HKLM), Level (Highest), Page (Directory, InstFiles), abort,
                                    constant, constantStr, createDirectory, createShortcut, delete,
                                    deleteRegKey, execWait, file, iff_, installDir, installDirRegKey,
-                                   name, nsis, onPagePre, outFile, page, readRegStr,
+                                   name, nsis, onPagePre, onError, outFile, page, readRegStr,
                                    requestExecutionLevel, rmdir, section, setOutPath, str,
                                    strLength, uninstall, unsafeInject, unsafeInjectGlobal,
                                    writeRegDWORD, writeRegStr, (%/=), fileExists)
@@ -147,6 +147,8 @@ writeInstallerNSIS (Version fullVersion') clusterName = do
                 createDirectory "$APPDATA\\Daedalus\\Secrets-1.0"
                 createDirectory "$APPDATA\\Daedalus\\Logs"
                 createDirectory "$APPDATA\\Daedalus\\Logs\\pub"
+                onError (delete [] "$APPDATA\\Daedalus\\launcher.lock") $
+                    abort "Daedalus is running. It needs to be fully shutdown before running installer!"
                 iff_ (fileExists "$APPDATA\\Daedalus\\Wallet-1.0\\open\\*.*") $
                     rmdir [] "$APPDATA\\Daedalus\\Wallet-1.0\\open"
                 file [] "cardano-node.exe"

--- a/installers/dhall/linux64.dhall
+++ b/installers/dhall/linux64.dhall
@@ -1,5 +1,5 @@
 \(cluster : ./cluster.type)      ->
-let dataDir = "\${XDG_DATA_HOME}/Daedalus/"
+let dataDir = "\${XDG_DATA_HOME}/Daedalus"
 in
 { name      = "linux64"
 , configurationYaml  = "\${DAEDALUS_CONFIG}/configuration.yaml"
@@ -11,7 +11,8 @@ in
   , walletDBPath     = "Wallet/"
   }
 , pass      =
-  { nodePath            = "cardano-node"
+  { statePath           = "${dataDir}/${cluster.name}"
+  , nodePath            = "cardano-node"
   , nodeDbPath          = "DB/"
   , nodeLogConfig       = "\${DAEDALUS_CONFIG}/daedalus.yaml"
   , nodeLogPath         = "${dataDir}/${cluster.name}/Logs/cardano-node.log"

--- a/installers/dhall/macos64.dhall
+++ b/installers/dhall/macos64.dhall
@@ -13,7 +13,8 @@ in
   , walletDBPath     = "${dataDir}/Wallet-1.0"
   }
 , pass      =
-  { nodePath            = "./cardano-node"
+  { statePath           = dataDir
+  , nodePath            = "./cardano-node"
   , nodeDbPath          = "${dataDir}/DB-1.0"
   , nodeLogConfig       = "log-config-prod.yaml"
   , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"

--- a/installers/dhall/os.type
+++ b/installers/dhall/os.type
@@ -8,7 +8,8 @@
   , walletDBPath     : Text
   }
 , pass :
-  { nodePath            : Text
+  { statePath           : Text
+  , nodePath            : Text
   , nodeDbPath          : Text
   , nodeLogConfig       : Text
   , nodeLogPath         : Text

--- a/installers/dhall/win64.dhall
+++ b/installers/dhall/win64.dhall
@@ -13,7 +13,8 @@ in
   , walletDBPath     = "${dataDir}\\Wallet-1.0"
   }
 , pass      =
-  { nodePath            = "\${DAEDALUS_DIR}\\cardano-node.exe"
+  { statePath           = dataDir
+  , nodePath            = "\${DAEDALUS_DIR}\\cardano-node.exe"
   , nodeDbPath          = "${dataDir}\\DB-1.0"
   , nodeLogConfig       = "log-config-prod.yaml"
   , nodeLogPath         = "${dataDir}\\Logs\\cardano-node.log"


### PR DESCRIPTION
This PR disables allow skip files so users can't ignore errors if cardano-node is already running. It also adds a lockfile to cardano-launcher so multiple launchers can't be running at the same time.
