### PR TITLE
main window on Linux:  icon relative to process.env.DAEDALUS_INSTALL_DIRECTORY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Logs
 
 # Runtime data
 pids
+icon.png
 *.exe
 *.pid
 *.seed

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ let
     };
     iconPath = {
       # the target of these paths must not be a symlink
+      demo    = ./installers/icons/staging.iconset/icon_512x512.png;
       mainnet = ./installers/icons/mainnet/1024x1024.png;
       staging = ./installers/icons/staging.iconset/icon_512x512.png;
       testnet = ./installers/icons/testnet.iconset/icon_512x512.png;

--- a/shell.nix
+++ b/shell.nix
@@ -80,6 +80,7 @@ let
       systemStartString = builtins.toString systemStart;
     in ''
       ${localLib.optionalString pkgs.stdenv.isLinux "export XDG_DATA_HOME=$HOME/.local/share"}
+      cp -f ${daedalusPkgs.iconPath.${cluster}} $DAEDALUS_DIR/icon.png
       ln -svf $(type -P cardano-node)
       ${pkgs.lib.optionalString autoStartBackend ''
         for x in wallet-topology.yaml configuration.yaml mainnet-genesis-dryrun-with-stakeholders.json ; do

--- a/source/main/windows/main.js
+++ b/source/main/windows/main.js
@@ -2,7 +2,6 @@ import path from 'path';
 import { app, BrowserWindow, ipcMain, Menu } from 'electron';
 import environment from '../../common/environment';
 import ipcApi from '../ipc';
-import { runtimeFolderPath } from '../config';
 import RendererErrorHandler from '../utils/rendererErrorHandler';
 
 const rendererErrorHandler = new RendererErrorHandler();

--- a/source/main/windows/main.js
+++ b/source/main/windows/main.js
@@ -18,7 +18,7 @@ export const createMainWindow = (isInSafeMode) => {
   };
 
   if (process.platform === 'linux') {
-    windowOptions.icon = path.join(runtimeFolderPath, 'icon.png');
+    windowOptions.icon = path.join(process.env.DAEDALUS_INSTALL_DIRECTORY, 'icon.png');
   }
 
   // Construct new BrowserWindow


### PR DESCRIPTION
Fix the startup hang on Linux, which looks like the following in the console:
```
$ /nix/store/rlp0drkvym62aljwrfj2nzs4z6dz3zdd-daedalus/bin/daedalus
+ export PATH=/nix/store/xrq40a9c4lv20p4a69js1y1gm43kdsgp-daedalus-frontend/bin/:/nix/store/vcnsd7mqcbmfzcwnp6slz6i25f9yic4p-cardano-daedalus-bridge-1.3.0/bin:/home/deepfire/Applications/.bin:/nix/store/lcin62a066vz93jn8ac9vj9qnjl2cdhy-enlightenment-0.22.4/bin:/home/deepfire/bin:/run/wrappers/bin:/home/deepfire/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/deepfire/bin:/home/deepfire/bin
+ PATH=/nix/store/xrq40a9c4lv20p4a69js1y1gm43kdsgp-daedalus-frontend/bin/:/nix/store/vcnsd7mqcbmfzcwnp6slz6i25f9yic4p-cardano-daedalus-bridge-1.3.0/bin:/home/deepfire/Applications/.bin:/nix/store/lcin62a066vz93jn8ac9vj9qnjl2cdhy-enlightenment-0.22.4/bin:/home/deepfire/bin:/run/wrappers/bin:/home/deepfire/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/etc/profiles/per-user/deepfire/bin:/home/deepfire/bin
+ test -z ''
+ XDG_DATA_HOME=/home/deepfire/.local/share
+ export CLUSTER=mainnet
+ CLUSTER=mainnet
+ export DAEDALUS_DIR=/home/deepfire/.local/share/Daedalus
+ DAEDALUS_DIR=/home/deepfire/.local/share/Daedalus
+ export DAEDALUS_CONFIG=/nix/store/i3laqw8lli7chbk744cray1f1gb9jfr9-daedalus-config
+ DAEDALUS_CONFIG=/nix/store/i3laqw8lli7chbk744cray1f1gb9jfr9-daedalus-config
+ mkdir -p /home/deepfire/.local/share/Daedalus/mainnet/Logs/pub /home/deepfire/.local/share/Daedalus/mainnet/Secrets
+ cd /home/deepfire/.local/share/Daedalus/mainnet/
+ exec /nix/store/vcnsd7mqcbmfzcwnp6slz6i25f9yic4p-cardano-daedalus-bridge-1.3.0/bin/cardano-launcher --config /nix/store/i3laqw8lli7chbk744cray1f1gb9jfr9-daedalus-config/launcher-config.yaml
[cardano-sl.launcher:Info:ThreadId 4] [2018-10-11 15:05:37.95 UTC] using configurations: ConfigurationOptions {cfoFilePath = "/nix/store/i3laqw8lli7chbk744cray1f1gb9jfr9-daedalus-config/configuration.yaml", cfoKey = "mainnet_wallet_linux64", cfoSystemStart = Nothing, cfoSeed = Nothing}
[cardano-sl.launcher:Info:ThreadId 4] [2018-10-11 15:05:38.89 UTC] System start time is 1506203091000000
[cardano-sl.launcher:Info:ThreadId 4] [2018-10-11 15:05:38.89 UTC] Current time is 1539270338899362
[cardano-sl.launcher:Info:ThreadId 4] [2018-10-11 15:05:38.89 UTC] Generating new TLS certificates in /home/deepfire/.local/share/Daedalus/mainnet/tls
[cardano-sl.launcher:Info:ThreadId 4] [2018-10-11 15:05:39.51 UTC] Waiting for wallet to finish...
[cardano-sl.launcher:Notice:ThreadId 4] [2018-10-11 15:05:39.51 UTC] Starting the wallet
```
..where `~/.local/share/Daedalus/mainnet/Logs/pub/Daedalus.log` has this error:
```
[22:37:23.515] [error] [main] unhandledException::renderer: {
  "stack": "TypeError: Path must be a string. Received undefined\n    at assertPath (path.js:28:11)\n    at Object.join (path.js:1232:7)\n    at createMainWindow (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:56904:41)\n    at _callee4$ (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:50026:51)\n    at tryCatch (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:50223:40)\n    at Generator.invoke [as _invoke] (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:50457:22)\n    at Generator.prototype.(anonymous function) [as next] (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:50275:21)\n    at step (/home/sam/work/iohk/daedalus/develop/dist/main/index.js:4976:30)\n    at /home/sam/work/iohk/daedalus/develop/dist/main/index.js:4987:13\n    at <anonymous>",
  "message": "Path must be a string. Received undefined"
```
---

## Review Checklist:

### Basics

- [x] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
