### PR TITLE
[DEVOPS-922] Different ports for mainnet/staging/testnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Features
+
+- Added support for configurable Api port ([PR 992](https://github.com/input-output-hk/daedalus/pull/992))
+
 ## 0.11.0
 
 ### Features

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,8 @@ const createElectronServer = (env, args = []) => {
     spawnOpt: {
       env: Object.assign({}, process.env, env),
       args,
-    }
+    },
+    port: process.env.ELECTRON_PORT
   });
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,8 +25,7 @@ const createElectronServer = (env, args = []) => {
     spawnOpt: {
       env: Object.assign({}, process.env, env),
       args,
-    },
-    port: process.env.ELECTRON_PORT
+    }
   });
 };
 

--- a/installers/Spec.hs
+++ b/installers/Spec.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as T
 import Filesystem.Path (FilePath, (</>))
 import Filesystem.Path.CurrentOS (fromText, decodeString)
 import System.IO.Temp (getCanonicalTemporaryDirectory)
-import Turtle (mktempdir, inproc, strict, ls, fold, writeTextFile, mktree, mkdir, cptree, cp, format)
+import Turtle (mktempdir, inproc, strict, ls, fold, writeTextFile, mktree, mkdir, cptree, format)
 import Control.Monad.Managed (MonadManaged, runManaged)
 import Data.Aeson.Types (Value)
 import Data.Aeson.Lens
@@ -85,6 +85,14 @@ configSpec = do
       dhallTest Win64 Staging Launcher "./dhall" $ \val -> do
         val^.key "reportServer"._String `shouldSatisfy` (T.isInfixOf "iohkdev.io")
         val^.key "configuration".key "key"._String `shouldBe` "mainnet_dryrun_wallet_win64"
+  describe "installer config generation" $ do
+    it "gets the right mainnet port" $ do
+      mainnetCfg <- getInstallerConfig "./dhall" Macos64 Mainnet
+      walletPort mainnetCfg `shouldBe` 8090
+    it "gets the right testnet port" $ do
+      stagingCfg <- getInstallerConfig "./dhall" Win64 Testnet
+      walletPort stagingCfg `shouldBe` 8092
+
 
 deleteSpec :: Spec
 deleteSpec = do

--- a/installers/common/Config.hs
+++ b/installers/common/Config.hs
@@ -151,12 +151,11 @@ dhallTopExpr dhallRoot cfg os cluster
   where comp x = dhallRoot <>"/"<> lshowText x <>".dhall"
 
 getInstallerConfig :: Text -> OS -> Cluster -> IO InstallerConfig
-getInstallerConfig dhallRoot os cluster = do
-    let
-        topexpr :: Dhall.Text
-        topexpr = LT.fromStrict $ format (s%" ("%s%" "%s%")") (dhallRoot <> "/installer.dhall") (comp os) (comp cluster)
+getInstallerConfig dhallRoot os cluster = Dhall.input Dhall.auto (LT.fromStrict topexpr)
+    where
+        topexpr = format (s%" "%s%" ("%s%" "%s%")") (dhallRoot <> "/installer.dhall") (comp cluster) (comp os) (comp cluster)
         comp x = dhallRoot <>"/"<> lshowText x <>".dhall"
-    Dhall.input Dhall.auto topexpr
+
 
 forConfigValues :: Text -> OS -> Cluster -> (Config -> YAML.Value -> IO a) -> IO ()
 forConfigValues dhallRoot os cluster action = do

--- a/installers/common/MacInstaller.hs
+++ b/installers/common/MacInstaller.hs
@@ -65,7 +65,7 @@ main opts@Options{..} = do
   print darwinConfig
 
   ver <- getBackendVersion oBackend
-  exportBuildVars opts ver
+  exportBuildVars opts installerConfig ver
 
   appRoot <- buildElectronApp darwinConfig
   makeComponentRoot opts appRoot darwinConfig

--- a/installers/common/Types.hs
+++ b/installers/common/Types.hs
@@ -132,6 +132,7 @@ withDir path = bracket (pwd >>= \old -> (cd path >> pure old)) cd . const
 data InstallerConfig = InstallerConfig {
       installDirectory :: Text
     , macPackageName :: Text
+    , walletPort :: Integer
     } deriving (Generic, Show)
 
 instance Dhall.Interpret InstallerConfig

--- a/installers/common/Util.hs
+++ b/installers/common/Util.hs
@@ -5,10 +5,10 @@ module Util where
 import Control.Monad (mapM_)
 import Data.Text (Text)
 import System.Directory (listDirectory, withCurrentDirectory, removeDirectory, removeFile, doesDirectoryExist)
