### PR TITLE
[DEVOPS-1203] Update cardano-sl to latest release/2.0.1

### DIFF
--- a/cardano-sl-src.json
+++ b/cardano-sl-src.json
@@ -1,6 +1,6 @@
 {
   "url": "https://github.com/input-output-hk/cardano-sl",
-  "rev": "6a13344867b285b93e27d9ae0b1dedef2b202ddd",
-  "sha256": "11cql2f3j33wc5ljp5r3r4nvn3s8kcy7578n11k1ynx04dwb2c9l",
+  "rev": "1d681492723592ee6e4bab411e2c67ccedf003ed",
+  "sha256": "1xhnnlgc2j6y0z988khw3r774xfbx35kdcc3dhibykfh6x1936pr",
   "fetchSubmodules": false
 }


### PR DESCRIPTION
Updates cardano-sl to latest `release/2.0.1`.

Appveyor build passes: https://ci.appveyor.com/project/input-output/daedalus/builds/21449642