### PR TITLE
[DEVOPS-888] set a logs prefix for launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - Fixed issues with printing paper wallet certificate PDFs on printers with low amount of memory by replacing the SVG assets with transparent PNG images ([PR 951](https://github.com/input-output-hk/daedalus/pull/951))
 - Fixed presentation bug that caused only ten wallets to be shown in the wallets list, even though there were more than ten wallets in the application ([PR 958](https://github.com/input-output-hk/daedalus/pull/958))
 - Fixed reporting server URL used for submitting support requests for the Linux build of Daedalus ([PR 959](https://github.com/input-output-hk/daedalus/pull/959))
+- Fixed missing launcher log file ([PR 963](https://github.com/input-output-hk/daedalus/pull/963))
 
 ## 0.10.0
 =======

--- a/installers/dhall/launcher.dhall
+++ b/installers/dhall/launcher.dhall
@@ -9,13 +9,13 @@
 , nodeTimeoutSec = 60
 , reportServer   = cluster.reportServer
 , walletArgs     = [] : List Text
+, logsPrefix     = os.nodeArgs.logsPrefix
 , nodeArgs =
     [ "--tlsca",               "tls/ca/ca.crt"
     , "--tlscert",             "tls/server/server.crt"
     , "--tlskey",              "tls/server/server.key"
     , "--update-server",       cluster.updateServer
     , "--keyfile",             os.nodeArgs.keyfile
-    , "--logs-prefix",         os.nodeArgs.logsPrefix
     , "--topology",            os.nodeArgs.topology
     , "--wallet-db-path",      os.nodeArgs.walletDBPath
     , "--update-latest-path",  os.nodeArgs.updateLatestPath


### PR DESCRIPTION
This PR fixes the missing launcher log files.

## Todo:

- [x] Test on `Linux`
- [x] Test on `macOS`
- [x] Test on `Windows`
