### PR TITLE
[DEVOPS-944] Bump cardano-sl to latest release/1.3.0

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "f7b6661121f1eead48043d99b9081d5ab52ff519",
-  "sha256": "1ccr3qhrvsbyjgd6pvw38vcb2dasvz577jqcw93939jz22g21j6p",
-  "fetchSubmodules": true
+  "rev": "8c75738ebb48c069e950ebafdb3cbebc753f6994",
+  "sha256": "0n0qm6iszsz36sg1b28ni81qydb51mj0gq8h355b90yr873bpwlm",
+  "fetchSubmodules": "true"
 }


### PR DESCRIPTION
This brings Daedalus up to date with cardano-sl 1.3.0 after input-output-hk/cardano-sl#3235 and input-output-hk/cardano-sl#3242. These are fixes to block streaming and don't really affect the wallet.
