### PR TITLE
[DDW-318] Revert "Blocks (current epoch)" into "Blocks produced"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixes
 
+- Updated stake pool tooltip to display "Produced blocks" instead of "Blocks (current epoch)" ([PR 2096](https://github.com/input-output-hk/daedalus/pull/2096))
 - Fixed wallet recovery phrase length used on "ITN rewards redemption" wizard ([PR 2095](https://github.com/input-output-hk/daedalus/pull/2095))
 
 ## 1.6.0-STN5

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -61,7 +61,7 @@ const messages = defineMessages({
   },
   producedBlocks: {
     id: 'staking.stakePools.tooltip.producedBlocks',
-    defaultMessage: '!!!Blocks (current epoch):',
+    defaultMessage: '!!!Produced blocks:',
     description: '"Blocks" for the Stake Pools Tooltip page.',
   },
   retirement: {

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -5406,7 +5406,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Blocks (current epoch):",
+        "defaultMessage": "!!!Produced blocks:",
         "description": "\"Blocks\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -462,7 +462,7 @@
   "staking.stakePools.tooltip.delegateButton": "Delegate to this pool",
   "staking.stakePools.tooltip.experimentalTooltipLabel": "Experimental feature, data may be inaccurate.",
   "staking.stakePools.tooltip.pledge": "Pledge:",
-  "staking.stakePools.tooltip.producedBlocks": "Blocks (current epoch):",
+  "staking.stakePools.tooltip.producedBlocks": "Produced blocks:",
   "staking.stakePools.tooltip.profitMargin": "Pool margin:",
   "staking.stakePools.tooltip.ranking": "Rank:",
   "staking.stakePools.tooltip.relativeStake": "Controlled stake:",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -462,7 +462,7 @@
   "staking.stakePools.tooltip.delegateButton": "このプールに委任する",
   "staking.stakePools.tooltip.experimentalTooltipLabel": "実験的機能データは不正確な場合があります",
   "staking.stakePools.tooltip.pledge": "出資：",
-  "staking.stakePools.tooltip.producedBlocks": "ブロック数（現行エポック）：",
+  "staking.stakePools.tooltip.producedBlocks": "生成ブロック数：",
   "staking.stakePools.tooltip.profitMargin": "プールマージン：",
   "staking.stakePools.tooltip.ranking": "ランク：",
   "staking.stakePools.tooltip.relativeStake": "管理下のステーク：",


### PR DESCRIPTION
This PR updates stake pool tooltip to display 'Produced blocks' instead of 'Blocks (current epoch)'.

## Screenshots

![Screenshot 2020-07-27 at 14 38 18](https://user-images.githubusercontent.com/376611/88542711-231ab700-d017-11ea-9110-5cea398ca8cc.png)
![Screenshot 2020-07-27 at 14 38 26](https://user-images.githubusercontent.com/376611/88542713-23b34d80-d017-11ea-8ec9-8c77ea05343d.png)

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