-import Turtle (export)
+import Turtle (export, format, d)
 
 import Config (Options(..), Backend(..))
-import Types (fromBuildJob, clusterNetwork)
+import Types (InstallerConfig(walletPort), fromBuildJob, clusterNetwork)
 
 windowsRemoveDirectoryRecursive :: FilePath -> IO ()
 windowsRemoveDirectoryRecursive path = do
@@ -25,13 +25,14 @@ windowsRemoveDirectoryRecursive path = do
 -- "npm package" build.
 -- When updating this, check that all variables are baked in with both
 -- webpack.config.js files.
-exportBuildVars :: Options -> Text -> IO ()
-exportBuildVars Options{oBackend, oBuildJob, oCluster} backendVersion = do
+exportBuildVars :: Options -> InstallerConfig -> Text -> IO ()
+exportBuildVars Options{oBackend, oBuildJob, oCluster} cfg backendVersion = do
     mapM_ (uncurry export)
         [ ("API", apiName oBackend)
         , ("API_VERSION", backendVersion)
         , ("BUILD_NUMBER", maybe "" fromBuildJob oBuildJob)
         , ("NETWORK", clusterNetwork oCluster)
+        , ("WALLET_PORT", format d (walletPort cfg))
         ]
     where
         apiName (Cardano _) = "ada"

--- a/installers/common/WindowsInstaller.hs
+++ b/installers/common/WindowsInstaller.hs
@@ -195,6 +195,7 @@ packageFrontend = do
 main :: Options -> IO ()
 main opts@Options{..}  = do
     generateOSClusterConfigs "./dhall" "." opts
+    installerConfig <- getInstallerConfig "./dhall" Win64 oCluster
 
     fetchCardanoSL "."
     printCardanoBuildInfo "."
@@ -203,14 +204,12 @@ main opts@Options{..}  = do
     cardanoVersion <- getCardanoVersion
 
     echo "Packaging frontend"
-    exportBuildVars opts cardanoVersion
+    exportBuildVars opts installerConfig cardanoVersion
     packageFrontend
 
     let fullName = packageFileName Win64 oCluster fullVersion cardanoVersion oBuildJob
 
     printf ("Building: "%fp%"\n") fullName
-
-    installerConfig <- getInstallerConfig "./dhall" Win64 oCluster
 
     echo "Adding permissions manifest to cardano-launcher.exe"
     procs "C:\\Program Files (x86)\\Windows Kits\\8.1\\bin\\x64\\mt.exe" ["-manifest", "cardano-launcher.exe.manifest", "-outputresource:cardano-launcher.exe;#1"] mempty

--- a/installers/dhall/cluster.type
+++ b/installers/dhall/cluster.type
@@ -5,4 +5,5 @@
 , reportServer : Text
 , installDirectorySuffix : Text
 , macPackageSuffix       : Text
+, walletPort             : Integer
 }

--- a/installers/dhall/installer.dhall
+++ b/installers/dhall/installer.dhall
@@ -1,5 +1,7 @@
+\(cluster : ./cluster.type) ->
 \( os : ./os.type) ->
 {
   installDirectory = os.installDirectory
 , macPackageName   = os.macPackageName
+, walletPort       = cluster.walletPort
 }

--- a/installers/dhall/launcher.dhall
+++ b/installers/dhall/launcher.dhall
@@ -22,7 +22,7 @@
     , "--topology",            os.nodeArgs.topology
     , "--wallet-db-path",      os.nodeArgs.walletDBPath
     , "--update-latest-path",  os.nodeArgs.updateLatestPath
-    , "--wallet-address",      "127.0.0.1:8090"
+    , "--wallet-address",      "127.0.0.1:${Integer/show cluster.walletPort}"
     -- XXX: this is a workaround for Linux
     , "--update-with-package"
     ]

--- a/installers/dhall/mainnet.dhall
+++ b/installers/dhall/mainnet.dhall
@@ -5,4 +5,5 @@
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = ""
 , macPackageSuffix       = ""
+, walletPort             = 8090
 }

--- a/installers/dhall/staging.dhall
+++ b/installers/dhall/staging.dhall
@@ -5,4 +5,5 @@
 , reportServer = "http://report-server.awstest.iohkdev.io:8080"
 , installDirectorySuffix = " Staging"
 , macPackageSuffix       = "Staging"
+, walletPort             = 8091
 }

--- a/installers/dhall/testnet.dhall
+++ b/installers/dhall/testnet.dhall
@@ -5,4 +5,5 @@
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = " Testnet"
 , macPackageSuffix       = "Testnet"
