### PR TITLE
[DEVOPS-398] Update to cardano-sl 1.3.1

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "6fa649355d93a1ebfaace3edbbfc54a7304ce5ff",
-  "sha256": "0xp6fl0pfcdvi54j3nvp5jp8q4q8vwr68zf4h6m1g755i9malbz1",
+  "rev": "061980e11a9ec65caaedbe43dd5aa647f2d5205a",
+  "sha256": "0y17zi02mr3qk4xmkz1p1gzvv0zcixzmqns1dxn5xqlb00wfac45",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Cardano SL 1.3.1 will have configuration and genesis data for the public testnet.

~Once input-output-hk/cardano-sl#3265 is merged then the cardano-sl rev can be updated again to latest `release/1.3.1` and this can be merged.~ Cardano SL release/1.3.1 is ready to go.

The installers built in CI from this PR should be able to connect to the public testnet.

Then you can get Testnet Ada from http://cardano-faucet.cardano-testnet.iohkdev.io/

It should be possible to install and run mainnet and testnet Daedalus simultaneously, and the testnet version should be clearly marked as such.

## Installers (are building)
 - [daedalus-0.11.1-cardano-sl-1.3.1-testnet-windows-9114.exe](https://appveyor-ci-deploy.s3-ap-northeast-1.amazonaws.com/installers/daedalus-0.11.1-cardano-sl-1.3.1-testnet-windows-9114.exe)
 - [daedalus-0.11.1-cardano-sl-1.3.1-testnet-macos-2824.pkg](https://ci-output-sink.s3.amazonaws.com/csl-daedalus/daedalus-0.11.1-cardano-sl-1.3.1-testnet-macos-2824.pkg)
 - [daedalus-0.11.1-cardano-sl-1.3.1-testnet-x86_64-linux-2824.bin](https://ci-output-sink.s3.amazonaws.com/csl-daedalus/daedalus-0.11.1-cardano-sl-1.3.1-testnet-x86_64-linux-2824.bin)
