### PR TITLE
[DDW-435] harden cardano-ndoe process handling logic

### DIFF
--- a/source/common/types/cardanoNode.types.js
+++ b/source/common/types/cardanoNode.types.js
@@ -23,12 +23,13 @@ export const NetworkNameOptions = {
 
 export type CardanoNodeState = (
   'stopped' | 'starting' | 'running' | 'stopping' | 'updating' |
-  'updated' | 'crashed' | 'errored'
+  'updated' | 'crashed' | 'errored' | 'exiting'
 );
 
 export const CardanoNodeStates: {
   STARTING: CardanoNodeState,
   RUNNING: CardanoNodeState;
+  EXITING: CardanoNodeState;
   STOPPING: CardanoNodeState;
   STOPPED: CardanoNodeState;
   UPDATING: CardanoNodeState;
@@ -38,6 +39,7 @@ export const CardanoNodeStates: {
 } = {
   STARTING: 'starting',
   RUNNING: 'running',
+  EXITING: 'exiting',
   STOPPING: 'stopping',
   STOPPED: 'stopped',
   UPDATING: 'updating',

--- a/source/renderer/app/stores/NetworkStatusStore.js
+++ b/source/renderer/app/stores/NetworkStatusStore.js
@@ -175,17 +175,9 @@ export default class NetworkStatusStore extends Store {
     Logger.info(`NetworkStatusStore: handling cardano-node state <${state}>`);
     const wasConnected = this.isConnected;
     switch (state) {
-      case CardanoNodeStates.RUNNING:
-        this._requestTlsConfig();
-        break;
-      case CardanoNodeStates.STOPPING:
-      case CardanoNodeStates.STOPPED:
-      case CardanoNodeStates.UPDATING:
-      case CardanoNodeStates.UPDATED:
-      case CardanoNodeStates.CRASHED:
-        this._setDisconnected(wasConnected);
-        break;
-      default:
+      case CardanoNodeStates.STARTING: break;
+      case CardanoNodeStates.RUNNING: this._requestTlsConfig(); break;
+      default: this._setDisconnected(wasConnected);
     }
     runInAction('setting cardanoNodeState', () => {
       this.cardanoNodeState = state;


### PR DESCRIPTION
This PR hardens the cardano-node process handling in cases of errors and crashes. Basically we are not believing anything the node tells us and always double check that it really died after it said so.

For this another another node state `exiting` was introduced which is the first transition when cardano node says it exited with some code … this state basically means "cardano-node says it exited but haven't confirmed that yet" … then we wait for the process to die or ensure it's properly killed before moving on to other states.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
