### PR TITLE
[DDW-425] add env var to keep deadalus alive after tests

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -5,20 +5,32 @@
 # Running Daedalus acceptance tests
 
 
-1. Make sure you have the correct node/npm versions installed on your machine (node v8.x and npm v5.x)
-2. Clone Daedalus repository to your machine (`git clone git@github.com:input-output-hk/daedalus.git` - use **master** branch)
-3. Install npm dependencies from within Daedalus directory:
+1. Make sure you have node and yarn installed on your machine
+2. Clone Daedalus repository to your machine (`git clone git@github.com:input-output-hk/daedalus.git`)
+3. Install dependencies from within Daedalus directory:
 
 ```bash
 $ cd daedalus/
 $ yarn install
 ```
+
 4. Build and run the backend (Cardano SL) following the instructions from [Daedalus](https://github.com/input-output-hk/daedalus/blob/master/README.md#development---with-cardano-wallet) README file.
 5. Run Daedalus frontend tests:
 
 ```bash
 $ cd daedalus/
-$ yarn run test
+$ nix-shell --arg autoStartBackend true --arg systemStart XXX # XXX = cardano system startup time
+$ yarn test
 ```
 
 Once tests are complete you will get a summary of passed/failed tests in the Terminal window.
+
+## Keeping Daedalus Alive After Tests
+
+While working on the tests it's often useful to keep Daedalus alive after the tests have run 
+(e.g: to inspect the app state). You can pass a special environment var to tell the test script
+not to close the app:
+
+````bash
+$ KEEP_APP_AFTER_TESTS=true yarn test
+````

--- a/features/support/electron.js
+++ b/features/support/electron.js
@@ -115,7 +115,10 @@ defineSupportCode(({ BeforeAll, Before, After, AfterAll, setDefaultTimeout }) =>
     if (scenariosCount === 0) {
       await printMainProcessLogs();
     }
-
+    if (process.env.KEEP_APP_AFTER_TESTS === 'true') {
+      console.log('Keeping the app running since KEEP_APP_AFTER_TESTS env var is true');
+      return;
+    }
     return context.app.stop();
   });
 });


### PR DESCRIPTION
This PR adds the optional `KEEP_APP_AFTER_TESTS=true` environment flag which tells the test script not to close the app after all tests have run. This is useful to inspect the state of the app after all tests have been executed (and especially during development via `test:watch`)

Also updated the readme about testing with this new information + fixed older docs which are out of date now with the node ipc stuff.
---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
