### PR TITLE
[DDW 436] Improve Daedalus lock file handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "gulp build",
     "start": "gulp start",
-    "start:watch": "gulp start:watch",
+    "start:dev": "NODE_ENV=development gulp start",
     "dev": "gulp dev",
     "test": "gulp test",
     "test:watch": "gulp test:watch",

--- a/source/main/cardano/CardanoNode.js
+++ b/source/main/cardano/CardanoNode.js
@@ -8,11 +8,7 @@ import environment from '../../common/environment';
 import type { CardanoNodeState, TlsConfig } from '../../common/types/cardanoNode.types';
 import { promisedCondition, deriveStorageKeys, deriveProcessNames } from './utils';
 import { CardanoNodeStates } from '../../common/types/cardanoNode.types';
-
-type Process = {
-  pid: number,
-  name: string,
-};
+import type { Process } from '../utils/processes';
 
 type Logger = {
   debug: (string) => void,

--- a/source/main/index.js
+++ b/source/main/index.js
@@ -23,16 +23,6 @@ import { ensureXDGDataIsSet } from './cardano/config';
 import { acquireDaedalusInstanceLock } from './utils/lockFiles';
 import { CardanoNodeStates } from '../common/types/cardanoNode.types';
 
-acquireDaedalusInstanceLock();
-setupLogging();
-mainErrorHandler();
-
-Logger.info(`========== Daedalus is starting at ${new Date().toString()} ==========`);
-
-Logger.debug(`!!! Daedalus is running on ${os.platform()} version ${os.release()}
-            with CPU: ${JSON.stringify(os.cpus(), null, 2)} with
-            ${JSON.stringify(os.totalmem(), null, 2)} total RAM !!!`);
-
 // Global references to windows to prevent them from being garbage collected
 let mainWindow: BrowserWindow;
 let cardanoNode: CardanoNode;
@@ -72,6 +62,17 @@ const menuActions = {
 };
 
 app.on('ready', async () => {
+  // Make sure this is the only Daedalus instance running per cluster before doing anything else
+  await acquireDaedalusInstanceLock();
+  setupLogging();
+  mainErrorHandler();
+
+  Logger.info(`========== Daedalus is starting at ${new Date().toString()} ==========`);
+
+  Logger.debug(`!!! Daedalus is running on ${os.platform()} version ${os.release()}
+            with CPU: ${JSON.stringify(os.cpus(), null, 2)} with
+            ${JSON.stringify(os.totalmem(), null, 2)} total RAM !!!`);
+
   const isProd = process.env.NODE_ENV === 'production';
   const isStartedByLauncher = !!process.env.LAUNCHER_CONFIG;
   if (isProd && !isStartedByLauncher) {

--- a/source/main/utils/lockFiles.js
+++ b/source/main/utils/lockFiles.js
@@ -2,12 +2,16 @@
 import path from 'path';
 import { lockSync, unlockSync } from 'lockfile';
 import { launcherConfig } from '../config';
+import { getProcessName } from './processes';
 
-const lockFilePath = path.join(launcherConfig.statePath, 'Daedalus.lock');
+const getLockFilePath = async (): Promise<string> => {
+  const processName = await getProcessName(process.pid);
+  return path.join(launcherConfig.statePath, `${processName}.lock`);
+};
 
-export const acquireDaedalusInstanceLock = () => {
+export const acquireDaedalusInstanceLock = async () => {
   try {
-    lockSync(lockFilePath);
+    lockSync(await getLockFilePath());
   } catch (error) {
     console.log('Error while trying to acquire lock for Daedalus instance:');
     if (error.code === 'EEXIST') {
@@ -18,4 +22,4 @@ export const acquireDaedalusInstanceLock = () => {
   }
 };
 
-export const releaseDaedalusInstanceLock = () => unlockSync(lockFilePath);
+export const releaseDaedalusInstanceLock = async () => unlockSync(await getLockFilePath());

--- a/source/main/utils/lockFiles.js
+++ b/source/main/utils/lockFiles.js
@@ -1,8 +1,9 @@
 // @flow
+import fs from 'fs';
 import path from 'path';
 import { lockSync, unlockSync } from 'lockfile';
 import { launcherConfig } from '../config';
-import { getProcessName } from './processes';
+import { getProcessName, getProcessesByName } from './processes';
 
 const getLockFilePath = async (): Promise<string> => {
   const processName = await getProcessName(process.pid);
@@ -10,12 +11,20 @@ const getLockFilePath = async (): Promise<string> => {
 };
 
 export const acquireDaedalusInstanceLock = async () => {
+  const lockFilePath = await getLockFilePath();
   try {
-    lockSync(await getLockFilePath());
+    lockSync(lockFilePath);
   } catch (error) {
-    console.log('Error while trying to acquire lock for Daedalus instance:');
     if (error.code === 'EEXIST') {
-      throw new Error('Another Daedalus instance is already running.');
+      console.log('Lockfile already exists. Checking for other Daedalus instance.');
+      const processName = await getProcessName(process.pid);
+      const processesWithSameName = await getProcessesByName(processName);
+      if (processesWithSameName.length > 1) {
+        throw new Error('Another Daedalus instance is already running.');
+      }
+      console.log('No other Daedalus instance running. Recreating the lockfile.');
+      fs.unlinkSync(lockFilePath);
+      await acquireDaedalusInstanceLock();
     } else {
       throw error;
     }

--- a/source/main/utils/processes.js
+++ b/source/main/utils/processes.js
@@ -1,3 +1,4 @@
+// @flow
 import psList from 'ps-list';
 
 export type Process = {

--- a/source/main/utils/processes.js
+++ b/source/main/utils/processes.js
@@ -3,12 +3,27 @@ import psList from 'ps-list';
 export type Process = {
   pid: number,
   name: string,
+  cmd: string,
+  ppid?: number,
+  cpu: number,
+  memore: number,
 };
 
-export const getProcessName = async (processId: number): Promise<string> => {
+export const getProcessById = async (processId: number): Promise<Process> => {
   // retrieves all running processes
   const processes: Array<Process> = await psList();
   // filters running processes against previous PID
   const matches: Array<Process> = processes.filter(({ pid }) => processId === pid);
-  return matches.length > 0 ? matches[0].name : Promise.reject();
+  return matches.length > 0 ? matches[0] : Promise.reject();
+};
+
+export const getProcessName = async (processId: number) => (
+  (await getProcessById(processId)).name
+);
+
+export const getProcessesByName = async (processName: string): Promise<Array<Process>> => {
+  // retrieves all running processes
+  const processes: Array<Process> = await psList();
+  // filters running processes against previous PID
+  return processes.filter(({ name }) => processName === name);
 };

--- a/source/main/utils/processes.js
+++ b/source/main/utils/processes.js
@@ -1,0 +1,14 @@
+import psList from 'ps-list';
+
+export type Process = {
+  pid: number,
+  name: string,
+};
+
+export const getProcessName = async (processId: number): Promise<string> => {
+  // retrieves all running processes
+  const processes: Array<Process> = await psList();
+  // filters running processes against previous PID
+  const matches: Array<Process> = processes.filter(({ pid }) => processId === pid);
+  return matches.length > 0 ? matches[0].name : Promise.reject();
+};


### PR DESCRIPTION
This PR improves the logic that ensures only a single instance of Daedalus is running per cluster.
Several common cases are handled now:

- The current process name is used to generate the lockfiles.
- In case there is an existing lockfile when starting Daedalus, it now also checks if there is really another instance running with the same before concluding that the lock is taken.
- If no other Daedalus instance with the same name is running (but the lockfile exists) it deletes the existing lock and creates a new one for the current instance.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
