### PR TITLE
[DDW-400] Dynamic Api port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 - Integrates the latest features from the develop branch of react-polymorph. Features include: render props architecture, theme composition, and a ThemeProvider HOC. [PR 950](https://github.com/input-output-hk/daedalus/pull/950)
 - Fixed broken storybook [PR 1041](https://github.com/input-output-hk/daedalus/pull/1041)
+- Make port and ca of ada api configurable during runtime [PR 1067](https://github.com/input-output-hk/daedalus/pull/1067)
 
 ### Features
 

--- a/source/renderer/app/api/ada/adaTestReset.js
+++ b/source/renderer/app/api/ada/adaTestReset.js
@@ -1,19 +1,15 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type AdaTestResetParams = {
-  ca: string,
-};
+import type { RequestConfig } from './types';
 
 export const adaTestReset = (
-  { ca }: AdaTestResetParams
+  config: RequestConfig
 ): Promise<void> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/test/reset',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/adaTxFee.js
+++ b/source/renderer/app/api/ada/adaTxFee.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransactionFee } from './types';
+import type { AdaTransactionFee, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type AdaTxFeeParams = {
-  ca: string,
   sender: string,
   receiver: string,
   amount: string,
@@ -14,13 +12,14 @@ export type AdaTxFeeParams = {
 };
 
 export const adaTxFee = (
-  { ca, sender, receiver, amount, groupingPolicy }: AdaTxFeeParams
+  config: RequestConfig,
+  { sender, receiver, amount, groupingPolicy }: AdaTxFeeParams
 ): Promise<AdaTransactionFee> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: `/api/txs/fee/${sender}/${receiver}/${amount}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, {}, { groupingPolicy })
 );

--- a/source/renderer/app/api/ada/applyAdaUpdate.js
+++ b/source/renderer/app/api/ada/applyAdaUpdate.js
@@ -1,19 +1,15 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type ApplyAdaUpdateParams = {
-  ca: string,
-};
+import type { RequestConfig } from './types';
 
 export const applyAdaUpdate = (
-  { ca }: ApplyAdaUpdateParams
+  config: RequestConfig,
 ): Promise<any> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/update/apply',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/changeAdaWalletPassphrase.js
+++ b/source/renderer/app/api/ada/changeAdaWalletPassphrase.js
@@ -1,18 +1,17 @@
 // @flow
-import type { AdaWallet } from './types';
+import type { AdaWallet, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 import { encryptPassphrase } from './lib/encryptPassphrase';
 
 export type ChangeAdaWalletPassphraseParams = {
-  ca: string,
   walletId: string,
   oldPassword: ?string,
   newPassword: ?string,
 };
 
 export const changeAdaWalletPassphrase = (
-  { ca, walletId, oldPassword, newPassword }: ChangeAdaWalletPassphraseParams
+  config: RequestConfig,
+  { walletId, oldPassword, newPassword }: ChangeAdaWalletPassphraseParams
 ): Promise<AdaWallet> => {
   const encryptedOldPassphrase = oldPassword ? encryptPassphrase(oldPassword) : null;
   const encryptedNewPassphrase = newPassword ? encryptPassphrase(newPassword) : null;
@@ -20,7 +19,7 @@ export const changeAdaWalletPassphrase = (
     hostname: 'localhost',
     method: 'POST',
     path: `/api/wallets/password/${walletId}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { old: encryptedOldPassphrase, new: encryptedNewPassphrase });
 };

--- a/source/renderer/app/api/ada/deleteAdaWallet.js
+++ b/source/renderer/app/api/ada/deleteAdaWallet.js
@@ -1,20 +1,20 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
+import type { RequestConfig } from './types';
 
 export type DeleteAdaWalletParams = {
-  ca: string,
   walletId: string,
 };
 
 export const deleteAdaWallet = (
-  { ca, walletId }: DeleteAdaWalletParams
+  config: RequestConfig,
+  { walletId }: DeleteAdaWalletParams
 ): Promise<[]> => (
   request({
     hostname: 'localhost',
     method: 'DELETE',
     path: `/api/wallets/${walletId}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/exportAdaBackupJSON.js
+++ b/source/renderer/app/api/ada/exportAdaBackupJSON.js
@@ -1,21 +1,21 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
+import type { RequestConfig } from './types';
 
 export type ExportAdaBackupJSONParams = {
-  ca: string,
   walletId: string,
   filePath: string,
 };
 
 export const exportAdaBackupJSON = (
-  { ca, walletId, filePath }: ExportAdaBackupJSONParams,
+  config: RequestConfig,
+  { walletId, filePath }: ExportAdaBackupJSONParams,
 ): Promise<[]> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: `/api/backup/export/${walletId}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, {}, filePath)
 );

--- a/source/renderer/app/api/ada/getAdaAccounts.js
+++ b/source/renderer/app/api/ada/getAdaAccounts.js
@@ -1,20 +1,19 @@
 // @flow
-import type { AdaAccounts } from './types';
+import type { AdaAccounts, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type GetAdaAccountsParams = {
-  ca: string,
+  ca: Uint8Array,
 };
 
 export const getAdaAccounts = (
-  { ca }: GetAdaAccountsParams
+  config: RequestConfig
 ): Promise<AdaAccounts> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/accounts',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaAddressHistory.js
+++ b/source/renderer/app/api/ada/getAdaAddressHistory.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransactions } from './types';
+import type { AdaTransactions, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type GetAdaAddressHistoryParams = {
-  ca: string,
   accountId: string,
   address: string,
   skip: number,
@@ -12,13 +10,14 @@ export type GetAdaAddressHistoryParams = {
 };
 
 export const getAdaAddressHistory = (
-  { ca, accountId, address, skip, limit }: GetAdaAddressHistoryParams
+  config: RequestConfig,
+  { accountId, address, skip, limit }: GetAdaAddressHistoryParams
 ): Promise<AdaTransactions> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { accountId, address, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistory.js
+++ b/source/renderer/app/api/ada/getAdaHistory.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransactions } from './types';
+import type { AdaTransactions, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type GetAdaHistoryParams = {
-  ca: string,
   walletId: ?string,
   accountId: ?string,
   address: ?string,
@@ -13,13 +11,14 @@ export type GetAdaHistoryParams = {
 };
 
 export const getAdaHistory = (
-  { ca, walletId, accountId, address, skip, limit }: GetAdaHistoryParams
+  config: RequestConfig,
+  { walletId, accountId, address, skip, limit }: GetAdaHistoryParams
 ): Promise<AdaTransactions> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { walletId, accountId, address, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistoryByAccount.js
+++ b/source/renderer/app/api/ada/getAdaHistoryByAccount.js
@@ -1,23 +1,22 @@
 // @flow
-import type { AdaTransactions } from './types';
+import type { AdaTransactions, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type GetAdaHistoryByAccountParams = {
-  ca: string,
   accountId: string,
   skip: number,
   limit: number,
 };
 
 export const getAdaHistoryByAccount = (
-  { ca, accountId, skip, limit }: GetAdaHistoryByAccountParams
+  config: RequestConfig,
+  { accountId, skip, limit }: GetAdaHistoryByAccountParams
 ): Promise<AdaTransactions> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { accountId, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaHistoryByWallet.js
+++ b/source/renderer/app/api/ada/getAdaHistoryByWallet.js
@@ -1,23 +1,22 @@
 // @flow
-import type { AdaTransactions } from './types';
+import type { AdaTransactions, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type GetAdaHistoryByWalletParams = {
-  ca: string,
   walletId: string,
   skip: number,
   limit: number,
 };
 
 export const getAdaHistoryByWallet = (
-  { ca, walletId, skip, limit }: GetAdaHistoryByWalletParams
+  config: RequestConfig,
+  { walletId, skip, limit }: GetAdaHistoryByWalletParams
 ): Promise<AdaTransactions> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/txs/histories',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { walletId, skip, limit })
 );

--- a/source/renderer/app/api/ada/getAdaLocalTimeDifference.js
+++ b/source/renderer/app/api/ada/getAdaLocalTimeDifference.js
@@ -1,20 +1,15 @@
 // @flow
-import type { AdaLocalTimeDifference } from './types';
+import type { AdaLocalTimeDifference, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type GetAdaLocalTimeDifferenceParams = {
-  ca: string,
-};
 
 export const getAdaLocalTimeDifference = (
-  { ca }: GetAdaLocalTimeDifferenceParams
+  config: RequestConfig
 ): Promise<AdaLocalTimeDifference> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/settings/time/difference',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaSyncProgress.js
+++ b/source/renderer/app/api/ada/getAdaSyncProgress.js
@@ -1,20 +1,15 @@
 // @flow
-import type { AdaSyncProgressResponse } from './types';
+import type { AdaSyncProgressResponse, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type GetAdaSyncProgressParams = {
-  ca: string,
-};
 
 export const getAdaSyncProgress = (
-  { ca }: GetAdaSyncProgressParams
+  config: RequestConfig,
 ): Promise<AdaSyncProgressResponse> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/settings/sync/progress',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/getAdaWalletAccounts.js
+++ b/source/renderer/app/api/ada/getAdaWalletAccounts.js
@@ -1,22 +1,20 @@
 // @flow
-import type { AdaAccounts } from './types';
+import type { AdaAccounts, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
 
 export type GetAdaWalletAccountsParams = {
-  ca: string,
   walletId: string,
 };
 
 export const getAdaWalletAccounts = (
-  { ca, walletId }: GetAdaWalletAccountsParams
+  config: RequestConfig,
+  { walletId }: GetAdaWalletAccountsParams
 ): Promise<AdaAccounts> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/accounts',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { accountId: walletId })
 );

--- a/source/renderer/app/api/ada/getAdaWallets.js
+++ b/source/renderer/app/api/ada/getAdaWallets.js
@@ -1,23 +1,17 @@
 // @flow
-import type { AdaV1Wallets } from './types';
+import type { AdaV1Wallets, RequestConfig } from './types';
 import { request } from './lib/v1/request';
 import { MAX_ADA_WALLETS_COUNT } from '../../config/numbersConfig';
-import environment from '../../../../common/environment';
-
-
-export type GetAdaWalletParams = {
-  ca: string,
-};
 
 export const getAdaWallets = (
-  { ca }: GetAdaWalletParams
+  config: RequestConfig
 ): Promise<AdaV1Wallets> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/v1/wallets',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, {
     per_page: MAX_ADA_WALLETS_COUNT, // 50 is the max per_page value
     sort_by: 'ASC[created_at]',

--- a/source/renderer/app/api/ada/importAdaBackupJSON.js
+++ b/source/renderer/app/api/ada/importAdaBackupJSON.js
@@ -1,21 +1,20 @@
 // @flow
-import type { AdaWallet } from './types';
+import type { AdaWallet, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type ImportAdaBackupJSONParams = {
-  ca: string,
   filePath: string,
 };
 
 export const importAdaBackupJSON = (
-  { ca, filePath }: ImportAdaBackupJSONParams,
+  config: RequestConfig,
+  { filePath }: ImportAdaBackupJSONParams,
 ): Promise<AdaWallet> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/backup/import',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, {}, filePath)
 );

--- a/source/renderer/app/api/ada/importAdaWallet.js
+++ b/source/renderer/app/api/ada/importAdaWallet.js
@@ -1,22 +1,21 @@
 // @flow
-import type { AdaWallet } from './types';
+import type { AdaWallet, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type ImportAdaWalletParams = {
-  ca: string,
   filePath: string,
   walletPassword: ?string,
 };
 
 export const importAdaWallet = (
-  { ca, walletPassword, filePath }: ImportAdaWalletParams
+  config: RequestConfig,
+  { walletPassword, filePath }: ImportAdaWalletParams
 ): Promise<AdaWallet> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/keys',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: walletPassword }, filePath)
 );

--- a/source/renderer/app/api/ada/index.js
+++ b/source/renderer/app/api/ada/index.js
@@ -394,9 +394,9 @@ export default class AdaApi {
     }
   };
 
-  isValidAddress = (address: string): Promise<boolean> => {
-    return isValidAdaAddress(this.config, { address });
-  };
+  isValidAddress = (address: string): Promise<boolean> => (
+    isValidAdaAddress(this.config, { address })
+  );
 
   isValidMnemonic(mnemonic: string): Promise<boolean> {
     return isValidMnemonic(mnemonic, WALLET_RECOVERY_PHRASE_WORD_COUNT);

--- a/source/renderer/app/api/ada/isValidAdaAddress.js
+++ b/source/renderer/app/api/ada/isValidAdaAddress.js
@@ -1,21 +1,21 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
+import type { RequestConfig } from './types';
 
 export type IsValidAdaAddressParams = {
-  ca: string,
   address: string,
 };
 
 export const isValidAdaAddress = (
-  { ca, address }: IsValidAdaAddressParams
+  config: RequestConfig,
+  { address }: IsValidAdaAddressParams
 ): Promise<boolean> => {
   const encodedAddress = encodeURIComponent(address);
   return request({
     hostname: 'localhost',
     method: 'GET',
     path: `/api/addresses/${encodedAddress}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   });
 };

--- a/source/renderer/app/api/ada/lib/request.js
+++ b/source/renderer/app/api/ada/lib/request.js
@@ -10,7 +10,7 @@ export type RequestOptions = {
   method: string,
   path: string,
   port: number,
-  ca: string,
+  ca: Uint8Array,
   headers?: {
     'Content-Type': string,
     'Content-Length': number,

--- a/source/renderer/app/api/ada/lib/v1/request.js
+++ b/source/renderer/app/api/ada/lib/v1/request.js
@@ -10,7 +10,7 @@ export type RequestOptions = {
   method: string,
   path: string,
   port: number,
-  ca: string,
+  ca: Uint8Array,
   headers?: {
     'Content-Type': string,
     'Content-Length': number,

--- a/source/renderer/app/api/ada/newAdaAccount.js
+++ b/source/renderer/app/api/ada/newAdaAccount.js
@@ -1,7 +1,6 @@
 // @flow
-import type { AdaAccount } from './types';
+import type { AdaAccount, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type NewAdaAccountQueryParams = {
   passphrase: ?string,
@@ -17,7 +16,7 @@ export type NewAdaAccountRawBodyParams = {
 };
 
 export const newAdaAccount = (
-  ca: string,
+  config: RequestConfig,
   pathParams: {},
   queryParams: NewAdaAccountQueryParams,
   rawBodyParams: NewAdaAccountRawBodyParams,
@@ -27,7 +26,7 @@ export const newAdaAccount = (
     hostname: 'localhost',
     method: 'POST',
     path: '/api/accounts',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, queryParams, accountInitData);
 };

--- a/source/renderer/app/api/ada/newAdaPayment.js
+++ b/source/renderer/app/api/ada/newAdaPayment.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransaction } from './types';
+import type { AdaTransaction, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type NewAdaPaymentParams = {
-  ca: string,
   sender: string,
   receiver: string,
   amount: string,
@@ -16,13 +14,14 @@ export type NewAdaPaymentParams = {
 
 
 export const newAdaPayment = (
-  { ca, sender, receiver, amount, groupingPolicy, password }: NewAdaPaymentParams
+  config: RequestConfig,
+  { sender, receiver, amount, groupingPolicy, password }: NewAdaPaymentParams
 ): Promise<AdaTransaction> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: `/api/txs/payments/${sender}/${receiver}/${amount}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: password }, { groupingPolicy })
 );

--- a/source/renderer/app/api/ada/newAdaWallet.js
+++ b/source/renderer/app/api/ada/newAdaWallet.js
@@ -1,22 +1,21 @@
 // @flow
-import type { AdaWallet, AdaWalletInitData } from './types';
+import type { AdaWallet, AdaWalletInitData, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type NewAdaWalletParams = {
-  ca: string,
   password: ?string,
   walletInitData: AdaWalletInitData
 };
 
 export const newAdaWallet = (
-  { ca, password, walletInitData }: NewAdaWalletParams
+  config: RequestConfig,
+  { password, walletInitData }: NewAdaWalletParams
 ): Promise<AdaWallet> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/new',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: password }, walletInitData)
 );

--- a/source/renderer/app/api/ada/newAdaWalletAddress.js
+++ b/source/renderer/app/api/ada/newAdaWalletAddress.js
@@ -1,23 +1,22 @@
 // @flow
-import type { AdaAddress } from './types';
+import type { AdaAddress, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type NewAdaWalletAddressParams = {
-  ca: string,
   password: ?string,
   accountId: string,
 };
 
 export const newAdaWalletAddress = (
-  { ca, password, accountId }: NewAdaWalletAddressParams
+  config: RequestConfig,
+  { password, accountId }: NewAdaWalletAddressParams
 ): Promise<AdaAddress> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/addresses',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: password }, accountId)
 );
 

--- a/source/renderer/app/api/ada/nextAdaUpdate.js
+++ b/source/renderer/app/api/ada/nextAdaUpdate.js
@@ -1,19 +1,15 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type NextAdaUpdateParams = {
-  ca: string,
-};
+import type { RequestConfig } from './types';
 
 export const nextAdaUpdate = (
-  { ca }: NextAdaUpdateParams
+  config: RequestConfig,
 ): Promise<any> => (
   request({
     hostname: 'localhost',
     method: 'GET',
     path: '/api/update',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/postponeAdaUpdate.js
+++ b/source/renderer/app/api/ada/postponeAdaUpdate.js
@@ -1,19 +1,15 @@
 // @flow
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
-
-export type PostponeAdaUpdateParams = {
-  ca: string,
-};
+import type { RequestConfig } from './types';
 
 export const postponeAdaUpdate = (
-  { ca }: PostponeAdaUpdateParams
+  config: RequestConfig
 ): Promise<any> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/update/postpone',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   })
 );

--- a/source/renderer/app/api/ada/redeemAda.js
+++ b/source/renderer/app/api/ada/redeemAda.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransaction } from './types';
+import type { AdaTransaction, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type RedeemAdaParams = {
-  ca: string,
   walletPassword: ?string,
   walletRedeemData: {
     crWalletId: string,
@@ -13,13 +11,14 @@ export type RedeemAdaParams = {
 };
 
 export const redeemAda = (
-  { ca, walletPassword, walletRedeemData }: RedeemAdaParams
+  config: RequestConfig,
+  { walletPassword, walletRedeemData }: RedeemAdaParams
 ): Promise<AdaTransaction> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/redemptions/ada',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: walletPassword }, walletRedeemData)
 );

--- a/source/renderer/app/api/ada/redeemAdaPaperVend.js
+++ b/source/renderer/app/api/ada/redeemAdaPaperVend.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaTransaction } from './types';
+import type { AdaTransaction, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type RedeemAdaPaperVendParams = {
-  ca: string,
   walletPassword: ?string,
   redeemPaperVendedData: {
     pvWalletId: string,
@@ -16,13 +14,14 @@ export type RedeemAdaPaperVendParams = {
 };
 
 export const redeemAdaPaperVend = (
-  { ca, walletPassword, redeemPaperVendedData }: RedeemAdaPaperVendParams
+  config: RequestConfig,
+  { walletPassword, redeemPaperVendedData }: RedeemAdaPaperVendParams
 ): Promise<AdaTransaction> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/papervend/redemptions/ada',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: walletPassword }, redeemPaperVendedData)
 );

--- a/source/renderer/app/api/ada/restoreAdaWallet.js
+++ b/source/renderer/app/api/ada/restoreAdaWallet.js
@@ -1,23 +1,22 @@
 // @flow
-import type { AdaWallet, AdaWalletInitData } from './types';
+import type { AdaWallet, AdaWalletInitData, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type RestoreAdaWalletParams = {
-  ca: string,
   walletPassword: ?string,
   walletInitData: AdaWalletInitData
 };
 
 export const restoreAdaWallet = (
-  { ca, walletPassword, walletInitData }: RestoreAdaWalletParams
+  config: RequestConfig,
+  { walletPassword, walletInitData }: RestoreAdaWalletParams
 ): Promise<AdaWallet> => (
   request({
     hostname: 'localhost',
     method: 'POST',
     path: '/api/wallets/restore',
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, { passphrase: walletPassword }, walletInitData)
 );
 

--- a/source/renderer/app/api/ada/types.js
+++ b/source/renderer/app/api/ada/types.js
@@ -1,5 +1,11 @@
 // @flow
 
+// ========= General Types ==========
+export type RequestConfig = {
+  port: number,
+  ca: Uint8Array,
+};
+
 // ========= Response Types =========
 export type AdaAssurance = 'CWANormal' | 'CWAStrict';
 export type AdaTransactionCondition = 'CPtxApplying' | 'CPtxInBlocks' | 'CPtxWontApply' | 'CPtxNotTracked';

--- a/source/renderer/app/api/ada/updateAdaWallet.js
+++ b/source/renderer/app/api/ada/updateAdaWallet.js
@@ -1,10 +1,8 @@
 // @flow
-import type { AdaWallet } from './types';
+import type { AdaWallet, RequestConfig } from './types';
 import { request } from './lib/request';
-import environment from '../../../../common/environment';
 
 export type UpdateAdaWalletParams = {
-  ca: string,
   walletId: string,
   walletMeta: {
     cwName: string,
@@ -14,13 +12,14 @@ export type UpdateAdaWalletParams = {
 };
 
 export const updateAdaWallet = (
-  { ca, walletId, walletMeta }: UpdateAdaWalletParams
+  config: RequestConfig,
+  { walletId, walletMeta }: UpdateAdaWalletParams
 ): Promise<AdaWallet> => (
   request({
     hostname: 'localhost',
     method: 'PUT',
     path: `/api/wallets/${walletId}`,
-    port: environment.WALLET_PORT,
-    ca,
+    port: config.port,
+    ca: config.ca,
   }, {}, walletMeta)
 );

--- a/source/renderer/app/api/index.js
+++ b/source/renderer/app/api/index.js
@@ -1,7 +1,9 @@
 // @flow
+import { remote } from 'electron';
 import AdaApi from './ada/index';
 import EtcApi from './etc/index';
 import LocalStorageApi from './localStorage/index';
+import environment from '../../../common/environment';
 
 export type Api = {
   ada: AdaApi,
@@ -10,7 +12,7 @@ export type Api = {
 };
 
 export const setupApi = (): Api => ({
-  ada: new AdaApi(),
+  ada: new AdaApi(environment.isTest(), environment.WALLET_PORT, remote.getGlobal('ca')),
   etc: new EtcApi(),
   localStorage: new LocalStorageApi(),
 });

--- a/source/renderer/app/api/index.js
+++ b/source/renderer/app/api/index.js
@@ -12,7 +12,10 @@ export type Api = {
 };
 
 export const setupApi = (): Api => ({
-  ada: new AdaApi(environment.isTest(), environment.WALLET_PORT, remote.getGlobal('ca')),
+  ada: new AdaApi(environment.isTest(), {
+    port: environment.WALLET_PORT,
+    ca: remote.getGlobal('ca'),
+  }),
   etc: new EtcApi(),
   localStorage: new LocalStorageApi(),
 });


### PR DESCRIPTION
This PR makes the ada api configurable which is a requirement for the upcoming features for controlling the backend node from within Daedalus (hence having to dynamically change port / certs while running).

The general idea is to move any configurable values out of the api class and pass it in as params / provide a config setter to update the values during runtime. Another benefit of this refactoring is the separation of config params (e.g: port / ca) vs. request params for the specific api call … which makes more sense than to include `ca` in all request types.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
