### PR TITLE
[DDW-1232] Fix stake pool rank color within the stake pool tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixes
 
+- Fixed stake pool rank coloring within the stake pool tooltip ([PR 1891](https://github.com/input-output-hk/daedalus/pull/1891))
 - Fixed missing notarization on macOS installers ([PR 1890](https://github.com/input-output-hk/daedalus/pull/1890))
 - Fixed issues with loading stake pools on the "Stake pools" screen ([PR 1888](https://github.com/input-output-hk/daedalus/pull/1888))
 

--- a/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.js
@@ -193,6 +193,7 @@ export class StakePoolThumbnail extends Component<Props, State> {
             onSelect={this.handleSelect}
             showWithSelectButton={showWithSelectButton}
             containerClassName={containerClassName}
+            numberOfStakePools={numberOfStakePools}
           />
         )}
       </div>

--- a/source/renderer/app/components/staking/stake-pools/StakePoolTooltip.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolTooltip.js
@@ -113,6 +113,7 @@ type Props = {
   left: number,
   color: string,
   containerClassName: string,
+  numberOfStakePools: number,
 };
 
 type State = {
@@ -382,6 +383,7 @@ export default class StakePoolTooltip extends Component<Props, State> {
       getPledgeAddressUrl,
       onSelect,
       showWithSelectButton,
+      numberOfStakePools,
     } = this.props;
 
     const {
@@ -479,7 +481,11 @@ export default class StakePoolTooltip extends Component<Props, State> {
             <dd className={styles.ranking}>
               <span
                 style={{
-                  background: getColorFromRange(ranking, { darken, alpha }),
+                  background: getColorFromRange(ranking, {
+                    darken,
+                    alpha,
+                    numberOfItems: numberOfStakePools,
+                  }),
                 }}
               >
                 {ranking}


### PR DESCRIPTION
This PR fixes the wrong rank background color within the stake pool tooltip.
Before this fix the number of stake pools was not taken into account when generating the background for the rank within the tooltip, unlike for the one on the stake pool tile/thumbnail.

## Screenshots

![Screenshot 2020-03-17 at 11 06 57](https://user-images.githubusercontent.com/376611/76848064-55373380-6843-11ea-95de-1921d703555a.png)
![Screenshot 2020-03-17 at 11 06 59](https://user-images.githubusercontent.com/376611/76848066-55cfca00-6843-11ea-9672-a682d015474f.png)
![Screenshot 2020-03-17 at 11 07 02](https://user-images.githubusercontent.com/376611/76848070-56686080-6843-11ea-8a11-84f0e231e731.png)


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
