### PR TITLE
Merge release/2.1.0-ITN1 into v2-integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changelog
 - Improved the paper wallet recovery phrase validation ([PR 1818](https://github.com/input-output-hk/daedalus/pull/1818))
 - Improved network screen with responsive main copy box ([PR 1797](https://github.com/input-output-hk/daedalus/pull/1797))
 - Updated checkboxes, radio buttons and switchers sizes and borders ([PR 1793](https://github.com/input-output-hk/daedalus/pull/1793))
+- Updated `cardano-wallet` to revision `b89cfa19` which includes Jormungandr 0.8.9 ([PR 1834](https://github.com/input-output-hk/daedalus/pull/1834))
 - Updated `cardano-wallet` to revision `23e12d1a` which includes Jormungandr 0.8.7 ([PR 1828](https://github.com/input-output-hk/daedalus/pull/1828))
 - Updated `cardano-wallet` to revision `d188a5fc` ([PR 1825](https://github.com/input-output-hk/daedalus/pull/1825))
 - Updated `cardano-wallet` to revision `e6316404` ([PR 1826](https://github.com/input-output-hk/daedalus/pull/1826))

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "23e12d1a26d282bf4acf9d8df3de9803e7e9baf5",
-        "sha256": "0w2a81ys6rk4bgs6gwi2wdaflaplrh2zrzw9baf9492v0n1gyfm8",
+        "rev": "b89cfa19255e13e15b9de18ae92bed863965f4f2",
+        "sha256": "1pw39z078c6mg6axzh9p4xx0x989kp9w5csizzj2zw22821y67rv",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/23e12d1a26d282bf4acf9d8df3de9803e7e9baf5.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/b89cfa19255e13e15b9de18ae92bed863965f4f2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "v2020-01-27"
     },


### PR DESCRIPTION
This PR merges the latest `release/2.1.0-ITN1` into `v2-integration` branch with the only change https://github.com/input-output-hk/daedalus/pull/1834