### PR TITLE
[DEVOPS-919] installers: fix missing backend in filenames

### DIFF
--- a/installers/Spec.hs
+++ b/installers/Spec.hs
@@ -130,5 +130,5 @@ utilSpec = do
 
   describe "Package filename generation" $ do
     it "generates a good filename for windows" $ do
-      let f = packageFileName Win64 Mainnet (Version "0.4.2") "test-9.9" (Just "job.id")
-      f `shouldBe` (fromText "daedalus-0.4.2-test-9.9-mainnet-windows-job.id.exe")
+      let f = packageFileName Win64 Mainnet (Version "0.4.2") (Cardano "") "9.9" (Just "job.id")
+      f `shouldBe` (fromText "daedalus-0.4.2-cardano-sl-9.9-mainnet-windows-job.id.exe")

--- a/installers/common/Config.hs
+++ b/installers/common/Config.hs
@@ -73,11 +73,6 @@ optReadLower = opt (diagReadCaseInsensitive . T.unpack)
 argReadLower :: (Bounded a, Enum a, Read a, Show a) => ArgName -> Optional HelpMessage -> Parser a
 argReadLower = arg (diagReadCaseInsensitive . T.unpack)
 
-data Backend
-  = Cardano { cardanoDaedalusBridge :: FilePath }
-  | Mantis
-  deriving (Eq, Show)
-
 data Command
   = GenConfig
     { cfDhallRoot   :: Text

--- a/installers/common/Config.hs
+++ b/installers/common/Config.hs
@@ -24,6 +24,7 @@ module Config
 
 import qualified Control.Exception                as Ex
 
+import           Data.Bool                           (bool)
 import qualified Data.ByteString                  as BS
 import qualified Data.ByteString.Char8            as BS8
 import qualified Data.Map                         as Map
@@ -126,11 +127,11 @@ optionsParser detectedOS = Options
                     <$> switch  "test-installer"      't' "Test installers after building")
 
 backendOptionParser :: Parser Backend
-backendOptionParser = cardano <|> mantis <|> pure (Cardano "")
+backendOptionParser = cardano <|> bool (Cardano "") Mantis <$> enableMantis
   where
     cardano = Cardano <$> optPath "cardano" 'C'
       "Use Cardano backend with given Daedalus bridge path"
-    mantis = switch "mantis" 'M' "Use Mantis (ETC) backend" *> pure Mantis
+    enableMantis = switch "mantis" 'M' "Use Mantis (ETC) backend"
 
 
 

--- a/installers/common/MacInstaller.hs
+++ b/installers/common/MacInstaller.hs
@@ -71,7 +71,7 @@ main opts@Options{..} = do
   makeComponentRoot opts appRoot darwinConfig
   daedalusVer <- getDaedalusVersion "../package.json"
 
-  let pkg = packageFileName Macos64 oCluster daedalusVer ver oBuildJob
+  let pkg = packageFileName Macos64 oCluster daedalusVer oBackend ver oBuildJob
       opkg = oOutputDir </> pkg
 
   tempInstaller <- makeInstaller opts darwinConfig appRoot pkg

--- a/installers/common/Types.hs
+++ b/installers/common/Types.hs
@@ -10,6 +10,7 @@ module Types
   (  -- * Atomic types
     OS(..)
   , Cluster(..)
+  , Backend(..)
   , Config(..), configFilename
   , ConfigRequest(..)
 
@@ -33,7 +34,7 @@ module Types
 where
 
 import           Universum                    hiding (FilePath)
-import           Data.Text                           (toLower)
+import qualified Data.Text                        as T
 import           Data.String                         (IsString)
 import           Filesystem.Path
 import           Filesystem.Path.CurrentOS           (fromText, encodeString)
@@ -56,6 +57,11 @@ data Cluster
   | Staging
   | Testnet
   deriving (Bounded, Enum, Eq, Read, Show)
+
+data Backend
+  = Cardano { cardanoDaedalusBridge :: FilePath }
+  | Mantis
+  deriving (Eq, Show)
 
 data Config
   = Launcher
@@ -86,7 +92,7 @@ testInstaller    False  = DontTestInstaller
 
 
 lshowText :: Show a => a -> Text
-lshowText = toLower . Universum.show
+lshowText = T.toLower . Universum.show
 
 tt :: FilePath -> Text
 tt = format fp
@@ -100,19 +106,23 @@ clusterNetwork Mainnet = "mainnet"
 clusterNetwork Staging = "testnet"
 clusterNetwork Testnet = "testnet"
 
-packageFileName :: OS -> Cluster -> Version -> Text -> Maybe BuildJob -> FilePath
-packageFileName os cluster ver backend build = fromText (mconcat name) <.> ext
+packageFileName :: OS -> Cluster -> Version -> Backend -> Text -> Maybe BuildJob -> FilePath
+packageFileName os cluster ver backend backendVer build = fromText name <.> ext
   where
-    name = ["daedalus-", fromVer ver, "-", backend, "-", lshowText cluster, "-", os', build']
+    name = T.intercalate "-" parts
+    parts = ["daedalus", fromVer ver, backend', backendVer, lshowText cluster, os'] ++ build'
+    backend' = case backend of
+                 Cardano _ -> "cardano-sl"
+                 Mantis    -> "mantis"
     ext = case os of
             Win64   -> "exe"
             Macos64 -> "pkg"
-            Linux64   -> "bin"
+            Linux64 -> "bin"
     os' = case os of
             Win64   -> "windows"
             Macos64 -> "macos"
-            Linux64   -> "linux"
-    build' = maybe "" (("-" <>) . fromBuildJob) build
+            Linux64 -> "linux"
+    build' = maybe [] (\b -> [fromBuildJob b]) build
 
 instance FromJSON Version where
   parseJSON = withObject "Package" $ \o -> Version <$> o .: "version"

--- a/installers/common/Types.hs
+++ b/installers/common/Types.hs
@@ -58,9 +58,10 @@ data Cluster
   | Testnet
   deriving (Bounded, Enum, Eq, Read, Show)
 
+-- | The wallet backend to include in the installer.
 data Backend
-  = Cardano { cardanoDaedalusBridge :: FilePath }
-  | Mantis
+  = Cardano FilePath -- ^ Cardano SL with the given daedalus-bridge.
+  | Mantis           -- ^ Mantis, to be implemented in DEVOPS-533.
   deriving (Eq, Show)
 
 data Config

--- a/installers/common/WindowsInstaller.hs
+++ b/installers/common/WindowsInstaller.hs
@@ -200,13 +200,13 @@ main opts@Options{..}  = do
     printCardanoBuildInfo "."
 
     fullVersion <- getDaedalusVersion "../package.json"
-    cardanoVersion <- getCardanoVersion
+    ver <- getCardanoVersion
 
     echo "Packaging frontend"
-    exportBuildVars opts cardanoVersion
+    exportBuildVars opts ver
     packageFrontend
 
-    let fullName = packageFileName Win64 oCluster fullVersion cardanoVersion oBuildJob
+    let fullName = packageFileName Win64 oCluster fullVersion oBackend ver oBuildJob
 
     printf ("Building: "%fp%"\n") fullName
 


### PR DESCRIPTION
I forgot to update the installer filenames to add the backend name which was removed from the get version function.
