### PR TITLE
[DDW] Bump Daedalus version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## vNext
+## 1.0.0-FC5
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "1.0.0-FC4",
+  "version": "1.0.0-FC5",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps Daedalus version to `1.0.0-FC5`.
