### PR TITLE
[DEVOPS-1237] Character encoding issues in Windows uninstaller

### DIFF
--- a/installers/common/WindowsInstaller.hs
+++ b/installers/common/WindowsInstaller.hs
@@ -51,20 +51,23 @@ writeUninstallerNSIS (Version fullVersion) installerConfig = do
     IO.writeFile "uninstaller.nsi" $ nsis $ do
         _ <- constantStr "Version" (str $ unpack fullVersion)
         _ <- constantStr "InstallDir" (str $ unpack $ installDirectory installerConfig)
-        mapM_ unsafeInjectGlobal
-          [ "LangString UninstallName ${LANG_ENGLISH} \"Uninstaller\""
-          , "LangString UninstallName ${LANG_JAPANESE} \"アンインストーラー\""
-          ]
-        -- TODO, the nsis library doesnt support translation vars
-        -- name "$InstallDir $(UninstallName) $Version"
-        unsafeInjectGlobal $ unpack ( "Name \"" <> (installDirectory installerConfig) <> " $(UninstallName) " <> (fullVersion) <> "\"")
-        outFile . str . encodeString $ tempDir </> "tempinstaller.exe"
         unsafeInjectGlobal "Unicode true"
-        unsafeInjectGlobal "!addplugindir \"nsis_plugins\\liteFirewall\\bin\""
-        unsafeInjectGlobal "SetCompress off"
 
         loadLanguage "English"
         loadLanguage "Japanese"
+
+        --mapM_ unsafeInjectGlobal
+        --  [ "LangString UninstallName ${LANG_ENGLISH} \"Uninstaller\""
+        --  , "LangString UninstallName ${LANG_JAPANESE} \"アンインストーラー\""
+        --  ]
+
+        name "$InstallDir Uninstaller $Version"
+        -- TODO, the nsis library doesnt support translation vars
+        -- name "$InstallDir $(UninstallName) $Version"
+        --unsafeInjectGlobal $ unpack ( "Name \"" <> (installDirectory installerConfig) <> " $(UninstallName) " <> (fullVersion) <> "\"")
+        outFile . str . encodeString $ tempDir </> "tempinstaller.exe"
+        unsafeInjectGlobal "!addplugindir \"nsis_plugins\\liteFirewall\\bin\""
+        unsafeInjectGlobal "SetCompress off"
 
         _ <- section "" [Required] $ do
             unsafeInject . T.unpack $ format ("WriteUninstaller \""%fp%"\"") ("c:\\uninstall.exe")


### PR DESCRIPTION
This PR fixes the uninstaller translations.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
