### PR TITLE
[DDW-529] Blocks stalling logic improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+## 0.12.1
+=======
+
+### Fixes
+
+- Fixed the network block stalling logic in order to prevent showing "Network connection lost - reconnecting..." screen in case network block height is stalling while local block height is still increasing ([PR 1246](https://github.com/input-output-hk/daedalus/pull/1246))
+
 ## 0.12.0
 =======
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {

--- a/source/renderer/app/components/status/NetworkStatus.js
+++ b/source/renderer/app/components/status/NetworkStatus.js
@@ -41,7 +41,8 @@ type Props = {
   isSystemTimeIgnored: boolean,
   isSystemTimeCorrect: boolean,
   isForceCheckingNodeTime: boolean,
-  mostRecentBlockTimestamp: number,
+  latestLocalBlockTimestamp: number,
+  latestNetworkBlockTimestamp: number,
   localBlockHeight: number,
   networkBlockHeight: number,
   onForceCheckLocalTimeDifference: Function,
@@ -118,7 +119,7 @@ export default class NetworkStatus extends Component<Props, State> {
       cardanoNodeState, isNodeResponding, isNodeSubscribed, isNodeSyncing, isNodeInSync,
       isNodeTimeCorrect, isConnected, isSynced, syncPercentage, hasBeenConnected,
       localTimeDifference, isSystemTimeCorrect, isForceCheckingNodeTime,
-      mostRecentBlockTimestamp, localBlockHeight, networkBlockHeight,
+      localBlockHeight, networkBlockHeight, latestLocalBlockTimestamp, latestNetworkBlockTimestamp,
       onForceCheckLocalTimeDifference, onClose, nodeConnectionError, isSystemTimeIgnored,
       onOpenExternalLink,
     } = this.props;
@@ -142,10 +143,16 @@ export default class NetworkStatus extends Component<Props, State> {
       ) ? styles.red : styles.green,
     ]);
 
-    const timeSinceLastBlock = moment(Date.now()).diff(moment(mostRecentBlockTimestamp));
-    const isBlockchainHeightStalling = timeSinceLastBlock > MAX_ALLOWED_STALL_DURATION;
-    const timeSinceLastBlockClasses = classNames([
-      mostRecentBlockTimestamp > 0 && !isBlockchainHeightStalling ? styles.green : styles.red,
+    const latestLocalBlockAge = moment(Date.now()).diff(moment(latestLocalBlockTimestamp));
+    const isLocalBlockHeightStalling = latestLocalBlockAge > MAX_ALLOWED_STALL_DURATION;
+    const latestLocalBlockAgeClasses = classNames([
+      latestLocalBlockTimestamp > 0 && !isLocalBlockHeightStalling ? styles.green : styles.red,
+    ]);
+
+    const latestNetworkBlockAge = moment(Date.now()).diff(moment(latestNetworkBlockTimestamp));
+    const isNetworkBlockHeightStalling = latestNetworkBlockAge > MAX_ALLOWED_STALL_DURATION;
+    const latestNetworkBlockAgeClasses = classNames([
+      latestNetworkBlockTimestamp > 0 && !isNetworkBlockHeightStalling ? styles.green : styles.red,
     ]);
 
     // Cardano Node EKG server is not enabled for the Mainnet!
@@ -198,9 +205,15 @@ export default class NetworkStatus extends Component<Props, State> {
                 </td>
               </tr>
               <tr>
-                <td>timeSinceLastNetworkBlockChange:</td>
-                <td className={timeSinceLastBlockClasses}>
-                  {mostRecentBlockTimestamp > 0 ? `${timeSinceLastBlock} ms` : '-'}
+                <td>latestLocalBlockAge:</td>
+                <td className={latestLocalBlockAgeClasses}>
+                  {latestLocalBlockTimestamp > 0 ? `${latestLocalBlockAge} ms` : '-'}
+                </td>
+              </tr>
+              <tr>
+                <td>latestNetworkBlockAge:</td>
+                <td className={latestNetworkBlockAgeClasses}>
+                  {latestNetworkBlockTimestamp > 0 ? `${latestNetworkBlockAge} ms` : '-'}
                 </td>
               </tr>
               <tr>

--- a/source/renderer/app/containers/status/NetworkStatusPage.js
+++ b/source/renderer/app/containers/status/NetworkStatusPage.js
@@ -25,8 +25,8 @@ export default class NetworkStatusPage extends Component<InjectedProps> {
       isConnected, isSynced, syncPercentage, hasBeenConnected,
       localTimeDifference, isSystemTimeCorrect, forceCheckTimeDifferenceRequest,
       forceCheckLocalTimeDifference, getNetworkStatusRequest,
-      localBlockHeight, networkBlockHeight, mostRecentBlockTimestamp, restartNode,
-      isSystemTimeIgnored,
+      localBlockHeight, networkBlockHeight, latestLocalBlockTimestamp, latestNetworkBlockTimestamp,
+      restartNode, isSystemTimeIgnored,
     } = stores.networkStatus;
     return (
       <CenteredLayout>
@@ -45,7 +45,8 @@ export default class NetworkStatusPage extends Component<InjectedProps> {
           isSystemTimeCorrect={isSystemTimeCorrect}
           isForceCheckingNodeTime={forceCheckTimeDifferenceRequest.isExecuting}
           isSystemTimeIgnored={isSystemTimeIgnored}
-          mostRecentBlockTimestamp={mostRecentBlockTimestamp}
+          latestLocalBlockTimestamp={latestLocalBlockTimestamp}
+          latestNetworkBlockTimestamp={latestNetworkBlockTimestamp}
           nodeConnectionError={
             getNetworkStatusRequest.error || forceCheckTimeDifferenceRequest.error
           }

--- a/source/renderer/app/stores/NetworkStatusStore.js
+++ b/source/renderer/app/stores/NetworkStatusStore.js
@@ -60,7 +60,8 @@ export default class NetworkStatusStore extends Store {
   @observable initialLocalHeight = null;
   @observable localBlockHeight = 0;
   @observable networkBlockHeight = 0;
-  @observable mostRecentBlockTimestamp = 0; // milliseconds
+  @observable latestLocalBlockTimestamp = 0; // milliseconds
+  @observable latestNetworkBlockTimestamp = 0; // milliseconds
   @observable localTimeDifference: ?number = 0; // microseconds
   @observable isSystemTimeIgnored = false; // Tracks if NTP time checks are ignored
   @observable getNetworkStatusRequest: Request<GetNetworkStatusResponse> = new Request(
@@ -208,10 +209,12 @@ export default class NetworkStatusStore extends Store {
     }
 
     if (isForcedTimeDifferenceCheck) {
-      // Set most recent block timestamp into the future as a guard
+      // Set latest block timestamps into the future as a guard
       // against system time changes - e.g. if system time was set into the past
-      runInAction('update mostRecentBlockTimestamp', () => {
-        this.mostRecentBlockTimestamp = Date.now() + NETWORK_STATUS_REQUEST_TIMEOUT;
+      runInAction('update latest block timestamps', () => {
+        const futureTimestamp = Date.now() + NETWORK_STATUS_REQUEST_TIMEOUT;
+        this.latestLocalBlockTimestamp = futureTimestamp;
+        this.latestNetworkBlockTimestamp = futureTimestamp;
       });
     }
 
@@ -283,39 +286,64 @@ export default class NetworkStatusStore extends Store {
         }
 
         // Update the local block height on each request
+        const lastLocalBlockHeight = this.localBlockHeight;
         this.localBlockHeight = localBlockchainHeight;
         Logger.debug('Local blockchain height: ' + localBlockchainHeight);
 
         // Update the network block height on each request
         const hasStartedReceivingBlocks = blockchainHeight > 0;
-        const lastBlockchainHeight = this.networkBlockHeight;
+        const lastNetworkBlockHeight = this.networkBlockHeight;
         this.networkBlockHeight = blockchainHeight;
         if (hasStartedReceivingBlocks) {
           Logger.debug('Network blockchain height: ' + blockchainHeight);
         }
 
-        // Check if the network's block height has ceased to change
-        const isBlockchainHeightIncreasing = (
-          hasStartedReceivingBlocks &&
-          this.networkBlockHeight > lastBlockchainHeight
-        );
+        // Check if the local block height has ceased to change
+        const isLocalBlockHeightIncreasing = this.localBlockHeight > lastLocalBlockHeight;
         if (
-          isBlockchainHeightIncreasing || // New block detected
-          this.mostRecentBlockTimestamp > Date.now() || // Guard against future timestamps
+          isLocalBlockHeightIncreasing || // New local block detected
+          this.latestLocalBlockTimestamp > Date.now() || // Guard against future timestamps
           ( // Guard against incorrect system time
             !this.isNodeTimeCorrect && !this.isSystemTimeIgnored
           )
         ) {
-          this.mostRecentBlockTimestamp = Date.now(); // Record latest block timestamp
+          this.latestLocalBlockTimestamp = Date.now(); // Record latest local block timestamp
         }
-        const timeSinceLastBlock = moment(Date.now()).diff(moment(this.mostRecentBlockTimestamp));
-        const isBlockchainHeightStalling = timeSinceLastBlock > MAX_ALLOWED_STALL_DURATION;
+        const latestLocalBlockAge = moment(
+          Date.now()).diff(moment(this.latestLocalBlockTimestamp)
+        );
+        const isLocalBlockHeightStalling = latestLocalBlockAge > MAX_ALLOWED_STALL_DURATION;
+        const isLocalBlockHeightSyncing = (
+          isLocalBlockHeightIncreasing || !isLocalBlockHeightStalling
+        );
+
+        // Check if the network's block height has ceased to change
+        const isNetworkBlockHeightIncreasing = (
+          hasStartedReceivingBlocks &&
+          this.networkBlockHeight > lastNetworkBlockHeight
+        );
+        if (
+          isNetworkBlockHeightIncreasing || // New network block detected
+          this.latestNetworkBlockTimestamp > Date.now() || // Guard against future timestamps
+          ( // Guard against incorrect system time
+            !this.isNodeTimeCorrect && !this.isSystemTimeIgnored
+          )
+        ) {
+          this.latestNetworkBlockTimestamp = Date.now(); // Record latest network block timestamp
+        }
+        const latestNetworkBlockAge = moment(
+          Date.now()).diff(moment(this.latestNetworkBlockTimestamp)
+        );
+        const isNetworkBlockHeightStalling = latestNetworkBlockAge > MAX_ALLOWED_STALL_DURATION;
+        const isNetworkBlockHeightSyncing = (
+          isNetworkBlockHeightIncreasing || !isNetworkBlockHeightStalling
+        );
 
         // Node is syncing in case we are receiving blocks and they are not stalling
         runInAction('update isNodeSyncing', () => {
           this.isNodeSyncing = (
             hasStartedReceivingBlocks &&
-            (isBlockchainHeightIncreasing || !isBlockchainHeightStalling)
+            (isLocalBlockHeightSyncing || isNetworkBlockHeightSyncing)
           );
         });
 


### PR DESCRIPTION
This PR improves blocks stalling detection logic by tracking both network and local block heights.
This way the "Network connection lost - reconnecting..." screen is **NOT** shown in case network block height is stalling while local block height is still increasing and vice versa. It will only be shown in case both block heights remain unchanged for more than 120 seconds.

## Screenshot:

![new](https://user-images.githubusercontent.com/376611/50631664-7ca72680-0f45-11e9-92f9-13db98028e7a.png)

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
