### PR TITLE
[DEVOPS-922] Choose backend ports for staging and testnet which don't conflict

### DIFF
--- a/installers/Spec.hs
+++ b/installers/Spec.hs
@@ -91,7 +91,7 @@ configSpec = do
       walletPort mainnetCfg `shouldBe` 8090
     it "gets the right testnet port" $ do
       stagingCfg <- getInstallerConfig "./dhall" Win64 Testnet
-      walletPort stagingCfg `shouldBe` 8092
+      walletPort stagingCfg `shouldBe` 8094
 
 
 deleteSpec :: Spec

--- a/installers/dhall/staging.dhall
+++ b/installers/dhall/staging.dhall
@@ -5,5 +5,5 @@
 , reportServer = "http://staging-report-server.awstest.iohkdev.io:8080"
 , installDirectorySuffix = " Staging"
 , macPackageSuffix       = "Staging"
-, walletPort             = 8091
+, walletPort             = 8092
 }

--- a/installers/dhall/testnet.dhall
+++ b/installers/dhall/testnet.dhall
@@ -5,5 +5,5 @@
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = " Testnet"
 , macPackageSuffix       = "Testnet"
-, walletPort             = 8092
+, walletPort             = 8094
 }

--- a/installers/dhall/testnet.dhall
+++ b/installers/dhall/testnet.dhall
@@ -1,7 +1,7 @@
 { name         = "testnet"
 , keyPrefix    = "testnet_wallet"
 , relays       = "relays.cardano-testnet.iohkdev.io"
-, updateServer = "https://update-cardano-mainnet.iohk.io"
+, updateServer = "http://updates-cardano-testnet.s3.amazonaws.com"
 , reportServer = "http://report-server.cardano-mainnet.iohk.io:8080"
 , installDirectorySuffix = " Testnet"
 , macPackageSuffix       = "Testnet"

--- a/yarn2nix.nix
+++ b/yarn2nix.nix
@@ -9,8 +9,8 @@ let
   # selection happens at runtime.
   walletPortMap = {
     mainnet = 8090;
-    staging = 8091;
-    testnet = 8092;
+    staging = 8092;
+    testnet = 8094;
   };
   dotGitExists = builtins.pathExists ./.git;
   isNix2 = 0 <= builtins.compareVersions builtins.nixVersion "1.12";


### PR DESCRIPTION
Ports for cardano-node backend:
- 8090 - mainnet
- 8092 - staging
- 8094 - testnet
- 8091 - api docs server

Next version will have dynamic ports.
