### PR TITLE
[DEVOPS-398] Installers: Add config for public testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Features
+
+- Added initial configuration for a testnet build of Daedalus ([PR 991](https://github.com/input-output-hk/daedalus/pull/991))
+
 ## 0.11.0
 
 ### Features
@@ -37,7 +43,6 @@ Changelog
 - Log expected errors as debug messages only ([PR 916](https://github.com/input-output-hk/daedalus/pull/916))
 - Refactored npm scripts to use colon style ([PR 939](https://github.com/input-output-hk/daedalus/pull/939))
 - Refactored various magic numbers & strings into constants ([PR 881](https://github.com/input-output-hk/daedalus/pull/881))
-- Added initial configuration for a testnet build of Daedalus ([PR 991](https://github.com/input-output-hk/daedalus/pull/991))
 
 ## 0.10.1
 =======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Changelog
 - Log expected errors as debug messages only ([PR 916](https://github.com/input-output-hk/daedalus/pull/916))
 - Refactored npm scripts to use colon style ([PR 939](https://github.com/input-output-hk/daedalus/pull/939))
 - Refactored various magic numbers & strings into constants ([PR 881](https://github.com/input-output-hk/daedalus/pull/881))
+- Added initial configuration for a testnet build of Daedalus ([PR 991](https://github.com/input-output-hk/daedalus/pull/991))
 
 ## 0.10.1
 =======

--- a/installers/dhall/linux64.dhall
+++ b/installers/dhall/linux64.dhall
@@ -18,7 +18,7 @@ in
   { statePath           = "${dataDir}/${cluster.name}"
   , nodePath            = "cardano-node"
   , nodeDbPath          = "${dataDir}/DB/"
-  , nodeLogConfig       = "\${DAEDALUS_CONFIG}/daedalus.yaml"
+  , nodeLogConfig       = "\${DAEDALUS_CONFIG}/log-config-prod.yaml"
   , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"
 
   , walletPath          = "daedalus-frontend"

--- a/installers/dhall/testnet.dhall
+++ b/installers/dhall/testnet.dhall
@@ -1,6 +1,6 @@
 { name         = "testnet"
-, keyPrefix    = "devnet"
-, relays       = "relays.FIXME.cardano-mainnet.iohk.io"
+, keyPrefix    = "testnet_wallet"
+, relays       = "relays.cardano-testnet.iohkdev.io"
 , updateServer = "https://update-cardano-mainnet.iohk.io"
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = " Testnet"

--- a/installers/nix/linux.nix
+++ b/installers/nix/linux.nix
@@ -7,14 +7,11 @@ sandboxed ? false
 let
   daedalus-config = runCommand "daedalus-config" {} ''
     mkdir -pv $out
-    cd $out
-    cp -v ${daedalus-bridge}/config/configuration.yaml configuration.yaml
-    ## TODO: we don't need both of those genesis files (even if file names sound cool),
+    ## TODO: we don't need all of the genesis files (even if file names sound cool),
     ##       but the choice would have to be made in the Dhall-generated files,
     ##       splitting the dep chain further:
-    cp -v ${daedalus-bridge}/config/mainnet-genesis-dryrun-with-stakeholders.json mainnet-genesis-dryrun-with-stakeholders.json
-    cp -v ${daedalus-bridge}/config/mainnet-genesis.json mainnet-genesis.json
-    cp -v ${daedalus-bridge}/config/log-config-prod.yaml daedalus.yaml
+    cp -v ${daedalus-bridge}/config/* $out
+    cd $out
     ${daedalus-installer}/bin/make-installer --out-dir "." --cluster ${cluster} config "${daedalus-installer.src}/dhall" "."
   '';
   # closure size TODO list


### PR DESCRIPTION
Configures the testnet installer so that the wallet can connect to the public testnet.

This PR is for the `release/0.11.0` branch. Merging this change won't have any impact on the mainnet or staging builds, so may as well be done now.
