### PR TITLE
[DDW-540] Disables Context Menu for Non-Selectable Elements

### DIFF
--- a/source/main/preload.js
+++ b/source/main/preload.js
@@ -54,4 +54,16 @@ process.once('loaded', () => {
   global.eval = () => {
     throw new Error('This app does not support window.eval().');
   };
+
+  // elements containing data that can be copied using the context menu (right click)
+  // must have an attribute set as follows: data-type="selectable" or be an input element
+  global.document.addEventListener('contextmenu', event => {
+    const targetData = Object.values(event.target.dataset);
+    const dataIsSelectable = targetData.includes('selectable');
+    const targetIsInput = event.target.nodeName === 'INPUT';
+
+    if (dataIsSelectable || targetIsInput) { return true; }
+
+    event.preventDefault();
+  }, false);
 });


### PR DESCRIPTION
This PR adds an event listener to `preload.js` which disables the default behavior of the context menu following a right click. Only `input` elements and those specified as selectable using a `data-type="selectable"` attribute will retain access to the context menu for copying and pasting text.

- Here is an example of how one can make a non-input element selectable using the `data-type="selectable"` attribute. On line 60 of `WalletSummary.js`, I can make the wallet's name selectable like this:

```
<div data-type="selectable" className={styles.walletName}>{walletName}</div>
```
This is only an example and is not included as a change in this PR.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
