### PR TITLE
[DDW-489] Fix an edge-case error message when Daedalus is not started…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changelog
 ### Fixes
 
 - Fixed an issue which allowed to submit invalid form on the "Send" screen using an "enter" key ([PR 1002](https://github.com/input-output-hk/daedalus/pull/1002))
+- Fixed an issue which would show a runtime JavaScript error in case Daedalus is not started using Launcher ([PR 1169](https://github.com/input-output-hk/daedalus/pull/1169))
 - Fixed an issue which would trigger submission of the "Generate address" button on the "Receive" screen on right-mouse click ([PR 1082](https://github.com/input-output-hk/daedalus/pull/1082))
 - Fixed an issue with the "Having Trouble Connecting" notification not showing up on the "Connection lost. Reconnecting..." screen ([PR 1112](https://github.com/input-output-hk/daedalus/pull/1112))
 - Fixed broken "Export wallet to file" dialog and improved "Wallet settings" screen dialogs file structure and namings ([PR 998](https://github.com/input-output-hk/daedalus/pull/998))

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -18,8 +18,13 @@ if (!isStartedByLauncher) {
   } else {
     dialogMessage = 'Daedalus should be started using nix-shell. Find more details here: https://github.com/input-output-hk/daedalus/blob/develop/README.md';
   }
-  dialog.showErrorBox(dialogTitle, dialogMessage);
-  app.exit(1);
+  try {
+    // app may not be available at this moment so we need to use try-catch
+    dialog.showErrorBox(dialogTitle, dialogMessage);
+    app.exit(1);
+  } catch (e) {
+    throw new Error(`${dialogTitle}\n\n${dialogMessage}\n`);
+  }
 }
 
 /**


### PR DESCRIPTION
… using Launcher

This PR fixes the edge-case scenario where in case Daedalus was not started using Launcher a generic JavaScript runtime error would be thrown instead of the nice error dialog with more descriptive "Missing configuration" error text.
Since in this very rare edge-case the app and error dialog are not available we can only make the generic JavaScript error message more descriptive by showing the same error text content as in the nice error dialog...

## Screenshots:

### Before
![screen shot 2018-11-13 at 14 27 16](https://user-images.githubusercontent.com/376611/48416355-3c4ed780-e750-11e8-8f50-f18bc4c3cf6b.png)

### After
![new](https://user-images.githubusercontent.com/376611/48416359-4244b880-e750-11e8-8306-d081a7234329.png)

### Usual error message (shown in 99% of cases)
![nice](https://user-images.githubusercontent.com/376611/48416367-4a9cf380-e750-11e8-9393-f841eddf006b.png)

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
