### PR TITLE
[DDW-581] Revert ada symbol images with unicode character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Features
 
-- Replaced ada symbol images with unicode character ([PR 1317](https://github.com/input-output-hk/daedalus/pull/1317))
+- Renamed Ada to its lowercase ada version ([PR 1317](https://github.com/input-output-hk/daedalus/pull/1317), [PR 1336](https://github.com/input-output-hk/daedalus/pull/1336))
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,9 @@ Changelog
 
 ## vNext
 
-### Features
-
-- Renamed Ada to its lowercase ada version ([PR 1317](https://github.com/input-output-hk/daedalus/pull/1317), [PR 1336](https://github.com/input-output-hk/daedalus/pull/1336))
-
 ### Chores
 
+- Replaced "Ada" with "ada" ([PR 1317](https://github.com/input-output-hk/daedalus/pull/1317), [PR 1336](https://github.com/input-output-hk/daedalus/pull/1336))
 - Improved the internal IPC communication ([PR 1332](https://github.com/input-output-hk/daedalus/pull/1332))
 - Improved Webpack 4 build performance ([PR 1320](https://github.com/input-output-hk/daedalus/pull/1320))
 

--- a/features/step_definitions/wallets-steps.js
+++ b/features/step_definitions/wallets-steps.js
@@ -441,7 +441,7 @@ Then(/^the latest transaction should show:$/, async function (table) {
   // Transaction amount includes transaction fees so we need to
   // substract them in order to get a match with expectedData.amountWithoutFees.
   // NOTE: we use "add()" as this is outgoing transaction and amount is a negative value!
-  const transactionAmount = new BigNumber(transactionAmounts[0].split(' ').shift());
+  const transactionAmount = new BigNumber(transactionAmounts[0]);
   const transactionAmountWithoutFees = transactionAmount.add(this.fees).toFormat(DECIMAL_PLACES_IN_ADA);
   expect(expectedData.amountWithoutFees).to.equal(transactionAmountWithoutFees);
 });
@@ -453,7 +453,7 @@ Then(/^the balance of "([^"]*)" wallet should be:$/, { timeout: 60000 }, async f
   const receiverWallet = getWalletByName.call(this, walletName);
   return this.client.waitUntil(async () => {
     const receiverWalletBalance = await this.client.getText(`.SidebarWalletsMenu_wallets .Wallet_${receiverWallet.id} .SidebarWalletMenuItem_info`);
-    return receiverWalletBalance === `${expectedData.balance} ₳`;
+    return receiverWalletBalance === `${expectedData.balance} ADA`;
   }, 60000);
 });
 

--- a/source/renderer/app/assets/images/ada-symbol-smallest-dark.inline.svg
+++ b/source/renderer/app/assets/images/ada-symbol-smallest-dark.inline.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="18px" height="20px" viewBox="0 0 18 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <g id="new_wallet_screen_summary" transform="translate(-1238.000000, -715.000000)" stroke="#5E6066" stroke-width="1.5">
+            <g id="amount-copy" transform="translate(760.000000, 460.000000)">
+                <g id="pending" transform="translate(60.000000, 246.000000)">
+                    <g id="ada-symbol-smallest-dark-copy" transform="translate(419.000000, 10.000000)">
+                        <polyline id="Path-2" stroke-linejoin="round" points="0.505531915 18 7.92 0 15.3344681 18"></polyline>
+                        <path d="M1.68510638,7.75 L14.1548936,7.75" id="Line"></path>
+                        <path d="M0,10.75 L15.84,10.75" id="Line-Copy"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/source/renderer/app/assets/images/ada-symbol.inline.svg
+++ b/source/renderer/app/assets/images/ada-symbol.inline.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="26px" viewBox="0 0 24 26" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="new_wallet_screen_transactions" transform="translate(-2458.000000, -713.000000)" stroke="#5E6066" stroke-width="2.6">
+            <g id="content" transform="translate(760.000000, 460.000000)">
+                <g id="transactions" transform="translate(0.000000, 140.000000)">
+                    <g id="today-list" transform="translate(0.000000, 64.000000)">
+                        <g id="list-item-1">
+                            <g id="money-right" transform="translate(1557.000000, 40.000000)">
+                                <g id="ada-symbol" transform="translate(143.000000, 11.000000)">
+                                    <polyline id="Path-2" points="0.631914894 22 9.9 0 19.1680851 22"></polyline>
+                                    <path d="M2.10638298,9.3 L17.693617,9.3" id="Line"></path>
+                                    <path d="M0,14.3 L19.8,14.3" id="Line-Copy"></path>
+                                </g>
+                            </g>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/source/renderer/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
+++ b/source/renderer/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.js
@@ -44,7 +44,7 @@ export default class AdaRedemptionSuccessOverlay extends Component<Props> {
         <SVGInline svg={successIcon} className={styles.icon} />
         <div className={styles.text}>
           <h1 className={styles.headline}>{intl.formatMessage(messages.headline)}</h1>
-          <div className={styles.amount}>{amount} <span>&#8371;</span></div>
+          <div className={styles.amount}>{amount} ADA</div>
           <Button
             className={styles.confirmButton}
             label={intl.formatMessage(messages.confirmButton)}

--- a/source/renderer/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.scss
+++ b/source/renderer/app/components/wallet/ada-redemption/AdaRedemptionSuccessOverlay.scss
@@ -38,10 +38,6 @@
   .amount {
     font-family: var(--font-medium);
     font-size: 28px;
-
-    span {
-      font-family: var(--font-light);
-    }
   }
 
   .confirmButton {

--- a/source/renderer/app/components/wallet/summary/WalletSummary.js
+++ b/source/renderer/app/components/wallet/summary/WalletSummary.js
@@ -5,6 +5,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import SVGInline from 'react-svg-inline';
 import classnames from 'classnames';
 import adaSymbolBig from '../../../assets/images/ada-symbol-big-dark.inline.svg';
+import adaSymbolSmallest from '../../../assets/images/ada-symbol-smallest-dark.inline.svg';
 import BorderedBox from '../../widgets/BorderedBox';
 import { DECIMAL_PLACES_IN_ADA } from '../../../config/numbersConfig';
 import type { UnconfirmedAmount } from '../../../types/unconfirmedAmountType';
@@ -76,14 +77,14 @@ export default class WalletSummary extends Component<Props> {
                 <div className={styles.pendingConfirmation}>
                   {`${intl.formatMessage(messages.pendingIncomingConfirmationLabel)}`}
                   : {pendingAmount.incoming.toFormat(DECIMAL_PLACES_IN_ADA)}
-                  &nbsp;&#8371;
+                  <SVGInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
                 </div>
               )}
               {pendingAmount.outgoing.greaterThan(0) && (
                 <div className={styles.pendingConfirmation}>
                   {`${intl.formatMessage(messages.pendingOutgoingConfirmationLabel)}`}
                   : {pendingAmount.outgoing.toFormat(DECIMAL_PLACES_IN_ADA)}
-                  &nbsp;&#8371;
+                  <SVGInline svg={adaSymbolSmallest} className={styles.currencySymbolSmallest} />
                 </div>
               )}
 

--- a/source/renderer/app/components/wallet/summary/WalletSummary.scss
+++ b/source/renderer/app/components/wallet/summary/WalletSummary.scss
@@ -52,6 +52,17 @@
 
 .pendingConfirmation {
   @extend %smallText;
+  & > .currencySymbolSmallest {
+    display: inline-block;
+    margin-left: 1px;
+    & > svg {
+      height: 10px;
+      width: 9px;
+      & > g > g {
+        stroke: var(--theme-icon-ada-summary-wallet-pending-confirmation-symbol-color);
+      }
+    }
+  }
 }
 
 .numberOfTransactions {

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -6,6 +6,7 @@ import SVGInline from 'react-svg-inline';
 import classNames from 'classnames';
 import styles from './Transaction.scss';
 import TransactionTypeIcon from './TransactionTypeIcon.js';
+import adaSymbol from '../../../assets/images/ada-symbol.inline.svg';
 import arrow from '../../../assets/images/collapse-arrow.inline.svg';
 import {
   transactionStates,
@@ -210,6 +211,7 @@ export default class Transaction extends Component<Props> {
 
     const status = intl.formatMessage(assuranceLevelTranslations[assuranceLevel]);
     const currency = intl.formatMessage(globalMessages.currency);
+    const symbol = adaSymbol;
 
     const transactionStateTag = () => {
       if (isRestoreActive) return;
@@ -251,7 +253,7 @@ export default class Transaction extends Component<Props> {
                   // hide currency (we are showing symbol instead)
                   formattedWalletAmount(data.amount, false)
                 }
-                <span>&nbsp;&#8371;</span>
+                <SVGInline svg={symbol} className={styles.currencySymbol} />
               </div>
             </div>
 

--- a/source/renderer/app/components/wallet/transactions/Transaction.scss
+++ b/source/renderer/app/components/wallet/transactions/Transaction.scss
@@ -84,10 +84,6 @@
   letter-spacing: 1px;
   margin-left: auto;
   user-select: text;
-
-  span {
-    font-family: var(--font-light);
-  }
 }
 
 .pendingLabel, .failedLabel, .low, .medium, .high {

--- a/source/renderer/app/i18n/global-messages.js
+++ b/source/renderer/app/i18n/global-messages.js
@@ -118,7 +118,7 @@ export default defineMessages({
   },
   unitAda: {
     id: 'global.unit.ada',
-    defaultMessage: '!!!\u20B3',
+    defaultMessage: '!!!ADA',
     description: 'Name for "ADA" unit.'
   },
   recoveryPhraseDialogTitle: {

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -3566,13 +3566,13 @@
         "description": "\"Outgoing pending confirmation\" label on Wallet summary page",
         "end": {
           "column": 3,
-          "line": 19
+          "line": 20
         },
         "file": "source/renderer/app/components/wallet/summary/WalletSummary.js",
         "id": "wallet.summary.page.pendingOutgoingConfirmationLabel",
         "start": {
           "column": 36,
-          "line": 15
+          "line": 16
         }
       },
       {
@@ -3580,13 +3580,13 @@
         "description": "\"Incoming pending confirmation\" label on Wallet summary page",
         "end": {
           "column": 3,
-          "line": 24
+          "line": 25
         },
         "file": "source/renderer/app/components/wallet/summary/WalletSummary.js",
         "id": "wallet.summary.page.pendingIncomingConfirmationLabel",
         "start": {
           "column": 36,
-          "line": 20
+          "line": 21
         }
       },
       {
@@ -3594,13 +3594,13 @@
         "description": "\"Number of transactions\" label on Wallet summary page",
         "end": {
           "column": 3,
-          "line": 29
+          "line": 30
         },
         "file": "source/renderer/app/components/wallet/summary/WalletSummary.js",
         "id": "wallet.summary.page.transactionsLabel",
         "start": {
           "column": 21,
-          "line": 25
+          "line": 26
         }
       }
     ],
@@ -3613,13 +3613,13 @@
         "description": "Transaction type shown for credit card payments.",
         "end": {
           "column": 3,
-          "line": 26
+          "line": 27
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.type.card",
         "start": {
           "column": 8,
-          "line": 22
+          "line": 23
         }
       },
       {
@@ -3627,13 +3627,13 @@
         "description": "Transaction type shown for {currency} transactions.",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 32
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.type",
         "start": {
           "column": 8,
-          "line": 27
+          "line": 28
         }
       },
       {
@@ -3641,13 +3641,13 @@
         "description": "Transaction type shown for money exchanges between currencies.",
         "end": {
           "column": 3,
-          "line": 36
+          "line": 37
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.type.exchange",
         "start": {
           "column": 12,
-          "line": 32
+          "line": 33
         }
       },
       {
@@ -3655,13 +3655,13 @@
         "description": "Transaction assurance level.",
         "end": {
           "column": 3,
-          "line": 41
+          "line": 42
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.assuranceLevel",
         "start": {
           "column": 18,
-          "line": 37
+          "line": 38
         }
       },
       {
@@ -3669,13 +3669,13 @@
         "description": "Transaction confirmations.",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 47
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.confirmations",
         "start": {
           "column": 17,
-          "line": 42
+          "line": 43
         }
       },
       {
@@ -3683,13 +3683,13 @@
         "description": "Transaction ID.",
         "end": {
           "column": 3,
-          "line": 51
+          "line": 52
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.transactionId",
         "start": {
           "column": 17,
-          "line": 47
+          "line": 48
         }
       },
       {
@@ -3697,13 +3697,13 @@
         "description": "Conversion rate.",
         "end": {
           "column": 3,
-          "line": 56
+          "line": 57
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.conversion.rate",
         "start": {
           "column": 18,
-          "line": 52
+          "line": 53
         }
       },
       {
@@ -3711,13 +3711,13 @@
         "description": "Label \"{currency} sent\" for the transaction.",
         "end": {
           "column": 3,
-          "line": 61
+          "line": 62
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.sent",
         "start": {
           "column": 8,
-          "line": 57
+          "line": 58
         }
       },
       {
@@ -3725,13 +3725,13 @@
         "description": "Label \"{currency} received\" for the transaction.",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 67
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.received",
         "start": {
           "column": 12,
-          "line": 62
+          "line": 63
         }
       },
       {
@@ -3739,13 +3739,13 @@
         "description": "From address",
         "end": {
           "column": 3,
-          "line": 71
+          "line": 72
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.address.from",
         "start": {
           "column": 15,
-          "line": 67
+          "line": 68
         }
       },
       {
@@ -3753,13 +3753,13 @@
         "description": "From addresses",
         "end": {
           "column": 3,
-          "line": 76
+          "line": 77
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.addresses.from",
         "start": {
           "column": 17,
-          "line": 72
+          "line": 73
         }
       },
       {
@@ -3767,13 +3767,13 @@
         "description": "To address",
         "end": {
           "column": 3,
-          "line": 81
+          "line": 82
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.address.to",
         "start": {
           "column": 13,
-          "line": 77
+          "line": 78
         }
       },
       {
@@ -3781,13 +3781,13 @@
         "description": "To addresses",
         "end": {
           "column": 3,
-          "line": 86
+          "line": 87
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.addresses.to",
         "start": {
           "column": 15,
-          "line": 82
+          "line": 83
         }
       },
       {
@@ -3795,13 +3795,13 @@
         "description": "Transaction amount.",
         "end": {
           "column": 3,
-          "line": 91
+          "line": 92
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.transactionAmount",
         "start": {
           "column": 21,
-          "line": 87
+          "line": 88
         }
       },
       {
@@ -3809,13 +3809,13 @@
         "description": "Transaction assurance level \"low\".",
         "end": {
           "column": 3,
-          "line": 99
+          "line": 100
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.assuranceLevel.low",
         "start": {
           "column": 34,
-          "line": 95
+          "line": 96
         }
       },
       {
@@ -3823,13 +3823,13 @@
         "description": "Transaction assurance level \"medium\".",
         "end": {
           "column": 3,
-          "line": 104
+          "line": 105
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.assuranceLevel.medium",
         "start": {
           "column": 37,
-          "line": 100
+          "line": 101
         }
       },
       {
@@ -3837,13 +3837,13 @@
         "description": "Transaction assurance level \"high\".",
         "end": {
           "column": 3,
-          "line": 109
+          "line": 110
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.assuranceLevel.high",
         "start": {
           "column": 35,
-          "line": 105
+          "line": 106
         }
       },
       {
@@ -3851,13 +3851,13 @@
         "description": "Transaction state \"pending\"",
         "end": {
           "column": 3,
-          "line": 117
+          "line": 118
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.state.pending",
         "start": {
           "column": 31,
-          "line": 113
+          "line": 114
         }
       },
       {
@@ -3865,13 +3865,13 @@
         "description": "Transaction state \"pending\"",
         "end": {
           "column": 3,
-          "line": 122
+          "line": 123
         },
         "file": "source/renderer/app/components/wallet/transactions/Transaction.js",
         "id": "wallet.transaction.state.failed",
         "start": {
           "column": 30,
-          "line": 118
+          "line": 119
         }
       }
     ],
@@ -5519,7 +5519,7 @@
         }
       },
       {
-        "defaultMessage": "!!!₳",
+        "defaultMessage": "!!!ADA",
         "description": "Name for \"ADA\" unit.",
         "end": {
           "column": 3,

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -65,7 +65,7 @@
   "global.passwordInstructions": "Note that password needs to be at least 7 characters long, and have at least 1 uppercase, 1 lowercase letter and 1 number.",
   "global.spendingPasswordLabel": "Spending Password",
   "global.spendingPasswordPlaceholder": "Password",
-  "global.unit.ada": "₳",
+  "global.unit.ada": "ADA",
   "inline.editing.dropdown.changesSaved": "Your changes have been saved",
   "inline.editing.input.cancel.label": "cancel",
   "inline.editing.input.change.label": "change",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -65,7 +65,7 @@
   "global.passwordInstructions": "パスワードは７文字以上であり、英字大文字、小文字、数字を含む必要があります。",
   "global.spendingPasswordLabel": "送金時のパスワード",
   "global.spendingPasswordPlaceholder": "パスワード",
-  "global.unit.ada": "₳",
+  "global.unit.ada": "ADA",
   "inline.editing.dropdown.changesSaved": "変更は保存されました",
   "inline.editing.input.cancel.label": "キャンセル",
   "inline.editing.input.change.label": "変更",

--- a/source/renderer/app/utils/formatters.js
+++ b/source/renderer/app/utils/formatters.js
@@ -8,7 +8,7 @@ export const formattedWalletAmount = (
 ) => {
   let formattedAmount = amount.toFormat(DECIMAL_PLACES_IN_ADA);
 
-  if (withCurrency) formattedAmount += ' ₳';
+  if (withCurrency) formattedAmount += ' ADA';
 
   return formattedAmount.toString();
 };


### PR DESCRIPTION
This PR reverts part of [PR 1317](https://github.com/input-output-hk/daedalus/pull/1317), which replaced ada symbol images with unicode character.

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
