### PR TITLE
[DEVOPS-919] installers: provide BUILD_NUMBER and API_VERSION

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -74,8 +74,9 @@
   ],
   "globals": {
     "API": true,
+    "API_VERSION": true,
     "NETWORK": true,
     "MOBX_DEV_TOOLS": true,
-    "DAEDALUS_VERSION": true
+    "BUILD_NUMBER": true
   }
 }

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,7 @@ in
 , pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
 , cluster ? "mainnet"
 , version ? "versionNotSet"
+, buildNum ? null
 }:
 
 let
@@ -39,7 +40,11 @@ let
     ## TODO: move to installers/nix
     daedalus-installer = self.callPackage ./installers/default.nix {};
     daedalus = self.callPackage ./installers/nix/linux.nix {};
-    rawapp = self.callPackage ./yarn2nix.nix { api = "ada"; };
+    rawapp = self.callPackage ./yarn2nix.nix {
+      inherit buildNum;
+      api = "ada";
+      apiVersion = cardanoPkgs.daedalus-bridge.version;
+    };
     source = builtins.filterSource cleanSourceFilter ./.;
 
     tests = {

--- a/installers/Spec.hs
+++ b/installers/Spec.hs
@@ -54,7 +54,7 @@ macBuildSpec = do
     it "Reads it" $ runManaged $ do
       tmp <- getTempDir "test-bridge"
       liftIO $ writeTextFile (tmp </> "version") "1.2.3"
-      liftIO $ Mac.readCardanoVersionFile tmp `shouldReturn` "cardano-sl-1.2.3"
+      liftIO $ Mac.readCardanoVersionFile tmp `shouldReturn` "1.2.3"
     it "Handles missing version file" $ runManaged $ do
       tmp <- getTempDir "test-bridge"
       liftIO $ Mac.readCardanoVersionFile tmp `shouldReturn` "UNKNOWN"

--- a/installers/common/MacInstaller.hs
+++ b/installers/common/MacInstaller.hs
@@ -211,7 +211,7 @@ readCardanoVersionFile :: FilePath -> IO Text
 readCardanoVersionFile bridge = prefix <$> handle handler (readTextFile verFile)
   where
     verFile = bridge </> "version"
-    prefix = maybe "UNKNOWN" ("cardano-sl-" <>) . safeHead . T.lines
+    prefix = fromMaybe "UNKNOWN" . safeHead . T.lines
     handler :: IOError -> IO Text
     handler e | isDoesNotExistError e = pure ""
               | otherwise = throwM e

--- a/installers/common/MacInstaller.hs
+++ b/installers/common/MacInstaller.hs
@@ -39,6 +39,7 @@ import           Turtle.Line               (unsafeTextToLine)
 import           Config
 import           RewriteLibs               (chain)
 import           Types
+import           Util                      (exportBuildVars)
 
 data DarwinConfig = DarwinConfig {
     dcAppNameApp :: Text -- ^ Daedalus.app for example
@@ -63,8 +64,11 @@ main opts@Options{..} = do
       }
   print darwinConfig
 
-  appRoot <- buildElectronApp darwinConfig oCluster
-  ver <- makeComponentRoot opts appRoot darwinConfig
+  ver <- getBackendVersion oBackend
+  exportBuildVars opts ver
+
+  appRoot <- buildElectronApp darwinConfig
+  makeComponentRoot opts appRoot darwinConfig
   daedalusVer <- getDaedalusVersion "../package.json"
 
   let pkg = packageFileName Macos64 oCluster daedalusVer ver oBuildJob
@@ -105,41 +109,40 @@ makeScriptsDir Options{..} DarwinConfig{..} = case oBackend of
 -- component root path.
 -- NB: If webpack scripts are changed then this function may need to
 -- be updated.
-buildElectronApp :: DarwinConfig -> Cluster -> IO FilePath
-buildElectronApp darwinConfig@DarwinConfig{..} cluster = do
+buildElectronApp :: DarwinConfig -> IO FilePath
+buildElectronApp darwinConfig@DarwinConfig{..} = do
   echo "Creating icons ..."
   procs "iconutil" ["--convert", "icns", "--output", "icons/electron.icns"
                    , "icons/electron.iconset"] mempty
 
-  withDir ".." . sh $ npmPackage darwinConfig cluster
+  withDir ".." . sh $ npmPackage darwinConfig
 
   let
     formatter :: Format r (Text -> Text -> r)
     formatter = "../release/darwin-x64/" % s % "-darwin-x64/" % s
   pure $ fromString $ T.unpack $ format formatter dcAppName dcAppNameApp
 
-npmPackage :: DarwinConfig -> Cluster -> Shell ()
-npmPackage DarwinConfig{..} cluster = do
-  let
-    clusterToNetwork Mainnet = "mainnet"
-    clusterToNetwork Staging = "testnet"
-    clusterToNetwork Testnet = "testnet"
+npmPackage :: DarwinConfig -> Shell ()
+npmPackage DarwinConfig{..} = do
   mktree "release"
   echo "~~~ Installing nodejs dependencies..."
   procs "npm" ["install"] empty
-  export "NODE_ENV" "production"
-  export "NETWORK" $ clusterToNetwork cluster
   echo "~~~ Running electron packager script..."
+  export "NODE_ENV" "production"
   procs "npm" ["run", "package", "--", "--name", dcAppName ] empty
   size <- inproc "du" ["-sh", "release"] empty
   printf ("Size of Electron app is " % l % "\n") size
 
-makeComponentRoot :: Options -> FilePath -> DarwinConfig -> IO Text
+getBackendVersion :: Backend -> IO Text
+getBackendVersion (Cardano bridge) = readCardanoVersionFile bridge
+getBackendVersion Mantis = pure "DEVOPS-533"
+
+makeComponentRoot :: Options -> FilePath -> DarwinConfig -> IO ()
 makeComponentRoot Options{..} appRoot darwinConfig@DarwinConfig{..} = do
   let dir     = appRoot </> "Contents/MacOS"
 
   echo "~~~ Preparing files ..."
-  ver <- case oBackend of
+  case oBackend of
     Cardano bridge -> do
       -- Executables (from daedalus-bridge)
       forM ["cardano-launcher", "cardano-node", "cardano-x509-certificates"] $ \f ->
@@ -164,17 +167,14 @@ makeComponentRoot Options{..} appRoot darwinConfig@DarwinConfig{..} = do
       -- Rewrite libs paths and bundle them
       void $ chain (encodeString dir) $ fmap tt [dir </> "cardano-launcher", dir </> "cardano-node", dir </> "cardano-x509-certificates"]
 
-      readCardanoVersionFile bridge
-
-    Mantis -> pure "mantis" -- DEVOPS-533
+    Mantis -> pure () -- DEVOPS-533
 
   -- Prepare launcher
   de <- testdir (dir </> "Frontend")
   unless de $ mv (dir </> (fromString $ T.unpack $ dcAppName)) (dir </> "Frontend")
   run "chmod" ["+x", tt (dir </> "Frontend")]
-  writeLauncherFile dir darwinConfig
+  void $ writeLauncherFile dir darwinConfig
 
-  pure ver
 
 makeInstaller :: Options -> DarwinConfig -> FilePath -> FilePath -> IO FilePath
 makeInstaller opts@Options{..} darwinConfig@DarwinConfig{..} componentRoot pkg = do

--- a/installers/common/Util.hs
+++ b/installers/common/Util.hs
@@ -1,6 +1,14 @@
+{-# LANGUAGE OverloadedStrings, NamedFieldPuns #-}
+
 module Util where
 
+import Control.Monad (mapM_)
+import Data.Text (Text)
 import System.Directory (listDirectory, withCurrentDirectory, removeDirectory, removeFile, doesDirectoryExist)
+import Turtle (export)
+
+import Config (Options(..), Backend(..))
+import Types (fromBuildJob, clusterNetwork)
 
 windowsRemoveDirectoryRecursive :: FilePath -> IO ()
 windowsRemoveDirectoryRecursive path = do
@@ -12,3 +20,19 @@ windowsRemoveDirectoryRecursive path = do
         removeDirectory path
     else do
         removeFile path
+
+-- | Sets the many environment variables required for the
+-- "npm package" build.
+-- When updating this, check that all variables are baked in with both
+-- webpack.config.js files.
+exportBuildVars :: Options -> Text -> IO ()
+exportBuildVars Options{oBackend, oBuildJob, oCluster} backendVersion = do
+    mapM_ (uncurry export)
+        [ ("API", apiName oBackend)
+        , ("API_VERSION", backendVersion)
+        , ("BUILD_NUMBER", maybe "" fromBuildJob oBuildJob)
+        , ("NETWORK", clusterNetwork oCluster)
+        ]
+    where
+        apiName (Cardano _) = "ada"
+        apiName Mantis      = "etc"

--- a/installers/common/WindowsInstaller.hs
+++ b/installers/common/WindowsInstaller.hs
@@ -264,10 +264,9 @@ getCardanoVersion = withDir "DLLs" (grepCardanoVersion run)
     prog = ".." </> "cardano-node.exe"
 
 grepCardanoVersion :: Shell Line -> IO Text
-grepCardanoVersion = fmap addPrefix . strict . sed versionPattern
+grepCardanoVersion = fmap T.stripEnd . strict . sed versionPattern
   where
     versionPattern = text "cardano-node-" *> plus (noneOf ", ") <* star dot
-    addPrefix = ("cardano-sl-" <>) . T.stripEnd
 
 getTempDir :: MonadIO io => io FilePath
 getTempDir = need "TEMP" >>= \case

--- a/installers/common/WindowsInstaller.hs
+++ b/installers/common/WindowsInstaller.hs
@@ -190,20 +190,21 @@ writeInstallerNSIS outName (Version fullVersion') installerConfig clusterName = 
 packageFrontend :: IO ()
 packageFrontend = do
     export "NODE_ENV" "production"
-    shells "npm run package -- --icon installers/icons/64x64" mempty
+    shells "npm run package -- --icon installers/icons/64x64" empty
 
 main :: Options -> IO ()
 main opts@Options{..}  = do
     generateOSClusterConfigs "./dhall" "." opts
-
-    echo "Packaging frontend"
-    packageFrontend
 
     fetchCardanoSL "."
     printCardanoBuildInfo "."
 
     fullVersion <- getDaedalusVersion "../package.json"
     cardanoVersion <- getCardanoVersion
+
+    echo "Packaging frontend"
+    exportBuildVars opts cardanoVersion
+    packageFrontend
 
     let fullName = packageFileName Win64 oCluster fullVersion cardanoVersion oBuildJob
 

--- a/release.nix
+++ b/release.nix
@@ -1,9 +1,9 @@
 { system ? builtins.currentSystem
-, buildNr ? null
+, buildNum ? null
 }:
 let
   daedalusPkgs = import ./. {};
-  suffix = if buildNr == null then "" else "-${toString buildNr}";
+  suffix = if buildNum == null then "" else "-${toString buildNum}";
   version = (builtins.fromJSON (builtins.readFile (./. + "/package.json"))).version;
 
   makeJobs = cluster: with import ./. { inherit cluster system; version = "${version}${suffix}"; }; {

--- a/scripts/build-installer-nix.sh
+++ b/scripts/build-installer-nix.sh
@@ -22,7 +22,7 @@ nix-build default.nix -A rawapp.deps -o node_modules.root -Q
 for cluster in ${CLUSTERS}
 do
   echo '~~~ Building '"${cluster}"' installer'
-  nix-build -Q release.nix -A "${cluster}.installer" --argstr buildNr "$BUILDKITE_BUILD_NUMBER" -o csl-daedalus
+  nix-build -Q release.nix -A "${cluster}.installer" --argstr buildNum "$BUILDKITE_BUILD_NUMBER" -o csl-daedalus
   if [ -n "${BUILDKITE_JOB_ID:-}" ]; then
     upload_artifacts_public csl-daedalus/daedalus*.bin
     nix-build -A daedalus.cfg  --argstr cluster "${cluster}"

--- a/scripts/build-installer-win64.bat
+++ b/scripts/build-installer-win64.bat
@@ -15,8 +15,6 @@ set /p CLUSTERS=<installer-clusters.cfg
 set LIBRESSL_VERSION=2.5.3
 set CURL_VERSION=7.54.0
 
-set DAEDALUS_VERSION=%1
-
 set CURL_URL=https://bintray.com/artifact/download/vszakats/generic/curl-%CURL_VERSION%-win64-mingw.7z
 set CURL_BIN=curl-%CURL_VERSION%-win64-mingw\bin
 set LIBRESSL_URL=https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-%LIBRESSL_VERSION%-windows.zip

--- a/source/common/environment.js
+++ b/source/common/environment.js
@@ -14,6 +14,7 @@ const environment = Object.assign({
   PRODUCTION: 'production',
   NETWORK: process.env.NETWORK,
   API: process.env.API || 'ada',
+  API_VERSION: process.env.API_VERSION || 'dev',
   MOBX_DEV_TOOLS: process.env.MOBX_DEV_TOOLS,
   current: process.env.NODE_ENV,
   REPORT_URL: process.env.REPORT_URL || 'http://report-server.awstest.iohkdev.io:8080/',
@@ -23,7 +24,7 @@ const environment = Object.assign({
   isMainnet: () => environment.NETWORK === 'mainnet',
   isAdaApi: () => environment.API === 'ada',
   isEtcApi: () => environment.API === 'etc',
-  build: process.env.DAEDALUS_VERSION || 'dev',
+  build: process.env.BUILD_NUMBER || 'dev',
   platform: os.platform(),
   version,
 }, remote ? remote.getGlobal('env') : process.env);

--- a/source/main/webpack.config.js
+++ b/source/main/webpack.config.js
@@ -47,9 +47,10 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin(Object.assign({
       'process.env.API': JSON.stringify(process.env.API || 'ada'),
+      'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION || 'dev'),
       'process.env.NETWORK': JSON.stringify(process.env.NETWORK || 'development'),
       'process.env.MOBX_DEV_TOOLS': process.env.MOBX_DEV_TOOLS || 0,
-      'process.env.DAEDALUS_VERSION': JSON.stringify(process.env.DAEDALUS_VERSION || 'dev'),
+      'process.env.BUILD_NUMBER': JSON.stringify(process.env.BUILD_NUMBER || 'dev'),
       'process.env.REPORT_URL': JSON.stringify(reportUrl),
     }, process.env.NODE_ENV === 'production' ? {
       // Only bake in NODE_ENV value for production build.

--- a/source/renderer/app/components/static/About.js
+++ b/source/renderer/app/components/static/About.js
@@ -88,7 +88,7 @@ export default class About extends Component<any> {
 
     const { version, build } = environment;
     const apiName = intl.formatMessage(environmentSpecificMessages[environment.API].apiName);
-    const apiVersion = intl.formatMessage(environmentSpecificMessages[environment.API].apiVersion);
+    const apiVersion = environment.API_VERSION;
     const apiIcon = environment.isAdaApi() ? cardanoIcon : mantisIcon;
 
     const apiHeadline = environment.isAdaApi()

--- a/source/renderer/app/i18n/global-messages.js
+++ b/source/renderer/app/i18n/global-messages.js
@@ -160,11 +160,6 @@ export const environmentSpecificMessages = {
       defaultMessage: '!!!Cardano',
       description: 'Name for "Cardano" client.'
     },
-    apiVersion: {
-      id: 'environment.apiVersion.cardano',
-      defaultMessage: '!!!1.0.4',
-      description: 'Version of "Cardano" client.'
-    },
   }),
 
   etc: defineMessages({
@@ -177,11 +172,6 @@ export const environmentSpecificMessages = {
       id: 'environment.apiName.mantis',
       defaultMessage: '!!!Mantis',
       description: 'Name for "Mantis" client.'
-    },
-    apiVersion: {
-      id: 'environment.apiVersion.mantis',
-      defaultMessage: '!!!1.0 rc1',
-      description: 'Version of "Mantis" client.'
     },
   }),
 };

--- a/source/renderer/app/i18n/locales/de-DE.json
+++ b/source/renderer/app/i18n/locales/de-DE.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "!!!Cardano-Core update is available",
   "environment.apiName.cardano": "!!!Cardano",
   "environment.apiName.mantis": "!!!Mantis",
-  "environment.apiVersion.cardano": "!!!1.0.4",
-  "environment.apiVersion.mantis": "!!!1.0 rc1",
   "environment.currency.ada": "!!!Ada",
   "environment.currency.etc": "!!!Etc",
   "global.assuranceLevel.normal": "!!!Normal",

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -5444,31 +5444,17 @@
         }
       },
       {
-        "defaultMessage": "!!!1.0.4",
-        "description": "Version of \"Cardano\" client.",
-        "end": {
-          "column": 5,
-          "line": 167
-        },
-        "file": "source/renderer/app/i18n/global-messages.js",
-        "id": "environment.apiVersion.cardano",
-        "start": {
-          "column": 16,
-          "line": 163
-        }
-      },
-      {
         "defaultMessage": "!!!Etc",
         "description": "Name for \"Etc\" unit.",
         "end": {
           "column": 5,
-          "line": 175
+          "line": 170
         },
         "file": "source/renderer/app/i18n/global-messages.js",
         "id": "environment.currency.etc",
         "start": {
           "column": 14,
-          "line": 171
+          "line": 166
         }
       },
       {
@@ -5476,27 +5462,13 @@
         "description": "Name for \"Mantis\" client.",
         "end": {
           "column": 5,
-          "line": 180
+          "line": 175
         },
         "file": "source/renderer/app/i18n/global-messages.js",
         "id": "environment.apiName.mantis",
         "start": {
           "column": 13,
-          "line": 176
-        }
-      },
-      {
-        "defaultMessage": "!!!1.0 rc1",
-        "description": "Version of \"Mantis\" client.",
-        "end": {
-          "column": 5,
-          "line": 185
-        },
-        "file": "source/renderer/app/i18n/global-messages.js",
-        "id": "environment.apiVersion.mantis",
-        "start": {
-          "column": 16,
-          "line": 181
+          "line": 171
         }
       }
     ],

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "Daedalus and Cardano node update is available",
   "environment.apiName.cardano": "Cardano",
   "environment.apiName.mantis": "Mantis",
-  "environment.apiVersion.cardano": "1.3.0",
-  "environment.apiVersion.mantis": "1.0 rc1",
   "environment.currency.ada": "ADA",
   "environment.currency.etc": "ETC",
   "global.assuranceLevel.normal": "Normal",

--- a/source/renderer/app/i18n/locales/hr-HR.json
+++ b/source/renderer/app/i18n/locales/hr-HR.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "!!!Cardano-Core update is available",
   "environment.apiName.cardano": "!!!Cardano",
   "environment.apiName.mantis": "!!!Mantis",
-  "environment.apiVersion.cardano": "!!!1.0.4",
-  "environment.apiVersion.mantis": "!!!1.0 rc1",
   "environment.currency.ada": "!!!Ada",
   "environment.currency.etc": "!!!Etc",
   "global.assuranceLevel.normal": "!!!Normal",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "ダイダロス、カルダノノードの更新プログラムが入手可能です。",
   "environment.apiName.cardano": "カルダノ",
   "environment.apiName.mantis": "マンティス",
-  "environment.apiVersion.cardano": "1.3.0",
-  "environment.apiVersion.mantis": "1.0 rc1",
   "environment.currency.ada": "ADA",
   "environment.currency.etc": "ETC",
   "global.assuranceLevel.normal": "普通",

--- a/source/renderer/app/i18n/locales/ko-KR.json
+++ b/source/renderer/app/i18n/locales/ko-KR.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "!!!Cardano-Core update is available",
   "environment.apiName.cardano": "!!!Cardano",
   "environment.apiName.mantis": "!!!Mantis",
-  "environment.apiVersion.cardano": "!!!1.0.4",
-  "environment.apiVersion.mantis": "!!!1.0 rc1",
   "environment.currency.ada": "!!!Ada",
   "environment.currency.etc": "!!!Etc",
   "global.assuranceLevel.normal": "!!!Normal",

--- a/source/renderer/app/i18n/locales/zh-CN.json
+++ b/source/renderer/app/i18n/locales/zh-CN.json
@@ -40,8 +40,6 @@
   "cardano.node.update.notification.titleWithoutVersion": "!!!Cardano-Core update is available",
   "environment.apiName.cardano": "!!!Cardano",
   "environment.apiName.mantis": "!!!Mantis",
-  "environment.apiVersion.cardano": "!!!1.0.4",
-  "environment.apiVersion.mantis": "!!!1.0 rc1",
   "environment.currency.ada": "!!!Ada",
   "environment.currency.etc": "!!!Etc",
   "global.assuranceLevel.normal": "!!!Normal",

--- a/source/renderer/webpack.config.js
+++ b/source/renderer/webpack.config.js
@@ -85,9 +85,10 @@ module.exports = {
     new ExtractTextPlugin('styles.css', { allChunks: true }),
     new webpack.DefinePlugin({
       'process.env.API': JSON.stringify(process.env.API || 'ada'),
+      'process.env.API_VERSION': JSON.stringify(process.env.API_VERSION || 'dev'),
       'process.env.NETWORK': JSON.stringify(process.env.NETWORK || 'development'),
       'process.env.MOBX_DEV_TOOLS': process.env.MOBX_DEV_TOOLS || 0,
-      'process.env.DAEDALUS_VERSION': JSON.stringify(process.env.DAEDALUS_VERSION || 'dev'),
+      'process.env.BUILD_NUMBER': JSON.stringify(process.env.BUILD_NUMBER || 'dev'),
       'process.env.REPORT_URL': JSON.stringify(reportUrl),
     }),
     new AutoDllPlugin({

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, nodejs-8_x, python, api, cluster, nukeReferences, version, fetchzip, daedalus, stdenv }:
+{ lib, pkgs, nodejs-8_x, python, api, apiVersion, cluster, buildNum, nukeReferences, fetchzip, daedalus, stdenv }:
 let
   nodejs = nodejs-8_x;
   yarn2nix = import (fetchzip {
@@ -18,9 +18,10 @@ yarn2nix.mkYarnPackage {
   name = "daedalus-js";
   src = if canUseFetchGit then builtins.fetchGit ./. else lib.cleanSource ./.;
   API = api;
+  API_VERSION = apiVersion;
   CI = "nix";
   NETWORK = networkMap.${cluster};
-  DAEDALUS_VERSION = "${version}";
+  BUILD_NUMBER = "${toString buildNum}";
   NODE_ENV = "production";
   installPhase = ''
     cp -v ${daedalus.cfg}/etc/launcher-config.yaml ./launcher-config.yaml


### PR DESCRIPTION
* Renames the variable `DAEDALUS_VERSION` to `BUILD_NUMBER` because that's what it contains.
* Makes sure that `BUILD_NUMBER` is set for the Windows and macOS builds.
* Adds new variable `API_VERSION` and sets to the cardano-sl version known at build time.
* Uses these new ENV variables in place of hardcoded translation key files versions