### PR TITLE
[DDW-997] Disable create a paper wallet certificate feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changelog
 
 ### Chores
 
+- Disabled create a paper wallet certificate feature ([PR 1640](https://github.com/input-output-hk/daedalus/pull/1640))
 - Removed all notions of account indexes from the codebase ([PR 1614](https://github.com/input-output-hk/daedalus/pull/1614))
 - Removed "Block consolidation status" dialog ([PR 1610](https://github.com/input-output-hk/daedalus/pull/1610))
 

--- a/source/renderer/app/components/sidebar/Sidebar.js
+++ b/source/renderer/app/components/sidebar/Sidebar.js
@@ -24,6 +24,7 @@ type Props = {
   onActivateCategory: Function,
   onOpenDialog: Function,
   onAddWallet: Function,
+  isIncentivizedTestnet: boolean,
 };
 
 export type SidebarMenus = ?{
@@ -45,17 +46,28 @@ export default class Sidebar extends Component<Props> {
   render() {
     const {
       menus,
-      categories,
       activeSidebarCategory,
       pathname,
       isShowingSubMenus,
       onAddWallet,
+      isIncentivizedTestnet,
     } = this.props;
+
+    let { categories } = this.props;
+
     let subMenu = null;
 
     const walletsCategory = find(categories, {
       name: CATEGORIES_BY_NAME.WALLETS.name,
     }).route;
+
+    if (isIncentivizedTestnet) {
+      categories = categories.filter(
+        category =>
+          category.name !==
+          CATEGORIES_BY_NAME.PAPER_WALLET_CREATE_CERTIFICATE.name
+      );
+    }
 
     if (menus && activeSidebarCategory === walletsCategory) {
       subMenu = (

--- a/source/renderer/app/containers/MainLayout.js
+++ b/source/renderer/app/containers/MainLayout.js
@@ -20,7 +20,7 @@ export default class MainLayout extends Component<InjectedContainerProps> {
 
   render() {
     const { actions, stores } = this.props;
-    const { sidebar, wallets, profile, app } = stores;
+    const { sidebar, wallets, profile, app, networkStatus } = stores;
     const activeWallet = wallets.active;
     const activeWalletId = activeWallet ? activeWallet.id : null;
     const { currentTheme } = profile;
@@ -47,6 +47,7 @@ export default class MainLayout extends Component<InjectedContainerProps> {
       <Sidebar
         menus={sidebarMenus}
         isShowingSubMenus={sidebar.isShowingSubMenus}
+        isIncentivizedTestnet={networkStatus.isIncentivizedTestnet}
         categories={sidebar.CATEGORIES}
         activeSidebarCategory={sidebar.activeSidebarCategory}
         onActivateCategory={category => {

--- a/storybook/stories/Sidebar.stories.js
+++ b/storybook/stories/Sidebar.stories.js
@@ -75,6 +75,7 @@ storiesOf('Sidebar', module)
       pathname="/"
       currentTheme={currentTheme}
       network="testnet"
+      isIncentivizedTestnet
     />
   ))
   .add('wallets category', () => (
@@ -90,6 +91,7 @@ storiesOf('Sidebar', module)
       pathname="/"
       currentTheme={currentTheme}
       network="testnet"
+      isIncentivizedTestnet
     />
   ))
   .add('wallets / sub', () => (
@@ -106,6 +108,7 @@ storiesOf('Sidebar', module)
       pathname="/"
       currentTheme={currentTheme}
       network="testnet"
+      isIncentivizedTestnet
     />
   ))
   .add('delegation category', () => (
@@ -121,6 +124,7 @@ storiesOf('Sidebar', module)
       pathname="/"
       currentTheme={currentTheme}
       network="testnet"
+      isIncentivizedTestnet
     />
   ))
   .add('decentralization-progress', () => (
@@ -136,5 +140,6 @@ storiesOf('Sidebar', module)
       pathname="/"
       currentTheme={currentTheme}
       network="testnet"
+      isIncentivizedTestnet
     />
   ));

--- a/storybook/stories/support/StoryLayout.js
+++ b/storybook/stories/support/StoryLayout.js
@@ -158,6 +158,7 @@ export default class StoryLayout extends Component<Props> {
         pathname="/"
         currentTheme={currentTheme}
         network="testnet"
+        isIncentivizedTestnet
       />
     );
   };


### PR DESCRIPTION
This PR removes the create paper wallet certificate feature from the sidemenu for Incentivized testnet.


## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1572964424326100)
- [ ] Test if another wallet restoration can be done during already running wallet restoration process

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
