### PR TITLE
[DDW-514] Improve NTP check UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 
 ### Features
 
+- Improve NTP check UX ([PR 1258](https://github.com/input-output-hk/daedalus/pull/1258))
 - Added support for "frontend-only" mode ([PR 1241](https://github.com/input-output-hk/daedalus/pull/1241))
 - Improved the lock-file UX by replacing "Daedalus is already running" dialog with focusing of the already running Daedalus instance ([PR 1229](https://github.com/input-output-hk/daedalus/pull/1229))
 - Replaced in-app support request with links to support page ([PR 1199](https://github.com/input-output-hk/daedalus/pull/1199))

--- a/source/renderer/app/components/status/NetworkStatus.js
+++ b/source/renderer/app/components/status/NetworkStatus.js
@@ -234,7 +234,7 @@ export default class NetworkStatus extends Component<Props, State> {
                   </span> |&nbsp;
                   <button
                     onClick={() => onForceCheckLocalTimeDifference()}
-                    disabled={isForceCheckingNodeTime}
+                    disabled={isForceCheckingNodeTime || !isConnected}
                   >
                     {isForceCheckingNodeTime ? 'Checking...' : 'Check time'}
                   </button>

--- a/source/renderer/app/config/timingConfig.js
+++ b/source/renderer/app/config/timingConfig.js
@@ -11,3 +11,4 @@ export const MAX_ALLOWED_STALL_DURATION = 2 * 60 * 1000; // 2 minutes | unit: mi
 export const NETWORK_STATUS_REQUEST_TIMEOUT = 30 * 1000; // 30 seconds | unit: milliseconds
 export const NETWORK_STATUS_POLL_INTERVAL = 2000; // 2 seconds | unit: milliseconds
 export const NTP_FORCE_CHECK_POLL_INTERVAL = 30 * 60 * 1000; // 30 minutes | unit: milliseconds
+export const NTP_IGNORE_CHECKS_GRACE_PERIOD = 10 * 1000; // 30 seconds | unit: milliseconds

--- a/source/renderer/app/config/timingConfig.js
+++ b/source/renderer/app/config/timingConfig.js
@@ -11,4 +11,4 @@ export const MAX_ALLOWED_STALL_DURATION = 2 * 60 * 1000; // 2 minutes | unit: mi
 export const NETWORK_STATUS_REQUEST_TIMEOUT = 30 * 1000; // 30 seconds | unit: milliseconds
 export const NETWORK_STATUS_POLL_INTERVAL = 2000; // 2 seconds | unit: milliseconds
 export const NTP_FORCE_CHECK_POLL_INTERVAL = 30 * 60 * 1000; // 30 minutes | unit: milliseconds
-export const NTP_IGNORE_CHECKS_GRACE_PERIOD = 10 * 1000; // 30 seconds | unit: milliseconds
+export const NTP_IGNORE_CHECKS_GRACE_PERIOD = 30 * 1000; // 30 seconds | unit: milliseconds

--- a/source/renderer/app/stores/NetworkStatusStore.js
+++ b/source/renderer/app/stores/NetworkStatusStore.js
@@ -10,6 +10,7 @@ import {
   NETWORK_STATUS_REQUEST_TIMEOUT,
   NETWORK_STATUS_POLL_INTERVAL,
   NTP_FORCE_CHECK_POLL_INTERVAL,
+  NTP_IGNORE_CHECKS_GRACE_PERIOD,
 } from '../config/timingConfig';
 import { UNSYNCED_BLOCKS_ALLOWED } from '../config/numbersConfig';
 import { Logger } from '../utils/logging';
@@ -100,6 +101,13 @@ export default class NetworkStatusStore extends Store {
     // Forced time difference check polling interval
     this._forceCheckTimeDifferencePollingInterval = setInterval(
       this.forceCheckLocalTimeDifference, NTP_FORCE_CHECK_POLL_INTERVAL
+    );
+
+    // Ignore system time checks for the first 30 seconds:
+    this.ignoreSystemTimeChecks();
+    setTimeout(
+      () => this.ignoreSystemTimeChecks(false),
+      NTP_IGNORE_CHECKS_GRACE_PERIOD
     );
   }
 
@@ -425,8 +433,8 @@ export default class NetworkStatusStore extends Store {
     }
   };
 
-  @action ignoreSystemTimeChecks = () => {
-    this.isSystemTimeIgnored = true;
+  @action ignoreSystemTimeChecks = (flag: boolean = true) => {
+    this.isSystemTimeIgnored = flag;
   };
 
   forceCheckLocalTimeDifference = () => {


### PR DESCRIPTION
This PR improves the user experience for the NTP check: When starting Daedalus there is a 30 seconds grace period for failing / not finished NTP checks before showing the big red warning screen. That improves the UX because atm the big red warning screen is for many users one of the first things they see when starting Daedalus, which is not a nice start (and unnecessary).

This PR also:
- prevents forced NTP checks while `isConnected = false` (including our forced NTP check poller)
- disables "Check time" link on the "Network Status" screen while `isConnected = false`
- triggers forced NTP check as soon as `isConnected` turns to `true` (regardless if we are connected for the first time or re-connected)

This new setup covers both of the currently broken scenarios:
1. Daedalus starts while being **disconnected** from the Internet and connects later on (this scenario is not fully functional yet due to a known Cardano issue which should be resolved soon:  https://iohk.myjetbrains.com/youtrack/issue/CDEC-659),
2. Daedalus starts while being **connected** to the Internet but then the connection is lost and restored.

In both of these cases once the connection is established Daedalus will trigger a forced NTP check which will remove the NTP error screen in case it was displayed during the offline period.
Since the Cardano node executes a forced NTP check on it's own every 30 mins, even if Daedalus doesn't execute a forced NTP check while being offline, eventually the `NTP service is unreachable` response will be received through our usual network-status calls. Running a forced NTP check once we are connected again prevents us from being stuck at the NTP error screen.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
