### PR TITLE
[DDW-613] Settings screen shown during wallet-loading phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Changelog
 
 ### Fixes
 
-- Fixed link position in Japanese version of the Support page for downloading logs ([PR 1372](https://github.com/input-output-hk/daedalus/pull/1372))
+- Fixed the routing logic which allowed the display of "Settings" screens before the wallet data is fully loaded ([PR 1373](https://github.com/input-output-hk/daedalus/pull/1373))
+- Fixed the "download logs" link position in Japanese version of the "Support" screen ([PR 1372](https://github.com/input-output-hk/daedalus/pull/1372))
 
 ### Chores
 

--- a/source/renderer/app/Routes.js
+++ b/source/renderer/app/Routes.js
@@ -54,12 +54,15 @@ export const Routes = (
       <Route path={ROUTES.WALLETS.RECEIVE} component={WalletReceivePage} />
       <Route path={ROUTES.WALLETS.SETTINGS} component={WalletSettingsPage} />
     </Route>
-    <Route path="/settings" component={Settings}>
-      <IndexRedirect to="general" />
-      <Route path="general" component={GeneralSettingsPage} />
-      <Route path="terms-of-use" component={TermsOfUseSettingsPage} />
-      <Route path="support" component={SupportSettingsPage} />
-      <Route path="display" component={DisplaySettingsPage} />
+    <Route path={ROUTES.SETTINGS.ROOT} component={Settings}>
+      <IndexRedirect to={ROUTES.SETTINGS.GENERAL} />
+      <Route path={ROUTES.SETTINGS.GENERAL} component={GeneralSettingsPage} />
+      <Route
+        path={ROUTES.SETTINGS.TERMS_OF_USE}
+        component={TermsOfUseSettingsPage}
+      />
+      <Route path={ROUTES.SETTINGS.SUPPORT} component={SupportSettingsPage} />
+      <Route path={ROUTES.SETTINGS.DISPLAY} component={DisplaySettingsPage} />
     </Route>
     <Route
       path={ROUTES.PAPER_WALLET_CREATE_CERTIFICATE}

--- a/source/renderer/app/containers/Root.js
+++ b/source/renderer/app/containers/Root.js
@@ -14,7 +14,7 @@ export default class Root extends Component<Props> {
     const { stores, actions, children } = this.props;
     const { networkStatus, profile, adaRedemption, app, wallets } = stores;
     const { isBlockConsolidationStatusPage } = app;
-    const { isSettingsPage } = profile;
+    const { isProfilePage, isSettingsPage } = profile;
     const { isAdaRedemptionPage } = adaRedemption;
     const { hasLoadedWallets } = wallets;
     const {
@@ -27,7 +27,7 @@ export default class Root extends Component<Props> {
 
     const isPageThatDoesntNeedWallets =
       isBlockConsolidationStatusPage ||
-      (isAdaRedemptionPage && hasLoadedWallets && isSynced);
+      ((isAdaRedemptionPage || isSettingsPage) && hasLoadedWallets && isSynced);
 
     // In case node is in stopping sequence we must show the "Connecting" screen
     // with the "Stopping Cardano node..." and "Cardano node stopped" messages
@@ -37,7 +37,7 @@ export default class Root extends Component<Props> {
     // Just render any page that doesn't require wallets to be loaded or node to be connected
     if (
       (isPageThatDoesntNeedWallets && !isNodeInStoppingSequence) ||
-      (isSettingsPage && (isNotEnoughDiskSpace || !isNodeInStoppingSequence))
+      (isProfilePage && (isNotEnoughDiskSpace || !isNodeInStoppingSequence))
     ) {
       return React.Children.only(children);
     }

--- a/source/renderer/app/stores/ProfileStore.js
+++ b/source/renderer/app/stores/ProfileStore.js
@@ -175,12 +175,14 @@ export default class SettingsStore extends Store {
     return this.getDataLayerMigrationAcceptanceRequest.result === true;
   }
 
+  @computed get isProfilePage(): boolean {
+    const { currentRoute } = this.stores.app;
+    return includes(ROUTES.PROFILE, currentRoute);
+  }
+
   @computed get isSettingsPage(): boolean {
     const { currentRoute } = this.stores.app;
-    return (
-      includes(ROUTES.PROFILE, currentRoute) ||
-      includes(ROUTES.SETTINGS, currentRoute)
-    );
+    return includes(ROUTES.SETTINGS, currentRoute);
   }
 
   _getSystemLocale = async () => {


### PR DESCRIPTION
This PR fixes the routing logic which allowed the display of "Settings" screens before the wallet data is fully loaded.

[Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1553269152256100)

## How to test:

A) While being on the Settings screen use "Restart node" option from the Network status screen - the Settings screen should be restored only after Daedalus has loaded wallet data.

B) Test profile actions (setting language, terms of use), Check the display of "Node is shutting down" message etc...

---

## Review Checklist:

### Basics

- [ ] PR is updated to the most recent version of target branch (and there are no conflicts)
- [ ] PR has good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance tests are passing (`yarn run test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn run dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn run package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn run flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn run lint`)
- [ ] Text changes are proofread and approved (Jane Wild)
- [ ] There are no missing translations (running `yarn run manage:translations` produces no changes)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn run storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly documented and commented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-rendering
- [ ] Any code that only works in Electron is neatly separated from components

### Testing
- [ ] New feature / change is covered by acceptance tests
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature / change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review:
- [ ] Merge PR
- [ ] Delete source branch
- [ ] Move ticket to `done` on the Youtrack board
