### PR TITLE
[DDW-798] "1 confirmations" is displayed on Transaction Assurance Level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changelog
 
 ### Fixes
 
+- Fixed single/plural wording in "confirmation" word on Transaction Assurance Level ([PR 1531](https://github.com/input-output-hk/daedalus/pull/1531))
 - Fixed external and copy icons inconsistencies ([PR 1512](https://github.com/input-output-hk/daedalus/pull/1512))
 - Fixed broken wallets storybook stories ([PR 1473](https://github.com/input-output-hk/daedalus/pull/1473))
 - Implemented Storybook menu using queryStrings over localStorage ([PR 1426](https://github.com/input-output-hk/daedalus/pull/1426))

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -1,7 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { defineMessages, intlShape } from 'react-intl';
-import { observer, inject } from 'mobx-react';
+import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
 import moment from 'moment';
 import SVGInline from 'react-svg-inline';
 import classNames from 'classnames';
@@ -16,11 +15,9 @@ import {
   TxnAssuranceLevelOptions,
   WalletTransaction,
 } from '../../../domains/WalletTransaction';
-import { MAX_TRANSACTION_CONFIRMATIONS } from '../../../config/numbersConfig';
 import globalMessages from '../../../i18n/global-messages';
 import type { TransactionState } from '../../../api/transactions/types';
 import { getNetworkExplorerUrl } from '../../../utils/network';
-import type { StoresMap } from '../../../stores';
 
 /* eslint-disable consistent-return */
 
@@ -48,7 +45,8 @@ const messages = defineMessages({
   },
   confirmations: {
     id: 'wallet.transaction.confirmations',
-    defaultMessage: '!!!confirmations',
+    defaultMessage:
+      '{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}',
     description: 'Transaction confirmations.',
   },
   transactionId: {
@@ -132,7 +130,6 @@ const stateTranslations = defineMessages({
 type Props = {
   data: WalletTransaction,
   state: TransactionState,
-  stores: any | StoresMap,
   assuranceLevel: string,
   isExpanded: boolean,
   isRestoreActive: boolean,
@@ -143,11 +140,7 @@ type Props = {
   onOpenExternalLink: ?Function,
 };
 
-@inject('stores')
-@observer
 export default class Transaction extends Component<Props> {
-  static defaultProps = { stores: null };
-
   static contextTypes = {
     intl: intlShape.isRequired,
   };
@@ -165,25 +158,6 @@ export default class Transaction extends Component<Props> {
       onOpenExternalLink(link);
     }
   }
-
-  displayNumberOfConfirmations = (confirmations: number) => {
-    let text = Math.min(
-      confirmations,
-      MAX_TRANSACTION_CONFIRMATIONS
-    ).toLocaleString();
-    if (confirmations > MAX_TRANSACTION_CONFIRMATIONS) text += '+';
-    return text;
-  };
-
-  formatConfirmationsText = (confirmations: number) => {
-    const { stores } = this.props;
-    const locale = stores.profile.currentLocale;
-    const text = this.context.intl.formatMessage(messages.confirmations);
-    if (locale === 'en-US' && confirmations === 1) {
-      text.slice(0, -1);
-    }
-    return text;
-  };
 
   render() {
     const {
@@ -360,11 +334,12 @@ export default class Transaction extends Component<Props> {
                         {status}.&nbsp;
                       </span>
                     )}
-                    {this.displayNumberOfConfirmations(
-                      data.numberOfConfirmations
-                    )}
-                    &nbsp;
-                    {this.formatConfirmationsText(data.numberOfConfirmations)}
+                    <FormattedMessage
+                      {...messages.confirmations}
+                      values={{
+                        confirmationsNumber: data.numberOfConfirmations,
+                      }}
+                    />
                   </span>
                 ) : null}
               </div>

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -1,6 +1,7 @@
 // @flow
 import React, { Component } from 'react';
 import { defineMessages, intlShape } from 'react-intl';
+import { observer, inject } from 'mobx-react';
 import moment from 'moment';
 import SVGInline from 'react-svg-inline';
 import classNames from 'classnames';
@@ -140,6 +141,8 @@ type Props = {
   onOpenExternalLink: ?Function,
 };
 
+@inject('stores')
+@observer
 export default class Transaction extends Component<Props> {
   static contextTypes = {
     intl: intlShape.isRequired,
@@ -165,6 +168,16 @@ export default class Transaction extends Component<Props> {
       MAX_TRANSACTION_CONFIRMATIONS
     ).toLocaleString();
     if (confirmations > MAX_TRANSACTION_CONFIRMATIONS) text += '+';
+    return text;
+  };
+
+  formatConfirmationsText = (confirmations: number) => {
+    const { stores } = this.props;
+    const locale = stores.profile.currentLocale;
+    let text = this.context.intl.formatMessage(messages.confirmations);
+    if (locale === 'en-US' && confirmations === 1) {
+      text.slice(0, -1);
+    }
     return text;
   };
 
@@ -347,7 +360,9 @@ export default class Transaction extends Component<Props> {
                       data.numberOfConfirmations
                     )}
                     &nbsp;
-                    {intl.formatMessage(messages.confirmations)}.
+                    {this.formatConfirmationsText(
+                      data.numberOfConfirmations
+                    )}
                   </span>
                 ) : null}
               </div>

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
   confirmations: {
     id: 'wallet.transaction.confirmations',
     defaultMessage:
-      '{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}',
+      '{confirmationsNumber, plural, one {# confirmation} =21 {20+ confirmations} other {# confirmations}}',
     description: 'Transaction confirmations.',
   },
   transactionId: {

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -144,6 +144,8 @@ type Props = {
 @inject('stores')
 @observer
 export default class Transaction extends Component<Props> {
+  static defaultProps = { stores: null };
+
   static contextTypes = {
     intl: intlShape.isRequired,
   };
@@ -174,7 +176,7 @@ export default class Transaction extends Component<Props> {
   formatConfirmationsText = (confirmations: number) => {
     const { stores } = this.props;
     const locale = stores.profile.currentLocale;
-    let text = this.context.intl.formatMessage(messages.confirmations);
+    const text = this.context.intl.formatMessage(messages.confirmations);
     if (locale === 'en-US' && confirmations === 1) {
       text.slice(0, -1);
     }

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -20,6 +20,7 @@ import { MAX_TRANSACTION_CONFIRMATIONS } from '../../../config/numbersConfig';
 import globalMessages from '../../../i18n/global-messages';
 import type { TransactionState } from '../../../api/transactions/types';
 import { getNetworkExplorerUrl } from '../../../utils/network';
+import type { StoresMap } from '../../../stores';
 
 /* eslint-disable consistent-return */
 
@@ -131,6 +132,7 @@ const stateTranslations = defineMessages({
 type Props = {
   data: WalletTransaction,
   state: TransactionState,
+  stores: any | StoresMap,
   assuranceLevel: string,
   isExpanded: boolean,
   isRestoreActive: boolean,

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -46,7 +46,7 @@ const messages = defineMessages({
   confirmations: {
     id: 'wallet.transaction.confirmations',
     defaultMessage:
-      '{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}',
+      '{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}',
     description: 'Transaction confirmations.',
   },
   transactionId: {

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -364,9 +364,7 @@ export default class Transaction extends Component<Props> {
                       data.numberOfConfirmations
                     )}
                     &nbsp;
-                    {this.formatConfirmationsText(
-                      data.numberOfConfirmations
-                    )}
+                    {this.formatConfirmationsText(data.numberOfConfirmations)}
                   </span>
                 ) : null}
               </div>

--- a/source/renderer/app/i18n/locales/de-DE.json
+++ b/source/renderer/app/i18n/locales/de-DE.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!confirmations",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/de-DE.json
+++ b/source/renderer/app/i18n/locales/de-DE.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/de-DE.json
+++ b/source/renderer/app/i18n/locales/de-DE.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {20+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "high",
   "wallet.transaction.assuranceLevel.low": "low",
   "wallet.transaction.assuranceLevel.medium": "medium",
-  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "Conversion rate",
   "wallet.transaction.received": "{currency} received",
   "wallet.transaction.sent": "{currency} sent",

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "high",
   "wallet.transaction.assuranceLevel.low": "low",
   "wallet.transaction.assuranceLevel.medium": "medium",
-  "wallet.transaction.confirmations": "confirmations",
+  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "Conversion rate",
   "wallet.transaction.received": "{currency} received",
   "wallet.transaction.sent": "{currency} sent",

--- a/source/renderer/app/i18n/locales/hr-HR.json
+++ b/source/renderer/app/i18n/locales/hr-HR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!visok",
   "wallet.transaction.assuranceLevel.low": "!!!nizak",
   "wallet.transaction.assuranceLevel.medium": "!!!srednji",
-  "wallet.transaction.confirmations": "!!!potvrda",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# potvrda} >20 {#+ potvrda} other {# potvrda}}",
   "wallet.transaction.conversion.rate": "!!!Tečajna stopa",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/hr-HR.json
+++ b/source/renderer/app/i18n/locales/hr-HR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!visok",
   "wallet.transaction.assuranceLevel.low": "!!!nizak",
   "wallet.transaction.assuranceLevel.medium": "!!!srednji",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# potvrda} =21 {#+ potvrda} other {# potvrda}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# potvrda} =21 {20+ potvrda} other {# potvrda}}",
   "wallet.transaction.conversion.rate": "!!!Tečajna stopa",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/hr-HR.json
+++ b/source/renderer/app/i18n/locales/hr-HR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!visok",
   "wallet.transaction.assuranceLevel.low": "!!!nizak",
   "wallet.transaction.assuranceLevel.medium": "!!!srednji",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# potvrda} >20 {#+ potvrda} other {# potvrda}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# potvrda} =21 {#+ potvrda} other {# potvrda}}",
   "wallet.transaction.conversion.rate": "!!!Tečajna stopa",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "高",
   "wallet.transaction.assuranceLevel.low": "低",
   "wallet.transaction.assuranceLevel.medium": "中",
-  "wallet.transaction.confirmations": "確認",
+  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# 確認} >20 {#+ 確認} other {# 確認}}",
   "wallet.transaction.conversion.rate": "両替率",
   "wallet.transaction.received": "{currency}受取済み",
   "wallet.transaction.sent": "{currency}送金済み",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "高",
   "wallet.transaction.assuranceLevel.low": "低",
   "wallet.transaction.assuranceLevel.medium": "中",
-  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# 確認} =21 {#+ 確認} other {# 確認}}",
+  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# 確認} =21 {20+ 確認} other {# 確認}}",
   "wallet.transaction.conversion.rate": "両替率",
   "wallet.transaction.received": "{currency}受取済み",
   "wallet.transaction.sent": "{currency}送金済み",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "高",
   "wallet.transaction.assuranceLevel.low": "低",
   "wallet.transaction.assuranceLevel.medium": "中",
-  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# 確認} >20 {#+ 確認} other {# 確認}}",
+  "wallet.transaction.confirmations": "{confirmationsNumber, plural, one {# 確認} =21 {#+ 確認} other {# 確認}}",
   "wallet.transaction.conversion.rate": "両替率",
   "wallet.transaction.received": "{currency}受取済み",
   "wallet.transaction.sent": "{currency}送金済み",

--- a/source/renderer/app/i18n/locales/ko-KR.json
+++ b/source/renderer/app/i18n/locales/ko-KR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!confirmations",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/ko-KR.json
+++ b/source/renderer/app/i18n/locales/ko-KR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/ko-KR.json
+++ b/source/renderer/app/i18n/locales/ko-KR.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {20+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/zh-CN.json
+++ b/source/renderer/app/i18n/locales/zh-CN.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!confirmations",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/zh-CN.json
+++ b/source/renderer/app/i18n/locales/zh-CN.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} >20 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",

--- a/source/renderer/app/i18n/locales/zh-CN.json
+++ b/source/renderer/app/i18n/locales/zh-CN.json
@@ -571,7 +571,7 @@
   "wallet.transaction.assuranceLevel.high": "!!!high",
   "wallet.transaction.assuranceLevel.low": "!!!low",
   "wallet.transaction.assuranceLevel.medium": "!!!medium",
-  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {#+ confirmations} other {# confirmations}}",
+  "wallet.transaction.confirmations": "!!!{confirmationsNumber, plural, one {# confirmation} =21 {20+ confirmations} other {# confirmations}}",
   "wallet.transaction.conversion.rate": "!!!Conversion rate",
   "wallet.transaction.received": "!!!{currency} received",
   "wallet.transaction.sent": "!!!{currency} sent",


### PR DESCRIPTION
This PR fixes the small issue with message display for amount of confirmations. When there is only 1 transaction confirmation it will display "1 confirmation" instead of "1 confirmations" as it was until now.

## Screenshots

<img width="1148" alt="Screenshot 2019-08-12 06 44 17" src="https://user-images.githubusercontent.com/15862062/62862829-a5a64b80-bccc-11e9-8f01-82a52891b489.png">

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1565610787181300)
- [ ] Test if there is a change in single/plural in word "confirmation" based on the number of confirmations

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
