### PR TITLE
Release/0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+## 0.11.2
+=======
+
+- Update cardano-sl revision to 1.3.2
+
 ## 0.11.1
 =======
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changelog
 ## 0.11.2
 =======
 
-- Update cardano-sl revision to 1.3.2
+### Fixes
+
+- Update Cardano SL revision to version `1.3.2` ([PR 1181](https://github.com/input-output-hk/daedalus/pull/1181))
 
 ## 0.11.1
 =======

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "061980e11a9ec65caaedbe43dd5aa647f2d5205a",
-  "sha256": "0y17zi02mr3qk4xmkz1p1gzvv0zcixzmqns1dxn5xqlb00wfac45",
+  "rev": "3fa92ec1588c1b0849be477b4abf1fa652aa842d",
+  "sha256": "02lgzhncbd80zmppw99016w0ya3mqjl9xjyna5z3rs3sid671yci",
   "fetchSubmodules": false
 }

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "3fa92ec1588c1b0849be477b4abf1fa652aa842d",
-  "sha256": "02lgzhncbd80zmppw99016w0ya3mqjl9xjyna5z3rs3sid671yci",
+  "rev": "d73464ceb6f9bb9f79d4f329bfeb940e52df215c",
+  "sha256": "0z1na7f51vdbpyln64259xyqgxk18mkxqpfwh1fc185qhc1fhpkx",
   "fetchSubmodules": false
 }

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "af722c49a41db0ad5073ade03efdd5d7e0065406",
-  "sha256": "0z1na7f51vdbpyln64259xyqgxk18mkxqpfwh1fc185qhc1fhpkx",
+  "rev": "a956b5cfaf9165651a1ed7c9e9dc1c790e5b0d95",
+  "sha256": "1qg8s99l1wvch1qyw48scg6j6bf7f68xjplpw5gg3np86gxk55za",
   "fetchSubmodules": false
 }

--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "d73464ceb6f9bb9f79d4f329bfeb940e52df215c",
+  "rev": "af722c49a41db0ad5073ade03efdd5d7e0065406",
   "sha256": "0z1na7f51vdbpyln64259xyqgxk18mkxqpfwh1fc185qhc1fhpkx",
   "fetchSubmodules": false
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
## 0.11.2

### Fixes

- Update Cardano SL revision to version `1.3.2` ([PR 1181](https://github.com/input-output-hk/daedalus/pull/1181))