### PR TITLE
Hide stake pool saturation info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Features
 
+- Removed stake pool saturation info ([PR 2067](https://github.com/input-output-hk/daedalus/pull/2067))
 - Implemented calculation of wallet's total rewards ([PR 2066](https://github.com/input-output-hk/daedalus/pull/2066))
 - Added display of transaction withdrawals within transaction details ([PR 2065](https://github.com/input-output-hk/daedalus/pull/2065))
 - Implemented the Redeem Incentivized testnet rewards feature ([PR 2042](https://github.com/input-output-hk/daedalus/pull/2042))

--- a/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.js
@@ -103,7 +103,7 @@ export class StakePoolThumbnail extends Component<Props, State> {
       disabledStakePoolId,
     } = this.props;
     const { top, left } = this.state;
-
+    const showSaturation = false;
     const { ranking, ticker, retiring, id, saturation } = stakePool;
     const color = getColorFromRange(ranking, numberOfStakePools);
     const isDisabled = disabledStakePoolId === id;
@@ -118,6 +118,7 @@ export class StakePoolThumbnail extends Component<Props, State> {
       isHighlighted ? styles.isHighlighted : null,
       onHover ? styles.isOnHover : null,
       isDisabled ? styles.disabled : null,
+      !showSaturation ? styles.hideSaturation : null,
     ]);
 
     const saturationClassnames = classnames([
@@ -154,13 +155,15 @@ export class StakePoolThumbnail extends Component<Props, State> {
               <div className={styles.ranking} style={{ color }}>
                 {ranking}
               </div>
-              <div className={saturationClassnames}>
-                <span
-                  style={{
-                    width: `${parseFloat(saturation.toFixed(2))}%`,
-                  }}
-                />
-              </div>
+              {showSaturation && (
+                <div className={saturationClassnames}>
+                  <span
+                    style={{
+                      width: `${parseFloat(saturation.toFixed(2))}%`,
+                    }}
+                  />
+                </div>
+              )}
             </>
           )}
 

--- a/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.scss
@@ -29,10 +29,14 @@
   }
 
   &.hideSaturation {
-    padding-top: 14px;
+    padding-top: 11px;
+
+    .ticker {
+      margin-bottom: 5px;
+    }
 
     .checkmarkWrapper {
-      margin-top: 5px;
+      margin-top: 7px;
     }
   }
 }

--- a/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolThumbnail.scss
@@ -27,6 +27,14 @@
   &.isOnHover:hover {
     @extend .isHighlighted;
   }
+
+  &.hideSaturation {
+    padding-top: 14px;
+
+    .checkmarkWrapper {
+      margin-top: 5px;
+    }
+  }
 }
 
 .isHighlighted {

--- a/source/renderer/app/components/staking/stake-pools/StakePoolTooltip.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolTooltip.js
@@ -374,7 +374,7 @@ export default class StakePoolTooltip extends Component<Props, State> {
       showWithSelectButton,
       numberOfStakePools,
     } = this.props;
-
+    const showSaturation = false;
     const {
       componentStyle,
       arrowStyle,
@@ -449,21 +449,25 @@ export default class StakePoolTooltip extends Component<Props, State> {
           />
 
           <dl className={styles.table}>
-            <dt className={styles.saturationLabel}>
-              {intl.formatMessage(messages.saturation)}
-            </dt>
-            <dd className={styles.saturationValue}>
-              <span>
-                <span className={saturationBarClassnames}>
-                  <span
-                    style={{
-                      width: `${parseFloat(saturation.toFixed(2))}%`,
-                    }}
-                  />
-                </span>
-                {`${parseFloat(saturation.toFixed(2))}%`}
-              </span>
-            </dd>
+            {showSaturation && (
+              <>
+                <dt className={styles.saturationLabel}>
+                  {intl.formatMessage(messages.saturation)}
+                </dt>
+                <dd className={styles.saturationValue}>
+                  <span>
+                    <span className={saturationBarClassnames}>
+                      <span
+                        style={{
+                          width: `${parseFloat(saturation.toFixed(2))}%`,
+                        }}
+                      />
+                    </span>
+                    {`${parseFloat(saturation.toFixed(2))}%`}
+                  </span>
+                </dd>
+              </>
+            )}
             <dt>{intl.formatMessage(messages.ranking)}</dt>
             <dd className={styles.ranking}>
               <span


### PR DESCRIPTION
This PR hides stake pool saturation info on the Stake pool Thumbnail and Stake pool tooltip elements.

## Screenshots

![Screenshot 2020-07-16 at 10 54 01](https://user-images.githubusercontent.com/376611/87650914-ad7b3500-c752-11ea-97e3-60214ef25c61.png)

![Screenshot 2020-07-16 at 10 54 03](https://user-images.githubusercontent.com/376611/87650922-afdd8f00-c752-11ea-8572-81ed7d851125.png)

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
