### PR TITLE
[DDW-438] Fix missing Cardano node pub logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ mainnet
 staging
 cardano-node
 configuration.yaml
+log-config-prod.yaml
 mainnet-genesis-dryrun-with-stakeholders.json
 wallet-topology.yaml
 

--- a/shell.nix
+++ b/shell.nix
@@ -96,7 +96,7 @@ let
       cp -f ${daedalusPkgs.iconPath.${cluster}} $DAEDALUS_INSTALL_DIRECTORY/icon.png
       ln -svf $(type -P cardano-node)
       ${pkgs.lib.optionalString autoStartBackend ''
-        for x in wallet-topology.yaml configuration.yaml mainnet-genesis-dryrun-with-stakeholders.json ; do
+        for x in wallet-topology.yaml log-config-prod.yaml configuration.yaml mainnet-genesis-dryrun-with-stakeholders.json ; do
           ln -svf ${daedalusPkgs.daedalus.cfg}/etc/$x
         done
         ${pkgs.lib.optionalString (cluster == "demo") ''

--- a/source/main/cardano/config.js
+++ b/source/main/cardano/config.js
@@ -19,6 +19,7 @@ export const prepareArgs = (config: LauncherConfig) => {
   const args: Array<string> = Array.from(config.nodeArgs);
   if (config.reportServer) args.push('--report-server', config.reportServer);
   if (config.nodeDbPath) args.push('--db-path', config.nodeDbPath);
+  if (config.nodeLogConfig) args.push('--log-config', config.nodeLogConfig);
   if (config.logsPrefix) args.push('--logs-prefix', config.logsPrefix);
   if (config.configuration) {
     if (config.configuration.filePath) args.push('--configuration-file', config.configuration.filePath);

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -18,6 +18,7 @@ export type LauncherConfig = {
   reportServer?: string,
   nodeDbPath: string,
   logsPrefix: string,
+  nodeLogConfig: string,
   nodeTimeoutSec: number,
   configuration: {
     filePath: string,


### PR DESCRIPTION
This PR adds `--log-config` argument to Cardano spawn call and updates `shell.nix` so that it exposes `log-config-prod.yaml` file in local development.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
