### PR TITLE
[DEVOPS-1112] Update cardano-sl to latest release/2.0.0 branch

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "4efd3d14188923c135bd2e757de07bcf02acbcc4",
-  "sha256": "11w4bi9ylji4zkm8v979zx8a6d0gniiza3lvjn5ldkykrnw1413i",
+  "rev": "98691060948315ed2ef669d096439c6afcfd8afa",
+  "sha256": "00kfnxzi2l2wjkh70fqcc373clzb2pavw1fcz1jq47x4x4sdpdha",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Updates cardano-sl to the latest revision on the `release/2.0.0` branch.
