### PR TITLE
[DEVOPS-1141] Bump cardano-sl to latest release/1.3.2

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "af722c49a41db0ad5073ade03efdd5d7e0065406",
-  "sha256": "0z1na7f51vdbpyln64259xyqgxk18mkxqpfwh1fc185qhc1fhpkx",
+  "rev": "a956b5cfaf9165651a1ed7c9e9dc1c790e5b0d95",
+  "sha256": "1qg8s99l1wvch1qyw48scg6j6bf7f68xjplpw5gg3np86gxk55za",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
This new commit contains a bump of the `applicationVersion` and `lastKnownBlockVersion` for the testnet wallet.
