### PR TITLE
[DDW-349] Open About dialog links in a new browser window

### DIFF
--- a/source/renderer/app/components/static/About.js
+++ b/source/renderer/app/components/static/About.js
@@ -62,7 +62,11 @@ const messages = defineMessages({
   },
 });
 
-export default class About extends Component<any> {
+type Props = {
+  onOpenExternalLink: Function,
+};
+
+export default class About extends Component<Props> {
 
   static contextTypes = {
     intl: intlShape.isRequired,
@@ -70,6 +74,7 @@ export default class About extends Component<any> {
 
   render() {
     const { intl } = this.context;
+    const { onOpenExternalLink } = this.props;
     const {
       version, build, os,
       API, API_VERSION, isAdaApi,
@@ -128,12 +133,24 @@ export default class About extends Component<any> {
         </div>
 
         <div className={styles.footerWrapper}>
-          <a href="http://daedaluswallet.io">http://daedaluswallet.io</a>
+          <span
+            onClick={() => onOpenExternalLink('http://daedaluswallet.io')}
+            className={styles.link}
+            role="link"
+            aria-hidden
+          >
+            http://daedaluswallet.io
+          </span>
           <div className={styles.copyright}>
             {intl.formatMessage(messages.aboutCopyright)}&nbsp;
-            <a href="https://github.com/input-output-hk/daedalus/blob/master/LICENSE">
+            <span
+              onClick={() => onOpenExternalLink('https://github.com/input-output-hk/daedalus/blob/master/LICENSE')}
+              className={styles.link}
+              role="link"
+              aria-hidden
+            >
               {intl.formatMessage(messages.licenseLink)}
-            </a>
+            </span>
           </div>
         </div>
 

--- a/source/renderer/app/components/static/About.js
+++ b/source/renderer/app/components/static/About.js
@@ -117,7 +117,6 @@ export default class About extends Component<Props> {
         </div>
 
         <div className={styles.contentText}>
-
           <h2>{intl.formatMessage(messages.aboutContentDaedalusHeadline)}</h2>
 
           <div className={styles.contentDaedalus}>
@@ -129,12 +128,11 @@ export default class About extends Component<Props> {
           <div className={styles.apiMembers}>
             {apiMembers}
           </div>
-
         </div>
 
         <div className={styles.footerWrapper}>
           <span
-            onClick={() => onOpenExternalLink('http://daedaluswallet.io')}
+            onClick={() => onOpenExternalLink('https://daedaluswallet.io')}
             className={styles.link}
             role="link"
             aria-hidden

--- a/source/renderer/app/components/static/About.scss
+++ b/source/renderer/app/components/static/About.scss
@@ -96,12 +96,17 @@
   .footerWrapper {
     margin-top: 20px;
 
-    a,
+    .link,
     .copyright {
       color: var(--theme-about-window-copyright-color);
       font-family: var(--font-regular);
       font-size: 12px;
       line-height: 1.25;
+    }
+
+    .link {
+      cursor: pointer;
+      text-decoration: underline;
     }
 
     .copyright {

--- a/source/renderer/app/containers/static/AboutDialog.js
+++ b/source/renderer/app/containers/static/AboutDialog.js
@@ -15,7 +15,6 @@ export default class AboutDialog extends Component<Props> {
   static defaultProps = { actions: null, stores: null };
 
   render() {
-
     const { app } = this.props.stores;
     const { openExternalLink } = app;
 
@@ -28,9 +27,7 @@ export default class AboutDialog extends Component<Props> {
         overlayClassName={styles.overlay}
         ariaHideApp={false}
       >
-        <About
-          onOpenExternalLink={openExternalLink}
-        />
+        <About onOpenExternalLink={openExternalLink} />
       </ReactModal>
     );
   }

--- a/source/renderer/app/containers/static/AboutDialog.js
+++ b/source/renderer/app/containers/static/AboutDialog.js
@@ -15,6 +15,10 @@ export default class AboutDialog extends Component<Props> {
   static defaultProps = { actions: null, stores: null };
 
   render() {
+
+    const { app } = this.props.stores;
+    const { openExternalLink } = app;
+
     return (
       <ReactModal
         isOpen
@@ -24,7 +28,9 @@ export default class AboutDialog extends Component<Props> {
         overlayClassName={styles.overlay}
         ariaHideApp={false}
       >
-        <About />
+        <About
+          onOpenExternalLink={openExternalLink}
+        />
       </ReactModal>
     );
   }


### PR DESCRIPTION
This PR fixes the links in the About dialog. Currently, they get open in the Daedalus window and thus prevents the user from using Daedalus once they are open (no way back).

## Todo:

- [x] Change the links to the `openExternalLink` function
- [x] Style the `span` tag properly

## Screenshots:

![image](https://user-images.githubusercontent.com/1504716/42449491-3e76b4b8-8357-11e8-8720-e5479c1b4a35.png)


---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
