### PR TITLE
[DDW-339] Correct order of receiving addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Chores
 
+- Changed the ordering of wallet addresses on the "Receive" screen so that the oldest one are on top and the newest one on the bottom of the list ([PR 2176](https://github.com/input-output-hk/daedalus/pull/2176))
 - Updated list of team members on About screen ([PR 2167](https://github.com/input-output-hk/daedalus/pull/2167))
 
 ## 2.2.0

--- a/source/renderer/app/api/api.js
+++ b/source/renderer/app/api/api.js
@@ -296,6 +296,7 @@ export default class AdaApi {
         );
       } else if (!isLegacy) {
         response = await getAddresses(this.config, walletId, queryParams);
+        response.reverse();
       }
       logger.debug('AdaApi::getAddresses success', { addresses: response });
       return response.map(_createAddressFromServerData);


### PR DESCRIPTION
This PR reverses ordering of addresses on the 'Receive' screen so that the oldest ones are shown on the top and the newest one on the bottom of the list.

## Screenshots

![Screenshot 2020-09-04 at 14 42 26](https://user-images.githubusercontent.com/376611/92241000-cb952400-eebd-11ea-850d-7f3da27b39b7.png)
![Screenshot 2020-09-04 at 14 42 53](https://user-images.githubusercontent.com/376611/92241002-cc2dba80-eebd-11ea-8306-39d8032c2071.png)

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Create new wallet and send ada to the address from the top of the “Receive” screen. After the transaction is confirmed the top address should be shown as “used” and only one new address should be added to the bottom of the list.

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
