### PR TITLE
[DEVOPS-1020] add logs in dev mode and nix improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Logs
 logs
+Logs
 *.log*
 
 # Runtime data

--- a/shell.nix
+++ b/shell.nix
@@ -6,15 +6,36 @@ in
 , pkgs ? (import (localLib.fetchNixPkgs) { inherit system config; })
 }:
 
-with pkgs;
+let
+  daedalusShell = pkgs.stdenv.mkDerivation {
+    name = "daedalus";
+    passthru = { inherit daedalus; };
 
-stdenv.mkDerivation {
-  name = "daedalus";
-
-  buildInputs = [
-    nix bash binutils coreutils curl gnutar
-    git python27 curl electron nodejs-8_x
-    nodePackages.node-gyp nodePackages.node-pre-gyp
-    gnumake yarn
-  ];
-}
+    buildInputs = with pkgs; [
+      nix bash binutils coreutils curl gnutar
+      git python27 curl electron nodejs-8_x
+      nodePackages.node-gyp nodePackages.node-pre-gyp
+      gnumake yarn
+    ];
+    shellHook = ''
+      yarn install
+      ln -svf ${pkgs.electron}/bin/electron ./node_modules/electron/dist/electron
+      echo "Instructions:"
+      echo "In cardano repo run scripts/launch/demo-nix.sh"
+      echo "export CARDANO_TLS_PATH=/path/to/cardano-sl/state-demo/tls/client"
+      echo "yarn dev"
+    '';
+  };
+  daedalus = daedalusShell.overrideAttrs (oldAttrs: {
+    shellHook = ''
+       if [ ! -f "$CARDANO_TLS_PATH/ca.crt" ]
+       then
+         echo "CARDANO_TLS_PATH must be set"
+         exit 1
+       fi
+      ${oldAttrs.shellHook}
+      yarn dev
+      exit 0
+    '';
+  });
+in daedalusShell

--- a/source/main/utils/getRuntimeFolderPath.js
+++ b/source/main/utils/getRuntimeFolderPath.js
@@ -1,6 +1,10 @@
 import path from 'path';
 
+const isProd = process.env.NODE_ENV === 'production';
 export default (platform, env, appName) => {
+  if (!isProd) {
+    return "./";
+  }
   switch (platform) {
     case 'darwin': {
       return path.join(env.HOME, 'Library', 'Application Support', appName);

--- a/source/main/utils/getRuntimeFolderPath.js
+++ b/source/main/utils/getRuntimeFolderPath.js
@@ -1,10 +1,12 @@
 import path from 'path';
 
 const isProd = process.env.NODE_ENV === 'production';
+
 export default (platform, env, appName) => {
   if (!isProd) {
-    return "./";
+    return './';
   }
+
   switch (platform) {
     case 'darwin': {
       return path.join(env.HOME, 'Library', 'Application Support', appName);


### PR DESCRIPTION
These are some basic changes to help QA with running daedalus with a demo cluster.

Overrides runTimePath to "./" when ran with `yarn dev` so logs are written to `Logs/pub/Daedalus.log` in current directory.
Improves nix shell code to give instructions on how to use.
Minor refactor to support multiple derivations in `shell.nix` using `passthru`.