### PR TITLE
[DDW-100] Generate an address after creating a Byron wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Chores
+
+- Implemented generation of an Byron wallet address after creating a Byron wallet ([PR 1943](https://github.com/input-output-hk/daedalus/pull/1943))
+
 ## 1.0.0-FC1
 
 ### Features

--- a/source/renderer/app/api/api.js
+++ b/source/renderer/app/api/api.js
@@ -546,6 +546,24 @@ export default class AdaApi {
           { walletInitData },
           'random'
         );
+
+        if (legacyWallet) {
+          const { id } = legacyWallet;
+          const account = await this.getAddresses({
+            walletId: id,
+            isLegacy: true,
+          });
+          const { accountIndex } = account;
+          const { passphrase } = walletInitData;
+          const address: Address = await createByronWalletAddress(this.config, {
+            passphrase,
+            walletId: id,
+            addressIndex: accountIndex,
+          });
+          logger.debug('AdaApi::createAddress (Byron) success', { address });
+          _createAddressFromServerData(address);
+        }
+
         const extraLegacyWalletProps = {
           address_pool_gap: 0, // Not needed for legacy wallets
           delegation: {

--- a/source/renderer/app/api/api.js
+++ b/source/renderer/app/api/api.js
@@ -549,17 +549,19 @@ export default class AdaApi {
 
         if (legacyWallet) {
           const { id } = legacyWallet;
+          // $FlowFixMe
           const account = await this.getAddresses({
             walletId: id,
             isLegacy: true,
           });
-          const { accountIndex } = account;
           const { passphrase } = walletInitData;
-          const address: Address = await createByronWalletAddress(this.config, {
+          const { addressIndex } = account;
+          let data = {
             passphrase,
             walletId: id,
-            addressIndex: accountIndex,
-          });
+          };
+          data = addressIndex ? { ...data, addressIndex } : data;
+          const address: Address = await createByronWalletAddress(this.config, data);
           logger.debug('AdaApi::createAddress (Byron) success', { address });
           _createAddressFromServerData(address);
         }

--- a/source/renderer/app/api/api.js
+++ b/source/renderer/app/api/api.js
@@ -547,24 +547,13 @@ export default class AdaApi {
           'random'
         );
 
-        if (legacyWallet) {
-          const { id } = legacyWallet;
-          // $FlowFixMe
-          const account = await this.getAddresses({
-            walletId: id,
-            isLegacy: true,
-          });
-          const { passphrase } = walletInitData;
-          const { addressIndex } = account;
-          let data = {
-            passphrase,
-            walletId: id,
-          };
-          data = addressIndex ? { ...data, addressIndex } : data;
-          const address: Address = await createByronWalletAddress(this.config, data);
-          logger.debug('AdaApi::createAddress (Byron) success', { address });
-          _createAddressFromServerData(address);
-        }
+        // Genearte address for the newly created Byron wallet
+        const { id: walletId } = legacyWallet;
+        const address: Address = await createByronWalletAddress(this.config, {
+          passphrase: spendingPassword,
+          walletId,
+        });
+        logger.debug('AdaApi::createAddress (Byron) success', { address });
 
         const extraLegacyWalletProps = {
           address_pool_gap: 0, // Not needed for legacy wallets

--- a/source/renderer/app/stores/WalletsStore.js
+++ b/source/renderer/app/stores/WalletsStore.js
@@ -487,6 +487,7 @@ export default class WalletsStore extends Store {
       await this._patchWalletRequestWithNewWallet(wallet);
       this.actions.dialogs.closeActiveDialog.trigger();
       this.goToWalletRoute(wallet.id);
+      this.refreshWalletsData();
     }
   };
 


### PR DESCRIPTION
This PR implements generation of an Byron wallet address after creating a Byron wallet

## Screenshots

<img width="1147" alt="Screenshot 2020-04-02 09 35 36" src="https://user-images.githubusercontent.com/15862062/78268465-73e52d80-74c5-11ea-9243-2796131ce8d0.png">

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1585842011289400)
- [ ] Test creation of the new wallet and inspect if the address is created and assigned to that wallet after wallet creation.

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
