### PR TITLE
[DDW-558] Fix handling of the 'frontendOnlyMode'  variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 
 ### Features
 
-- Added support for "frontend-only" mode ([PR 1241](https://github.com/input-output-hk/daedalus/pull/1241))
+- Added support for "frontend-only" mode ([PR 1241](https://github.com/input-output-hk/daedalus/pull/1241), [PR 1260](https://github.com/input-output-hk/daedalus/pull/1260))
 - Improved the lock-file UX by replacing "Daedalus is already running" dialog with focusing of the already running Daedalus instance ([PR 1229](https://github.com/input-output-hk/daedalus/pull/1229))
 - Replaced in-app support request with links to support page ([PR 1199](https://github.com/input-output-hk/daedalus/pull/1199))
 - Improved the UX of inline editing fields (like wallet renaming) ([PR 1231](https://github.com/input-output-hk/daedalus/pull/1231))

--- a/shell.nix
+++ b/shell.nix
@@ -24,7 +24,7 @@ let
     (pkgs.lib.optional (systemStart != null) ".configuration.systemStart = ${toString systemStart}")
     (pkgs.lib.optional (cluster == "demo") ''.configuration.key = "default"'')
     (pkgs.lib.optional (fullExtraArgs != []) ''.nodeArgs += ${builtins.toJSON fullExtraArgs}'')
-    (pkgs.lib.optional (autoStartBackend == true) ''.frontendOnlyMode = false'')
+    (pkgs.lib.optional (autoStartBackend == true) ''.frontendOnlyMode = true'')
   ];
   patchesString = pkgs.lib.concatStringsSep " | " patches;
   launcherYamlWithStartTime = pkgs.runCommand "launcher-config.yaml" { buildInputs = [ pkgs.jq yaml2json ]; } ''

--- a/source/main/cardano/setup.js
+++ b/source/main/cardano/setup.js
@@ -1,6 +1,7 @@
 // @flow
 import { BrowserWindow } from 'electron';
 import { CardanoNode } from './CardanoNode';
+import { frontendOnlyMode } from '../config';
 import type { LauncherConfig } from '../config';
 import { setupFrontendOnlyMode } from './setupFrontendOnlyMode';
 import { setupCardanoNodeMode } from './setupCardanoNodeMode';
@@ -15,8 +16,6 @@ import { setupCardanoNodeMode } from './setupCardanoNodeMode';
 export const setupCardano = (
   launcherConfig: LauncherConfig, mainWindow: BrowserWindow
 ): ?CardanoNode => {
-  const { frontendOnlyMode } = launcherConfig;
-
   if (frontendOnlyMode) {
     return setupFrontendOnlyMode(mainWindow);
   }

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -60,6 +60,12 @@ export const ALLOWED_LAUNCHER_LOGS = new RegExp(/(launcher-)(\d{14}$)/);
 export const MAX_NODE_LOGS_ALLOWED = 3;
 export const MAX_LAUNCHER_LOGS_ALLOWED = 3;
 
+// We need to invert 'frontendOnlyMode' value received from the launcherConfig
+// as this variable has an opposite meaning from the launcher's perspective.
+// Launcher treats the 'frontendOnlyMode' set to 'true' as the case where Daedalus
+// takes the responsiblity for launching and managing the cardano-node.
+export const frontendOnlyMode = !launcherConfig.frontendOnlyMode;
+
 // CardanoNode config
 export const NODE_STARTUP_TIMEOUT = 5000;
 export const NODE_STARTUP_MAX_RETRIES = 5;


### PR DESCRIPTION
This PR fixes the handling of the `frontendOnlyMode` variable picked up from the `launcherConfig`.
Launcher treats this variable in an opposite way than what Daedalus code expects.
From the Launcher's perspective, setting `frontendOnlyMode` to `true` means that Launcher is responsible for launching only Daedalus and then Daedalus is responsible for launching the cardano-node. If `frontendOnlyMode` is set to `false`, Launcher tries to launch both Daedalus and cardano-node.
This is unexpected from Daedalus perspective as we treat `frontendOnlyMode` set to `true` as a case where Daedalus connects to manually started instances of cardano-node for advanced debugging purposes.

In order to avoid big refactorings on both ends (Launcher and Daedalus), @cleverca22 and @nikolaglumac agreed to invert the value of the `frontendOnlyMode` in Daedalus and leave the rest of the code on both ends intact.

## NOTE:
**THIS IS JUST A TEMPORARY FIX** as the real fix is to rename `frontendOnlyMode` variable in `launcherConfig` to `daedalusManagedCardanoNode` to avoid confusion and is to be implemented in a separate task: https://iohk.myjetbrains.com/youtrack/issue/DDW-561

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
