### PR TITLE
[DEVOPS-398] installers: Add config for public testnet

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "5eae3c328ba0614691cf67530f08c9369e718793",
-  "sha256": "0qbbi3ghmidkwfkznhgz12lv2d81lms6p54v2kcs2p9m97pmrmga",
+  "rev": "f7b6661121f1eead48043d99b9081d5ab52ff519",
+  "sha256": "1ccr3qhrvsbyjgd6pvw38vcb2dasvz577jqcw93939jz22g21j6p",
   "fetchSubmodules": true
 }

--- a/installers/README.md
+++ b/installers/README.md
@@ -17,7 +17,7 @@ The Dhall expressions that comprise the runtime configuration are thus composed 
   - `launcher.dhall` -- top level expression defining the launcher configuration YAML file
   - `topology.dhall` -- top level expression defining the wallet topology YAML file
   - `{linux64,macos64,win64}.dhall`
-  - `{mainnet,staging}.dhall`
+  - `{mainnet,staging,testnet}.dhall`
 
 The set of clusters (currently `mainnet` and `staging`) that the build scripts
 (`scripts/build-installer-*`) will build installers for is enumerated in

--- a/installers/common/Config.hs
+++ b/installers/common/Config.hs
@@ -123,7 +123,7 @@ optionsParser detectedOS = Options
   <*> (fromMaybe detectedOS <$> (optional $
                    optReadLower "os"                  's' "OS, defaults to host OS.  One of:  linux64 macos64 win64"))
   <*> (fromMaybe Mainnet    <$> (optional $
-                   optReadLower "cluster"             'c' "Cluster the resulting installer will target:  mainnet or staging"))
+                   optReadLower "cluster"             'c' "Cluster the resulting installer will target:  mainnet, staging, or testnet"))
   <*> (fromMaybe "daedalus" <$> (optional $
       (AppName      <$> optText "appname"             'n' "Application name:  daedalus or..")))
   <*>                   optPath "out-dir"             'o' "Installer output directory"

--- a/installers/dhall/linux64.dhall
+++ b/installers/dhall/linux64.dhall
@@ -18,7 +18,7 @@ in
   { statePath           = "${dataDir}/${cluster.name}"
   , nodePath            = "cardano-node"
   , nodeDbPath          = "${dataDir}/DB/"
-  , nodeLogConfig       = "\${DAEDALUS_CONFIG}/daedalus.yaml"
+  , nodeLogConfig       = "\${DAEDALUS_CONFIG}/log-config-prod.yaml"
   , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"
 
   , walletPath          = "daedalus-frontend"

--- a/installers/dhall/testnet.dhall
+++ b/installers/dhall/testnet.dhall
@@ -1,6 +1,6 @@
 { name         = "testnet"
-, keyPrefix    = "devnet"
-, relays       = "relays.FIXME.cardano-mainnet.iohk.io"
+, keyPrefix    = "testnet_wallet"
+, relays       = "relays.cardano-testnet.iohkdev.io"
 , updateServer = "https://update-cardano-mainnet.iohk.io"
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = " Testnet"

--- a/installers/nix/linux.nix
+++ b/installers/nix/linux.nix
@@ -7,14 +7,11 @@ sandboxed ? false
 let
   daedalus-config = runCommand "daedalus-config" {} ''
     mkdir -pv $out
-    cd $out
-    cp -v ${daedalus-bridge}/config/configuration.yaml configuration.yaml
-    ## TODO: we don't need both of those genesis files (even if file names sound cool),
+    ## TODO: we need don't all of the genesis files (even if file names sound cool),
     ##       but the choice would have to be made in the Dhall-generated files,
     ##       splitting the dep chain further:
-    cp -v ${daedalus-bridge}/config/mainnet-genesis-dryrun-with-stakeholders.json mainnet-genesis-dryrun-with-stakeholders.json
-    cp -v ${daedalus-bridge}/config/mainnet-genesis.json mainnet-genesis.json
-    cp -v ${daedalus-bridge}/config/log-config-prod.yaml daedalus.yaml
+    cp -v ${daedalus-bridge}/config/* $out
+    cd $out
     ${daedalus-installer}/bin/make-installer --out-dir "." --cluster ${cluster} config "${daedalus-installer.src}/dhall" "."
   '';
   # closure size TODO list

--- a/scripts/build-installer-unix.sh
+++ b/scripts/build-installer-unix.sh
@@ -18,7 +18,7 @@ usage() {
 
   Options:
     --clusters "[CLUSTER-NAME...]"
-                              Build installers for CLUSTERS.  Defaults to "mainnet staging"
+                              Build installers for CLUSTERS.  Defaults to "mainnet staging testnet"
     --fast-impure             Fast, impure, incremental build
     --build-id BUILD-NO       Identifier of the build; defaults to '0'
 


### PR DESCRIPTION
Configures the testnet installer so that the wallet can connect to the public testnet.