### PR TITLE
[DDW-1162] 2.0.1-INT1 preparation - Windows fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 ### Chores
 - Updated `cardano-wallet` to revision `992161dff5aa11c86c80238a1ddf3c8674ce75f3`
 
+## 2.0.0-ITN1
+
 ### Features
 
 - Added stake pool metadata registry for "SelfNode" network ([PR 1771](https://github.com/input-output-hk/daedalus/pull/1771/))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 ## 2.0.1-ITN1
 
 ### Chores
-- Updated `cardano-wallet` to revision `992161dff5aa11c86c80238a1ddf3c8674ce75f3`
+
+- Updated `cardano-wallet` to revision `398565cc1a65553827834520c5a95827a7c48d41`
 
 ## 2.0.0-ITN1
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "992161dff5aa11c86c80238a1ddf3c8674ce75f3",
-        "sha256": "01n1c3mg2ar2jbdknrqkwdbb4r4a9qjhb8qfz8yjf7y0rj5c4k1p",
+        "rev": "a420d48f9f13580a6359cf075117041d13091c9f",
+        "sha256": "1araz0p1cm6r55kaw06ysk5cs3rcxd3i0yvwgyajrcaqr6y3w5pm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/992161dff5aa11c86c80238a1ddf3c8674ce75f3.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/a420d48f9f13580a6359cf075117041d13091c9f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "v2019-12-16"
     },

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "a420d48f9f13580a6359cf075117041d13091c9f",
-        "sha256": "1araz0p1cm6r55kaw06ysk5cs3rcxd3i0yvwgyajrcaqr6y3w5pm",
+        "rev": "398565cc1a65553827834520c5a95827a7c48d41",
+        "sha256": "1fq8hjwqnajlz7g09zihmzhjc3hyyjl685nr5qa4r2fqnjzq5i24",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/a420d48f9f13580a6359cf075117041d13091c9f.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/398565cc1a65553827834520c5a95827a7c48d41.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "v2019-12-16"
     },


### PR DESCRIPTION
This PR updates `cardano-wallet` dependency to v2019-12-23 (`398565cc1a65553827834520c5a95827a7c48d41`) with a fix for Windows migration issue.
