### PR TITLE
[DDW-369] Disable nodeLogPath in dhall files

### DIFF
--- a/installers/dhall/linux64.dhall
+++ b/installers/dhall/linux64.dhall
@@ -19,8 +19,7 @@ in
   , nodePath            = "cardano-node"
   , nodeDbPath          = "${dataDir}/DB/"
   , nodeLogConfig       = "\${DAEDALUS_CONFIG}/daedalus.yaml"
-  , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"
-
+  , nodeLogPath         = [] : Optional Text
   , walletPath          = "daedalus-frontend"
   , walletLogging       = False
   , frontendOnlyMode    = False

--- a/installers/dhall/macos64.dhall
+++ b/installers/dhall/macos64.dhall
@@ -21,7 +21,7 @@ in
   , nodePath            = "./cardano-node"
   , nodeDbPath          = "${dataDir}/DB-1.0"
   , nodeLogConfig       = "log-config-prod.yaml"
-  , nodeLogPath         = "${dataDir}/Logs/cardano-node.log"
+  , nodeLogPath         = [] : Optional Text
 
   , walletPath          = "./Frontend"
   , walletLogging       = True

--- a/installers/dhall/os.type
+++ b/installers/dhall/os.type
@@ -16,7 +16,7 @@
   , nodePath            : Text
   , nodeDbPath          : Text
   , nodeLogConfig       : Text
-  , nodeLogPath         : Text
+  , nodeLogPath         : Optional Text
   , walletPath          : Text
   , walletLogging       : Bool
   , frontendOnlyMode    : Bool

--- a/installers/dhall/win64.dhall
+++ b/installers/dhall/win64.dhall
@@ -22,7 +22,7 @@ in
   , nodePath            = "\${DAEDALUS_DIR}\\cardano-node.exe"
   , nodeDbPath          = "${dataDir}\\DB-1.0"
   , nodeLogConfig       = "log-config-prod.yaml"
-  , nodeLogPath         = "${dataDir}\\Logs\\cardano-node.log"
+  , nodeLogPath         = [] : Optional Text
 
   , walletPath          = "\${DAEDALUS_DIR}\\Daedalus.exe"
   , walletLogging       = True


### PR DESCRIPTION
This PR makes the nodelLogPath entry in launcher-config.yaml optional , this will have the effect of disabling logging to cardano-node.log which was deamed to be causing a performance issue


### Testing
- [x]  Installer from this PR to be tested 
- [x]  Should start up on all platforms
- [x]  Do a restore on a MacOS vm to verfiy performance fix
- [x]  Check pub logging is still working

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move DDW-369 ticket to `done` on the Youtrack board
