### PR TITLE
[DEVOPS-900] Bump version to 0.10.1-cardano-sl-1.2.1

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@ steps:
   - label: 'daedalus-x86_64-darwin'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.2.0
+      VERSION: 1.2.1
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       NETWORK: mainnet
     agents:
@@ -10,12 +10,12 @@ steps:
   - label: 'daedalus-x86_64-linux'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-unix.sh $VERSION --build-id $BUILDKITE_BUILD_NUMBER --pull-request $BUILDKITE_PULL_REQUEST"'
     env:
-      VERSION: 1.2.0
+      VERSION: 1.2.1
     agents:
       system: x86_64-linux
   - label: 'daedalus-x86_64-linux-nix'
     command: 'scripts/nix-shell.sh --run "scripts/build-installer-nix.sh"'
     env:
-      VERSION: 1.2.0
+      VERSION: 1.2.1
     agents:
       system: x86_64-linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.2.0.{build}
+version: 1.2.1.{build}
 
 environment:
   nodejs_version: "8"

--- a/installers/WindowsInstaller.hs
+++ b/installers/WindowsInstaller.hs
@@ -120,7 +120,7 @@ writeInstallerNSIS (Version fullVersion') clusterName = do
         _ <- constantStr "Version" (str fullVersion)
         _ <- constantStr "Cluster" (str $ unpack $ lshowText clusterName)
         name "Daedalus ($Version)"                  -- The name of the installer
-        outFile "daedalus-0.10.0-cardano-sl-$Version-$Cluster-windows.exe"           -- Where to produce the installer
+        outFile "daedalus-0.10.1-cardano-sl-$Version-$Cluster-windows.exe"           -- Where to produce the installer
         unsafeInjectGlobal $ "!define MUI_ICON \"icons\\64x64.ico\""
         unsafeInjectGlobal $ "!define MUI_HEADERIMAGE"
         unsafeInjectGlobal $ "!define MUI_HEADERIMAGE_BITMAP \"icons\\installBanner.bmp\""
@@ -207,7 +207,7 @@ main :: Options -> IO ()
 main opts@Options{..}  = do
     echo "Writing version.txt"
     let fullVersion = Version $ fromVer oDaedalusVer <> ".0"
-        fullName    = "daedalus-0.10.0-cardano-sl-" <> (fromVer fullVersion) <> "-" <> (lshowText oCluster) <> "-windows.exe"
+        fullName    = "daedalus-0.10.1-cardano-sl-" <> (fromVer fullVersion) <> "-" <> (lshowText oCluster) <> "-windows.exe"
     TIO.writeFile "version.txt" $ fromVer fullVersion
 
     generateOSClusterConfigs "./dhall" "." opts

--- a/release.nix
+++ b/release.nix
@@ -1,11 +1,11 @@
-{ version ? "1.2.0", buildNr ? "nix" }:
+{ version ? "1.2.1", buildNr ? "nix" }:
 let
   makeJobs = cluster: with import ./. { inherit cluster; version = "${version}.${buildNr}"; }; {
     inherit daedalus;
     installer = wrappedBundle newBundle pkgs cluster;
   };
   wrappedBundle = newBundle: pkgs: cluster: let
-    fn = "daedalus-0.10.0-cardano-sl-${version}.${buildNr}-${cluster}-linux.bin";
+    fn = "daedalus-0.10.1-cardano-sl-${version}.${buildNr}-${cluster}-linux.bin";
   in pkgs.runCommand "daedaus-installer" {} ''
     mkdir -pv $out/nix-support
     cp ${newBundle} $out/${fn}

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -128,7 +128,7 @@ cd installers
     do
           echo "~~~ Generating installer for cluster ${cluster}.."
           export DAEDALUS_CLUSTER=${cluster}
-                    INSTALLER_PKG="daedalus-0.10.0-cardano-sl-${DAEDALUS_VERSION}-${cluster}-macos.pkg"
+                    INSTALLER_PKG="daedalus-0.10.1-cardano-sl-${DAEDALUS_VERSION}-${cluster}-macos.pkg"
 
           INSTALLER_CMD="$INSTALLER/bin/make-installer ${pull_request} ${test_installer}"
           INSTALLER_CMD+="  --cardano          ${DAEDALUS_BRIDGE}"

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -143,7 +143,7 @@ FOR %%C IN (%CLUSTERS:"=%) DO (
   @echo ###
   @echo ##############################################################################
 
-  make-installer %XARGS:"=% -c %%C -o daedalus-0.10.0-cardano-sl-%DAEDALUS_VERSION%-%%C-windows.exe
+  make-installer %XARGS:"=% -c %%C -o daedalus-0.10.1-cardano-sl-%DAEDALUS_VERSION%-%%C-windows.exe
   @if %errorlevel% neq 0 ( @echo FATAL: failed to build installer
                            popd & exit /b 1)
   copy  /y launcher-config.yaml launcher-config-%%C.win64.yaml


### PR DESCRIPTION
This PR changes the installer filenames to reflect the current version.

It's a manual search&replace process on for the 0.10.x series, but will be automatic starting with 0.11.0.

Have checked it with the following commands:

    git grep --color '1\.2\.0' | grep -v '[.-]lock'
    git grep --color '0\.10\.0' | grep -v '[.-]lock' | grep -v '\.svg'
