### PR TITLE
[DDW-443] Fix Antivirus Notification Close Button Hover Color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,12 @@ Changelog
 
 ### Fixes
 
-- Fixes the close button's hover state within the AntivirusRestaurationSlowdownNotification so it's full height.
-([PR 1131](https://github.com/input-output-hk/daedalus/pull/1131))
 - Fixed an issue which allowed to submit invalid form on the "Send" screen using an "enter" key ([PR 1002](https://github.com/input-output-hk/daedalus/pull/1002))
 - Fixed an issue which would trigger submission of the "Generate address" button on the "Receive" screen on right-mouse click ([PR 1082](https://github.com/input-output-hk/daedalus/pull/1082))
 - Fixed an issue with the "Having Trouble Connecting" notification not showing up on the "Connection lost. Reconnecting..." screen ([PR 1112](https://github.com/input-output-hk/daedalus/pull/1112))
 - Fixed broken "Export wallet to file" dialog and improved "Wallet settings" screen dialogs file structure and namings ([PR 998](https://github.com/input-output-hk/daedalus/pull/998))
 - Fixed special buttons outline color ([PR 990](https://github.com/input-output-hk/daedalus/pull/990))
+- Fixed the close button's hover state within the AntivirusRestaurationSlowdownNotification so it's full height ([PR 1131](https://github.com/input-output-hk/daedalus/pull/1131))
 - Fixed uninstaller unicode issue ([PR 1116](https://github.com/input-output-hk/daedalus/pull/1116))
 - Implement design review fixes and improvements ([PR 1090](https://github.com/input-output-hk/daedalus/pull/1090))
 - Pinned eslint-scope version via the yarn resolutions feature ([PR 1017](https://github.com/input-output-hk/daedalus/pull/1017))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Changelog
 
 ### Fixes
 
+- Fixes the close button's hover state within the AntivirusRestaurationSlowdownNotification so it's full height.
+([PR 1131](https://github.com/input-output-hk/daedalus/pull/1131))
 - Fixed an issue which allowed to submit invalid form on the "Send" screen using an "enter" key ([PR 1002](https://github.com/input-output-hk/daedalus/pull/1002))
 - Fixed an issue which would trigger submission of the "Generate address" button on the "Receive" screen on right-mouse click ([PR 1082](https://github.com/input-output-hk/daedalus/pull/1082))
 - Fixed an issue with the "Having Trouble Connecting" notification not showing up on the "Connection lost. Reconnecting..." screen ([PR 1112](https://github.com/input-output-hk/daedalus/pull/1112))

--- a/source/renderer/app/components/notifications/AntivirusRestaurationSlowdownNotification.scss
+++ b/source/renderer/app/components/notifications/AntivirusRestaurationSlowdownNotification.scss
@@ -8,33 +8,34 @@
   position: absolute;
   bottom: 0;
   align-items: center;
-  padding: 10px 0;
-}
 
-.text {
-  color: white;
-  font-family: $theme-font-light;
-  text-align: center;
-  font-size: 12px;
-  flex-grow: 1;
-  line-height: 1.2em;
-
-  a:link, a:visited {
+  .text {
+    padding: 10px 0;
     color: white;
-  }
-}
+    font-family: $theme-font-light;
+    text-align: center;
+    font-size: 12px;
+    flex-grow: 1;
+    line-height: 1.2em;
 
-.closeButton {
-  width: 50px;
-  &:hover {
-    cursor: pointer;
-    background-color: #951604;
+    a:link, a:visited {
+      color: white;
+    }
   }
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
 
-.closeCross {
-  width: 10px;
+  .closeButton {
+    width: 50px;
+    padding: 25px 0;
+    &:hover {
+      cursor: pointer;
+      background-color: #951604;
+    }
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .closeCross {
+    width: 10px;
+  }
 }

--- a/source/renderer/app/components/notifications/AntivirusRestaurationSlowdownNotification.scss
+++ b/source/renderer/app/components/notifications/AntivirusRestaurationSlowdownNotification.scss
@@ -1,41 +1,42 @@
 @import "../../themes/simple/config";
 
 .component {
-  width: 100%;
+  align-items: center;
   background-color: #b2311d;
-  box-shadow: 0 -5px 20px 0 rgba(0, 0, 0, 0.25);
+  bottom: 0;
+  box-shadow: 0 -5px 20px 0 rgba(0,0,0,0.25);
   display: flex;
   position: absolute;
-  bottom: 0;
-  align-items: center;
+  width: 100%;
 
   .text {
-    padding: 10px 0;
-    color: white;
+    color: #fff;
     font-family: $theme-font-light;
-    text-align: center;
     font-size: 12px;
     flex-grow: 1;
     line-height: 1.2em;
+    padding: 10px 0;
+    text-align: center;
 
     a:link, a:visited {
-      color: white;
+      color: #fff;
     }
   }
 
   .closeButton {
-    width: 50px;
+    align-items: center;
+    display: flex;
+    justify-content: center;
     padding: 25px 0;
+    width: 50px;
+
     &:hover {
       cursor: pointer;
       background-color: #951604;
     }
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
 
-  .closeCross {
-    width: 10px;
+    .closeCross {
+      width: 10px;
+    }
   }
 }


### PR DESCRIPTION
This PR makes the close button full height within the `AntivirusRestaurationSlowdownNotification` component so that when the button is in a `:hover` state, the dark red background assumes the full height of the AntiVirus notification.

## Screenshots:

![oct-16-2018 19-01-01](https://user-images.githubusercontent.com/13347886/47057497-df262d00-d175-11e8-92ea-af67377c96e4.gif)

## Review Checklist:

### Basics

- [x] PR is updated to the most recent version of target branch (and there are no conflicts)
- [x] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [x] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [x] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [x] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [x] There are no *flow* errors or warnings (`yarn run flow:test`)
- [x] There are no *lint* errors or warnings (`yarn run lint`)
- [x] Text changes are proofread and approved (Jane Wild)
- [x] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [x] UI changes look good in all themes (Alexander Rukin)
- [x] Storybook works and no stories are broken (`yarn run storybook`)
- [x] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [x] Important parts of the code are properly documented and commented
- [x] Code is properly typed with flow
- [x] React components are split-up enough to avoid unnecessary re-rendering
- [x] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
