### PR TITLE
[DEVOPS-1112] Update cardano-sl to latest release/2.0.0 branch

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "e4116635f783b4aac2c1bdbc2b577b4d45f2bf03",
-  "sha256": "1sz1wc92vz9b9ayfipb1n5m49sickcv5cwlfzbkxwawnh9vka7q3",
+  "rev": "e84ca6cbbedf651ac1f43c8f8e4d6c6b04f96078",
+  "sha256": "0bylg1lvkkvxcmcv6rvaffqh7cwr68q41f7rfgnc3gg32l45hsx9",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Another cardano-sl revision bump due to the late merge of input-output-hk/cardano-sl#3742.