### PR TITLE
[DDW-497] Daedalus does not support spending password with only non-Latin characters and numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 - Fixed the partly broken flow setup ([PR 1124](https://github.com/input-output-hk/daedalus/pull/1124))
 - Fixed failing apply-node-update test ([PR 1156](https://github.com/input-output-hk/daedalus/pull/1156))
 - Removed Antivirus notification ([PR 1164](https://github.com/input-output-hk/daedalus/pull/1164))
+- Added support to non-Latin characters for the spending password ([PR 1196](https://github.com/input-output-hk/daedalus/pull/1196))
 
 ### Chores
 

--- a/source/renderer/app/utils/validations.js
+++ b/source/renderer/app/utils/validations.js
@@ -10,10 +10,10 @@ export const isValidWalletName = (walletName: string) => {
 export const isValidSpendingPassword = (spendingPassword: string) => {
   // Validation rules:
   // - should contain at least one digit: (?=.*\d)
-  // - should contain at least one lower case: (?=.*[a-z])
-  // - should contain at least one upper case: (?=.*[A-Z])
+  // - should contain at least one lower case: (?=.*[а-я])
+  // - should contain at least one upper case: (?=.*[А-Я])
   // - should contain at least 7 characters long: .{7,}
-  const passwordRegex = /^(?=.*\d)(?=.*[a-z])(?=.*[A-Z]).{7,}$/;
+  const passwordRegex = /^(?=.*\d)(?=.*[а-я])(?=.*[А-Я]).{7,}$/;
   return passwordRegex.test(spendingPassword);
 };
 


### PR DESCRIPTION
This PR Adds support to non-Latin characters for the spending password.


## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
