### PR TITLE
[DEVOPS-1095] allow opening links when in the sandbox

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,8 +55,8 @@ let
     nix-bundle = import (pkgs.fetchFromGitHub {
       owner = "matthewbauer";
       repo = "nix-bundle";
-      rev = "496f2b524743da67717e4533745394575c6aab1f";
-      sha256 = "0p9hsrbc1b0i4aipwnl4vxjsayc5m865xhp8q139ggaxq7xd0lps";
+      rev = "7f12322399fd87d937355d0fc263d37d798496fc";
+      sha256 = "07wnmdadchf73p03wk51abzgd3zm2xz5khwadz1ypbvv3cqlzp5m";
     }) { nixpkgs = pkgs; };
     desktopItem = pkgs.makeDesktopItem {
       name = "Daedalus${if cluster != "mainnet" then "-${cluster}" else ""}";
@@ -84,7 +84,12 @@ let
       cat /etc/nsswitch.conf > etc/nsswitch.conf
       cat /etc/machine-id > etc/machine-id
       cat /etc/resolv.conf > etc/resolv.conf
-      exec .${self.nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -c -m /home:/home -m /etc:/host-etc -m etc:/etc -p DISPLAY -p HOME -p XAUTHORITY -- /nix/var/nix/profiles/profile-${cluster}/bin/enter-phase2 daedalus
+
+      if [ "x$DEBUG_SHELL" == x ]; then
+        exec .${self.nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -c -e -m /home:/home -m /etc:/host-etc -m etc:/etc -p DISPLAY -p HOME -p XAUTHORITY -- /nix/var/nix/profiles/profile-${cluster}/bin/enter-phase2 daedalus
+      else
+        exec .${self.nix-bundle.nix-user-chroot}/bin/nix-user-chroot -n ./nix -c -e -m /home:/home -m /etc:/host-etc -m etc:/etc -p DISPLAY -p HOME -p XAUTHORITY -- /nix/var/nix/profiles/profile-${cluster}/bin/enter-phase2 bash
+      fi
     '';
     postInstall = pkgs.writeScriptBin "post-install" ''
       #!${pkgs.stdenv.shell}
@@ -103,13 +108,18 @@ let
       cp -f ${self.iconPath.${cluster}} $DAEDALUS_DIR/icon.png
       cp -Lf ${self.namespaceHelper}/bin/namespaceHelper $DAEDALUS_DIR/namespaceHelper
       mkdir -pv ~/.local/bin ''${XDG_DATA_HOME}/applications
-      cp -Lf ${self.namespaceHelper}/bin/namespaceHelper ~/.local/bin/daedalus
+      ${pkgs.lib.optionalString (cluster == "mainnet") "cp -Lf ${self.namespaceHelper}/bin/namespaceHelper ~/.local/bin/daedalus"}
       cp -Lf ${self.namespaceHelper}/bin/namespaceHelper ~/.local/bin/daedalus-${cluster}
 
       cat ${self.desktopItem}/share/applications/Daedalus*.desktop | sed \
         -e "s+INSERT_PATH_HERE+''${DAEDALUS_DIR}/namespaceHelper+g" \
         -e "s+INSERT_ICON_PATH_HERE+''${DAEDALUS_DIR}/icon.png+g" \
         > "''${XDG_DATA_HOME}/applications/Daedalus${if cluster != "mainnet" then "-${cluster}" else ""}.desktop"
+    '';
+    xdg-open = pkgs.writeScriptBin "xdg-open" ''
+      #!${pkgs.stdenv.shell}
+
+      echo -n "xdg-open \"$1\"" > /escape-hatch
     '';
     preInstall = pkgs.writeText "pre-install" ''
       if grep sse4 /proc/cpuinfo -q; then
@@ -124,7 +134,7 @@ let
     in (import ./installers/nix/nix-installer.nix {
       inherit (self) postInstall preInstall cluster;
       installationSlug = installPath;
-      installedPackages = [ daedalus' self.postInstall self.namespaceHelper daedalus'.cfg self.daedalus-bridge daedalus'.daedalus-frontend ];
+      installedPackages = [ daedalus' self.postInstall self.namespaceHelper daedalus'.cfg self.daedalus-bridge daedalus'.daedalus-frontend self.xdg-open ];
       nix-bundle = self.nix-bundle;
     }).installerBundle;
   };

--- a/installers/nix/nix-installer.nix
+++ b/installers/nix/nix-installer.nix
@@ -40,7 +40,7 @@ let
     bash "$1" --extract
     ls -ltrh dat/nix/store/*-tarball/tarball/tarball.tar.xz
     UNPACK2=$(mktemp -d)
-    tar -C $UNPACK2 -xf dat/nix/store/*-tarball/tarball/tarball.tar.xz
+    tar --delay-directory-restore -C $UNPACK2 -xf dat/nix/store/*-tarball/tarball/tarball.tar.xz
     cd
     rmrf $UNPACK
     ls -ltrh $UNPACK2
@@ -125,7 +125,7 @@ let
 
     UNPACK=$(mktemp -d)
 
-    pv $TARPATH | unxz | tar -x -C $UNPACK
+    pv $TARPATH | unxz | tar --delay-directory-restore -x -C $UNPACK
 
     NIX_REMOTE=local?root=$UNPACK nix-store --load-db < $UNPACK/nix-path-registration
     pwd


### PR DESCRIPTION
This PR allows `xdg-open` to work from within the sandbox, so electron can now open links
this also changes the error `nix-user-chroot` gives when user namespaces need to be enabled, it now shows how to correctly run it with `sudo`.

this handles DEVOPS-1105, the `~/.local/bin/daedalus` is only mainnet from now on
## Todo:

- [ ] after merging, cherry-pick it to the release branch

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
