### PR TITLE
[DDW-302] Double punctuation on delegation dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 - Added UX improvements for the display of stake pool ID ([PR 2074](https://github.com/input-output-hk/daedalus/pull/2074))
 
+### Fixes
+
+- Fixed double punctuation on delegation dialog ([PR 2049](https://github.com/input-output-hk/daedalus/pull/2049))
+
 ## 1.3.0-STN2
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 
 ### Fixes
 
-- Fixed double punctuation on delegation dialog ([PR 2049](https://github.com/input-output-hk/daedalus/pull/2049))
+- Fixed double punctuation on delegation dialog ([PR 2077](https://github.com/input-output-hk/daedalus/pull/2077))
 
 ## 1.3.0-STN2
 

--- a/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsSuccessDialog.js
+++ b/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsSuccessDialog.js
@@ -32,7 +32,7 @@ const messages = defineMessages({
   descriptionLine2: {
     id: 'staking.delegationSetup.success.step.dialog.description.line2',
     defaultMessage:
-      '!!!Your new delegation preferences are now posted on the Cardano blockchain. <strong>These preferences will take effect after both the current and the next Cardano epochs have completed in {timeUntilNextEpochStart}.</strong>. During this time, your previous delegation preferences remain active.',
+      '!!!Your new delegation preferences are now posted on the Cardano blockchain. <strong>These preferences will take effect after both the current and the next Cardano epochs have completed in {timeUntilNextEpochStart}.</strong> During this time, your previous delegation preferences remain active.',
     description:
       'Description "line 2" on the delegation setup "success" step dialog.',
   },

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -363,7 +363,7 @@
   "staking.delegationSetup.steps.step.3.label": "Confirmation",
   "staking.delegationSetup.success.step.dialog.closeButtonLabel": "Close",
   "staking.delegationSetup.success.step.dialog.description.line1": "The stake from your wallet <span>{delegatedWalletName}</span> is now delegated to the <span>[{delegatedStakePoolTicker}] {delegatedStakePoolName}</span> stake pool.",
-  "staking.delegationSetup.success.step.dialog.description.line2": "Your new delegation preferences are now posted on the Cardano blockchain. <strong>These preferences will take effect after both the current and the next Cardano epochs have completed in {timeUntilNextEpochStart}.</strong>. During this time, your previous delegation preferences remain active.",
+  "staking.delegationSetup.success.step.dialog.description.line2": "Your new delegation preferences are now posted on the Cardano blockchain. <strong>These preferences will take effect after both the current and the next Cardano epochs have completed in {timeUntilNextEpochStart}.</strong> During this time, your previous delegation preferences remain active.",
   "staking.delegationSetup.success.step.dialog.title": "Wallet Delegated",
   "staking.epochs.currentEpoch.tableHeader.pool": "Stake pool",
   "staking.epochs.currentEpoch.tableHeader.slotsElected": "Slots elected",


### PR DESCRIPTION
This PR fixes double punctuation error on delegation dialog.

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1595277241270100)
- [ ] Have Daedalus installed and synced. Have a wallet with funds to delegate. Access to delegation center. Select a wallet and delegate it. Validate success dialog.

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
