### PR TITLE
Only create block0.bin when running in selfnode mode

### DIFF
--- a/source/main/cardano/CardanoWalletLauncher.js
+++ b/source/main/cardano/CardanoWalletLauncher.js
@@ -15,7 +15,14 @@ export type WalletOpts = {
 export async function CardanoWalletLauncher(
   walletOpts: WalletOpts
 ): Promise<ChildProcess> {
-  const { logStream, nodeImplementation, cliBin, stateDir, path } = walletOpts;
+  const {
+    logStream,
+    nodeImplementation,
+    cliBin,
+    stateDir,
+    path,
+    walletArgs,
+  } = walletOpts;
 
   // This switch statement handles any node specifc
   // configuration, prior to spawning the child process
@@ -23,12 +30,16 @@ export async function CardanoWalletLauncher(
     case 'cardano-node':
       break;
     case 'jormungandr':
-      await configureJormungandrDeps(cliBin, stateDir);
+      // This configuration is for the selfnode only
+      // The selfnode is identified by the unique genesis-block wallet arg
+      if (walletArgs.findIndex(arg => arg === '--genesis-block') > -1) {
+        await configureJormungandrDeps(cliBin, stateDir);
+      }
       break;
     default:
       break;
   }
 
   const walletStdio: string[] = ['inherit', logStream, logStream, 'ipc'];
-  return spawn(path, walletOpts.walletArgs, { stdio: walletStdio });
+  return spawn(path, walletArgs, { stdio: walletStdio });
 }


### PR DESCRIPTION
Selfnode is identified by the unique `genesis-block` walletArg. Other cluster modes us `genesis-block-hash`, so this should be relatively reliable