### PR TITLE
[DEVOPS-796] fix cp interactive in nix scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - Fixed issues with printing paper wallet certificate PDFs on printers with low amount of memory by replacing the SVG assets with transparent PNG images ([PR 951](https://github.com/input-output-hk/daedalus/pull/951))
 - Fixed presentation bug that caused only ten wallets to be shown in the wallets list, even though there were more than ten wallets in the application ([PR 958](https://github.com/input-output-hk/daedalus/pull/958))
+- Fixed reporting server URL used for submitting support requests for the Linux build of Daedalus ([PR 959](https://github.com/input-output-hk/daedalus/pull/959))
 
 ## 0.10.0
 =======

--- a/installers/nix/linux.nix
+++ b/installers/nix/linux.nix
@@ -12,13 +12,13 @@ let
   daedalus-config = runCommand "daedalus-config" {} ''
     mkdir -pv $out
     cd $out
-    cp -vi ${daedalus-bridge}/config/configuration.yaml configuration.yaml
+    cp -v ${daedalus-bridge}/config/configuration.yaml configuration.yaml
     ## TODO: we don't need both of those genesis files (even if file names sound cool),
     ##       but the choice would have to be made in the Dhall-generated files,
     ##       splitting the dep chain further:
-    cp -vi ${daedalus-bridge}/config/mainnet-genesis-dryrun-with-stakeholders.json mainnet-genesis-dryrun-with-stakeholders.json
-    cp -vi ${daedalus-bridge}/config/mainnet-genesis.json mainnet-genesis.json
-    cp -vi ${daedalus-bridge}/config/log-config-prod.yaml daedalus.yaml
+    cp -v ${daedalus-bridge}/config/mainnet-genesis-dryrun-with-stakeholders.json mainnet-genesis-dryrun-with-stakeholders.json
+    cp -v ${daedalus-bridge}/config/mainnet-genesis.json mainnet-genesis.json
+    cp -v ${daedalus-bridge}/config/log-config-prod.yaml daedalus.yaml
     ${daedalus-installer}/bin/make-installer --cluster ${cluster} config "${daedalus-installer.src}/dhall" "."
   '';
   # closure size TODO list

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -18,7 +18,7 @@ yarn2nix.mkYarnPackage {
   DAEDALUS_VERSION = "${version}";
   NODE_ENV = "production";
   installPhase = ''
-    cp -vi ${daedalus.cfg}/etc/launcher-config.yaml ./launcher-config.yaml
+    cp -v ${daedalus.cfg}/etc/launcher-config.yaml ./launcher-config.yaml
     npm run build
     mkdir -p $out/bin $out/share/daedalus
     cp -R dist/* $out/share/daedalus


### PR DESCRIPTION
This PR fixes reporting server URL used for submitting support requests for the Linux build of Daedalus.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`npm run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`npm run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`npm run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`npm run flow:test`)
- [ ] There are no *lint* errors or warnings (`npm run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `npm run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`npm run storybook`)
- [ ] In case of npm dependency changes both `package-lock.json` and `yarn.lock` files are updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