+, walletPort             = 8092
 }

--- a/source/common/environment.js
+++ b/source/common/environment.js
@@ -18,6 +18,7 @@ const environment = Object.assign({
   MOBX_DEV_TOOLS: process.env.MOBX_DEV_TOOLS,
   current: process.env.NODE_ENV,
   REPORT_URL: process.env.REPORT_URL || 'http://report-server.awstest.iohkdev.io:8080/',
+  WALLET_PORT: parseInt(process.env.WALLET_PORT || '8090', 10),
   isDev: () => environment.current === environment.DEVELOPMENT,
   isTest: () => environment.current === environment.TEST,
   isProduction: () => environment.current === environment.PRODUCTION,

--- a/source/main/webpack.config.js
+++ b/source/main/webpack.config.js
@@ -53,10 +53,11 @@ module.exports = {
       'process.env.BUILD_NUMBER': JSON.stringify(process.env.BUILD_NUMBER || 'dev'),
       'process.env.REPORT_URL': JSON.stringify(reportUrl),
     }, process.env.NODE_ENV === 'production' ? {
-      // Only bake in NODE_ENV value for production build.
+      // Only bake in NODE_ENV and WALLET_PORT values for production builds.
       // This is so that the test suite based on the webpack build will
       // choose the correct path to ca.crt (see setupTls.js).
       'process.env.NODE_ENV': '"production"',
+      'process.env.WALLET_PORT': JSON.stringify(process.env.WALLET_PORT || ''),
     } : {})),
     !isCi && (
       new HardSourceWebpackPlugin({

--- a/source/renderer/app/api/ada/adaTestReset.js
+++ b/source/renderer/app/api/ada/adaTestReset.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type AdaTestResetParams = {
   ca: string,
@@ -12,7 +13,7 @@ export const adaTestReset = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/test/reset',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/adaTxFee.js
+++ b/source/renderer/app/api/ada/adaTxFee.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransactionFee } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type AdaTxFeeParams = {
   ca: string,
@@ -19,7 +20,7 @@ export const adaTxFee = (
     hostname: 'localhost',
     method: 'POST',
     path: `/api/txs/fee/${sender}/${receiver}/${amount}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, {}, { groupingPolicy })
 );

--- a/source/renderer/app/api/ada/applyAdaUpdate.js
+++ b/source/renderer/app/api/ada/applyAdaUpdate.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type ApplyAdaUpdateParams = {
   ca: string,
@@ -12,7 +13,7 @@ export const applyAdaUpdate = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/update/apply',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/changeAdaWalletPassphrase.js
+++ b/source/renderer/app/api/ada/changeAdaWalletPassphrase.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 import { encryptPassphrase } from './lib/encryptPassphrase';
 
 export type ChangeAdaWalletPassphraseParams = {
@@ -19,7 +20,7 @@ export const changeAdaWalletPassphrase = (
     hostname: 'localhost',
     method: 'POST',
     path: `/api/wallets/password/${walletId}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { old: encryptedOldPassphrase, new: encryptedNewPassphrase });
 };

--- a/source/renderer/app/api/ada/deleteAdaWallet.js
+++ b/source/renderer/app/api/ada/deleteAdaWallet.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type DeleteAdaWalletParams = {
   ca: string,
@@ -13,7 +14,7 @@ export const deleteAdaWallet = (
     hostname: 'localhost',
     method: 'DELETE',
     path: `/api/wallets/${walletId}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/exportAdaBackupJSON.js
+++ b/source/renderer/app/api/ada/exportAdaBackupJSON.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type ExportAdaBackupJSONParams = {
   ca: string,
@@ -14,7 +15,7 @@ export const exportAdaBackupJSON = (
     hostname: 'localhost',
     method: 'POST',
     path: `/api/backup/export/${walletId}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, {}, filePath)
 );

--- a/source/renderer/app/api/ada/getAdaAccounts.js
+++ b/source/renderer/app/api/ada/getAdaAccounts.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaAccounts } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaAccountsParams = {
   ca: string,
@@ -13,7 +14,7 @@ export const getAdaAccounts = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/accounts',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaAddressHistory.js
+++ b/source/renderer/app/api/ada/getAdaAddressHistory.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransactions } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaAddressHistoryParams = {
   ca: string,
@@ -17,7 +18,7 @@ export const getAdaAddressHistory = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { accountId, address, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistory.js
+++ b/source/renderer/app/api/ada/getAdaHistory.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransactions } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaHistoryParams = {
   ca: string,
@@ -18,7 +19,7 @@ export const getAdaHistory = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { walletId, accountId, address, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistoryByAccount.js
+++ b/source/renderer/app/api/ada/getAdaHistoryByAccount.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransactions } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaHistoryByAccountParams = {
   ca: string,
@@ -16,7 +17,7 @@ export const getAdaHistoryByAccount = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { accountId, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistoryByWallet.js
+++ b/source/renderer/app/api/ada/getAdaHistoryByWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransactions } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaHistoryByWalletParams = {
   ca: string,
@@ -16,7 +17,7 @@ export const getAdaHistoryByWallet = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { walletId, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaLocalTimeDifference.js
+++ b/source/renderer/app/api/ada/getAdaLocalTimeDifference.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaLocalTimeDifference } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaLocalTimeDifferenceParams = {
   ca: string,
@@ -13,7 +14,7 @@ export const getAdaLocalTimeDifference = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/settings/time/difference',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaSyncProgress.js
+++ b/source/renderer/app/api/ada/getAdaSyncProgress.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaSyncProgressResponse } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type GetAdaSyncProgressParams = {
   ca: string,
@@ -13,7 +14,7 @@ export const getAdaSyncProgress = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/settings/sync/progress',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaWalletAccounts.js
+++ b/source/renderer/app/api/ada/getAdaWalletAccounts.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaAccounts } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 
 export type GetAdaWalletAccountsParams = {
@@ -15,7 +16,7 @@ export const getAdaWalletAccounts = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/accounts',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { accountId: walletId })
 );

--- a/source/renderer/app/api/ada/getAdaWallets.js
+++ b/source/renderer/app/api/ada/getAdaWallets.js
@@ -2,6 +2,8 @@
 import type { AdaV1Wallets } from './types';
 import { request } from './lib/v1/request';
 import { MAX_ADA_WALLETS_COUNT } from '../../config/numbersConfig';
+import environment from '../../../../common/environment';
+
 
 export type GetAdaWalletParams = {
   ca: string,
@@ -14,7 +16,7 @@ export const getAdaWallets = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/v1/wallets',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, {
     per_page: MAX_ADA_WALLETS_COUNT, // 50 is the max per_page value

--- a/source/renderer/app/api/ada/importAdaBackupJSON.js
+++ b/source/renderer/app/api/ada/importAdaBackupJSON.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type ImportAdaBackupJSONParams = {
   ca: string,
@@ -14,7 +15,7 @@ export const importAdaBackupJSON = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/backup/import',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, {}, filePath)
 );

--- a/source/renderer/app/api/ada/importAdaWallet.js
+++ b/source/renderer/app/api/ada/importAdaWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type ImportAdaWalletParams = {
   ca: string,
@@ -15,7 +16,7 @@ export const importAdaWallet = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/keys',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: walletPassword }, filePath)
 );

--- a/source/renderer/app/api/ada/isValidAdaAddress.js
+++ b/source/renderer/app/api/ada/isValidAdaAddress.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type IsValidAdaAddressParams = {
   ca: string,
@@ -14,7 +15,7 @@ export const isValidAdaAddress = (
     hostname: 'localhost',
     method: 'GET',
     path: `/api/addresses/${encodedAddress}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   });
 };

--- a/source/renderer/app/api/ada/newAdaAccount.js
+++ b/source/renderer/app/api/ada/newAdaAccount.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaAccount } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type NewAdaAccountQueryParams = {
   passphrase: ?string,
@@ -26,7 +27,7 @@ export const newAdaAccount = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/accounts',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, queryParams, accountInitData);
 };

--- a/source/renderer/app/api/ada/newAdaPayment.js
+++ b/source/renderer/app/api/ada/newAdaPayment.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransaction } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type NewAdaPaymentParams = {
   ca: string,
@@ -21,7 +22,7 @@ export const newAdaPayment = (
     hostname: 'localhost',
     method: 'POST',
     path: `/api/txs/payments/${sender}/${receiver}/${amount}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: password }, { groupingPolicy })
 );

--- a/source/renderer/app/api/ada/newAdaWallet.js
+++ b/source/renderer/app/api/ada/newAdaWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet, AdaWalletInitData } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type NewAdaWalletParams = {
   ca: string,
@@ -15,7 +16,7 @@ export const newAdaWallet = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/new',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: password }, walletInitData)
 );

--- a/source/renderer/app/api/ada/newAdaWalletAddress.js
+++ b/source/renderer/app/api/ada/newAdaWalletAddress.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaAddress } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type NewAdaWalletAddressParams = {
   ca: string,
@@ -15,7 +16,7 @@ export const newAdaWalletAddress = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/addresses',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: password }, accountId)
 );

--- a/source/renderer/app/api/ada/nextAdaUpdate.js
+++ b/source/renderer/app/api/ada/nextAdaUpdate.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type NextAdaUpdateParams = {
   ca: string,
@@ -12,7 +13,7 @@ export const nextAdaUpdate = (
     hostname: 'localhost',
     method: 'GET',
     path: '/api/update',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/postponeAdaUpdate.js
+++ b/source/renderer/app/api/ada/postponeAdaUpdate.js
@@ -1,5 +1,6 @@
 // @flow
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type PostponeAdaUpdateParams = {
   ca: string,
@@ -12,7 +13,7 @@ export const postponeAdaUpdate = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/update/postpone',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   })
 );

--- a/source/renderer/app/api/ada/redeemAda.js
+++ b/source/renderer/app/api/ada/redeemAda.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransaction } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type RedeemAdaParams = {
   ca: string,
@@ -18,7 +19,7 @@ export const redeemAda = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/redemptions/ada',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: walletPassword }, walletRedeemData)
 );

--- a/source/renderer/app/api/ada/redeemAdaPaperVend.js
+++ b/source/renderer/app/api/ada/redeemAdaPaperVend.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaTransaction } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type RedeemAdaPaperVendParams = {
   ca: string,
@@ -21,7 +22,7 @@ export const redeemAdaPaperVend = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/papervend/redemptions/ada',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: walletPassword }, redeemPaperVendedData)
 );

--- a/source/renderer/app/api/ada/restoreAdaWallet.js
+++ b/source/renderer/app/api/ada/restoreAdaWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet, AdaWalletInitData } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type RestoreAdaWalletParams = {
   ca: string,
@@ -15,7 +16,7 @@ export const restoreAdaWallet = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/restore',
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, { passphrase: walletPassword }, walletInitData)
 );

--- a/source/renderer/app/api/ada/updateAdaWallet.js
+++ b/source/renderer/app/api/ada/updateAdaWallet.js
@@ -1,6 +1,7 @@
 // @flow
 import type { AdaWallet } from './types';
 import { request } from './lib/request';
+import environment from '../../../../common/environment';
 
 export type UpdateAdaWalletParams = {
   ca: string,
@@ -19,7 +20,7 @@ export const updateAdaWallet = (
     hostname: 'localhost',
     method: 'PUT',
     path: `/api/wallets/${walletId}`,
-    port: 8090,
+    port: environment.WALLET_PORT,
     ca,
   }, {}, walletMeta)
 );

--- a/source/renderer/webpack.config.js
+++ b/source/renderer/webpack.config.js
@@ -90,6 +90,7 @@ module.exports = {
       'process.env.MOBX_DEV_TOOLS': process.env.MOBX_DEV_TOOLS || 0,
       'process.env.BUILD_NUMBER': JSON.stringify(process.env.BUILD_NUMBER || 'dev'),
       'process.env.REPORT_URL': JSON.stringify(reportUrl),
+      'process.env.WALLET_PORT': JSON.stringify(process.env.WALLET_PORT || ''),
     }),
     new AutoDllPlugin({
       filename: 'vendor.dll.js',

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -10,6 +10,13 @@ let
     staging = "testnet";
     testnet = "testnet";
   };
+  # TODO: these hard-coded values will go away when wallet port
+  # selection happens at runtime.
+  walletPortMap = {
+    mainnet = 8090;
+    staging = 8091;
+    testnet = 8092;
+  };
   dotGitExists = builtins.pathExists ./.git;
   isNix2 = 0 <= builtins.compareVersions builtins.nixVersion "1.12";
   canUseFetchGit = dotGitExists && isNix2;
@@ -21,6 +28,7 @@ yarn2nix.mkYarnPackage {
   API_VERSION = apiVersion;
   CI = "nix";
   NETWORK = networkMap.${cluster};
+  WALLET_PORT = walletPortMap.${cluster};
   BUILD_NUMBER = "${toString buildNum}";
   NODE_ENV = "production";
   installPhase = ''


### PR DESCRIPTION
This change will be targeting release/0.11.0 or release/0.11.1.

The `WALLET_PORT` environment variable will be set at webpack build time based on the target network. It is available to use from the `environment.WALLET_PORT` global.

The cardano launcher will use the same port.

This will allow mainnet and testnet builds of Daedalus to run at the same time.