### PR TITLE
Bumps Daedalus version to 1.2.0-FC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## vNext
+## 1.2.0-FC1
 
 ### Fixes
 
@@ -11,6 +11,7 @@ Changelog
 
 ### Chores
 
+- Bump Daedalus version ([PR 2018](https://github.com/input-output-hk/daedalus/pull/2018))
 - Consolidated Japanese translations ([PR 2003](https://github.com/input-output-hk/daedalus/pull/2003))
 - Prevented import for more than maximum number of wallets ([PR 2012](https://github.com/input-output-hk/daedalus/pull/2012))
 - Implemented automated tests for wallet migration and import features ([PR 2011](https://github.com/input-output-hk/daedalus/pull/2011))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "1.1.0",
+  "version": "1.2.0-FC1",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
This PR bumps Daedalus version to `1.2.0-FC1`.