### PR TITLE
Fix "Stake pools" screen UI/UX issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### Features
 
 - Added tooltips to stake pools table view headers ([PR 2214](https://github.com/input-output-hk/daedalus/pull/2214))
-- Added stake pools list view ([PR 2186](https://github.com/input-output-hk/daedalus/pull/2186))
+- Added stake pools list view ([PR 2186](https://github.com/input-output-hk/daedalus/pull/2186), [PR 2215](https://github.com/input-output-hk/daedalus/pull/2215))
 - Implemented stake pool details explanation tooltips ([PR 2211](https://github.com/input-output-hk/daedalus/pull/2211))
 - Re-enabled stake pool saturation info ([PR 2200](https://github.com/input-output-hk/daedalus/pull/2200))
 - Implemented the wallet migration leftovers handling ([PR 2178](https://github.com/input-output-hk/daedalus/pull/2178))

--- a/source/renderer/app/components/staking/stake-pools/StakePools.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePools.js
@@ -65,14 +65,15 @@ type State = {
   selectedList?: ?string,
   isGridView: boolean,
   isListView: boolean,
-  isFixed: boolean,
-  isHeaderFixed: boolean,
-  isScrolled: boolean,
-  maintainFixed: boolean,
+  isTableHeaderHovered: boolean,
 };
 
 const initialState = {
+  search: '',
   selectedList: null,
+  isGridView: true,
+  isListView: false,
+  isTableHeaderHovered: false,
 };
 
 @observer
@@ -83,63 +84,32 @@ export default class StakePools extends Component<Props, State> {
     intl: intlShape.isRequired,
   };
 
-  state = {
-    search: '',
-    isGridView: true,
-    isListView: false,
-    isFixed: false,
-    isHeaderFixed: false,
-    isScrolled: false,
-    maintainFixed: false,
-    ...initialState,
-  };
+  state = { ...initialState };
 
-  handleSearch = (search: string) =>
-    this.setState((prevState) => ({
-      search,
-      maintainFixed: prevState.isFixed,
-    }));
-  handleClearSearch = () =>
-    this.setState({ search: '', maintainFixed: false, isFixed: false });
+  handleSearch = (search: string) => this.setState({ search });
+
+  handleClearSearch = () => this.setState({ search: '' });
+
   handleGridView = () =>
     this.setState({
       isGridView: true,
       isListView: false,
-      isFixed: false,
-      maintainFixed: false,
-      isScrolled: false,
-      isHeaderFixed: false,
     });
+
   handleListView = () =>
     this.setState({
       isGridView: false,
       isListView: true,
-      isFixed: false,
-      maintainFixed: false,
-      isScrolled: false,
-      isHeaderFixed: false,
     });
-  handleSearchComponentScrollView = (
-    isScrolled: boolean,
-    isHeaderFixed: boolean
-  ) => {
-    if (isHeaderFixed) {
-      this.setState((prevState) => ({
-        isFixed: !prevState.isFixed,
-        isScrolled,
-        isHeaderFixed,
-      }));
-    } else {
-      this.setState(() => ({
-        isFixed: !(!isScrolled && !isHeaderFixed),
-        isScrolled,
-        isHeaderFixed: false,
-      }));
-    }
-  };
 
   handleSetListActive = (selectedList: string) =>
     this.setState({ selectedList });
+
+  handleTableHeaderMouseEnter = () =>
+    this.setState({ isTableHeaderHovered: true });
+
+  handleTableHeaderMouseLeave = () =>
+    this.setState({ isTableHeaderHovered: false });
 
   onDelegate = (poolId: string) => {
     const { onDelegate } = this.props;
@@ -168,10 +138,7 @@ export default class StakePools extends Component<Props, State> {
       selectedList,
       isListView,
       isGridView,
-      isFixed,
-      isHeaderFixed,
-      maintainFixed,
-      isScrolled,
+      isTableHeaderHovered,
     } = this.state;
 
     const filteredStakePoolsList: Array<StakePool> = getFilteredStakePoolsList(
@@ -202,14 +169,6 @@ export default class StakePools extends Component<Props, State> {
       isLoading ? styles.isLoading : null,
     ]);
 
-    const tableHeadingClasses = classnames([
-      styles.tableHeading,
-      isFixed && filteredStakePoolsList.length
-        ? styles.tableHeadingFixed
-        : null,
-      isHeaderFixed ? styles.tableHeadingFixedPosition : null,
-    ]);
-
     return (
       <div className={componentClasses}>
         {isLoading ? (
@@ -221,7 +180,9 @@ export default class StakePools extends Component<Props, State> {
           <Fragment>
             <BackToTopButton
               scrollableElementClassName="StakingWithNavigation_page"
+              scrollTopToActivate={isListView ? 400 : 340}
               buttonTopPosition={isListView ? 184 : 144}
+              isForceHidden={isTableHeaderHovered}
             />
             <StakePoolsRanking
               wallets={wallets}
@@ -244,11 +205,7 @@ export default class StakePools extends Component<Props, State> {
               onListView={this.handleListView}
               isListView={isListView}
               isGridView={isGridView}
-              isFixed={
-                (isFixed || maintainFixed) && !!filteredStakePoolsList.length
-              }
               isClearTooltipOpeningDownward
-              isScrolled={isScrolled}
             />
             {stakePoolsDelegatingList.length > 0 && (
               <Fragment>
@@ -271,7 +228,7 @@ export default class StakePools extends Component<Props, State> {
             )}
             {isListView && (
               <Fragment>
-                <h2 className={tableHeadingClasses}>
+                <h2>
                   <FormattedMessage
                     {...listTitleMessage}
                     values={{
@@ -291,11 +248,8 @@ export default class StakePools extends Component<Props, State> {
                   onSelect={this.onDelegate}
                   numberOfRankedStakePools={numberOfRankedStakePools}
                   showWithSelectButton
-                  onScrollView={this.handleSearchComponentScrollView}
-                  maintainFixed={
-                    maintainFixed && !!filteredStakePoolsList.length
-                  }
-                  isScrolled={isScrolled}
+                  onTableHeaderMouseEnter={this.handleTableHeaderMouseEnter}
+                  onTableHeaderMouseLeave={this.handleTableHeaderMouseLeave}
                 />
               </Fragment>
             )}

--- a/source/renderer/app/components/staking/stake-pools/StakePools.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePools.scss
@@ -31,15 +31,5 @@
     margin: 20px 0 10px;
     opacity: 0.5;
     padding-left: 20px;
-
-    &.tableHeading {
-      &.tableHeadingFixed {
-        margin-top: 91px;
-      }
-
-      &.tableHeadingFixedPosition {
-        margin-top: 131px;
-      }
-    }
   }
 }

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsList.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsList.js
@@ -57,9 +57,7 @@ export class StakePoolsList extends Component<Props, State> {
     window.addEventListener('resize', this.handleResize);
   }
 
-  state = {
-    ...initialState,
-  };
+  state = { ...initialState };
 
   // We need to track the mounted state in order to avoid calling
   // setState promise handling code after the component was already unmounted:

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js
@@ -11,6 +11,7 @@ import {
   shortNumber,
   generateThousands,
   formattedWalletAmount,
+  toFixedUserFormat,
 } from '../../../utils/formatters';
 import {
   getFilteredWallets,
@@ -148,7 +149,7 @@ export default class StakePoolsRanking extends Component<Props, State> {
     sliderValue: Math.round(
       INITIAL_DELEGATION_FUNDS_LOG * RANKING_SLIDER_RATIO
     ),
-    displayValue: Number(INITIAL_DELEGATION_FUNDS).toString(),
+    displayValue: toFixedUserFormat(INITIAL_DELEGATION_FUNDS, 0),
   };
 
   componentDidMount() {
@@ -157,7 +158,7 @@ export default class StakePoolsRanking extends Component<Props, State> {
       const hasDecimal = stake - Math.floor(stake);
       const displayValue = hasDecimal
         ? formattedWalletAmount(new BigNumber(stake), false)
-        : stake;
+        : toFixedUserFormat(stake, 0);
       this.setState({
         sliderValue: Math.round(Math.log(stake) * RANKING_SLIDER_RATIO),
         displayValue,
@@ -231,7 +232,7 @@ export default class StakePoolsRanking extends Component<Props, State> {
         Math.exp(sliderValue / RANKING_SLIDER_RATIO)
       );
     }
-    const displayValue = Number(amountValue).toString();
+    const displayValue = toFixedUserFormat(amountValue, 0);
     this.setState({ sliderValue, displayValue });
     updateDelegatingStake(null, amountValue);
   };

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsSearch.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsSearch.js
@@ -42,8 +42,6 @@ type Props = {
   onGridView?: Function,
   onListView?: Function,
   search: string,
-  isFixed?: boolean,
-  isScrolled?: boolean,
 };
 
 export class StakePoolsSearch extends Component<Props> {
@@ -73,24 +71,7 @@ export class StakePoolsSearch extends Component<Props> {
       isListView,
       isGridView,
       isClearTooltipOpeningDownward,
-      isFixed,
-      isScrolled,
     } = this.props;
-
-    let componentClasses: string = '';
-    if (isScrolled) {
-      componentClasses = classnames([
-        styles.component,
-        isListView && isScrolled ? styles.componentFixedPosition : null,
-      ]);
-    } else {
-      componentClasses = classnames([
-        styles.component,
-        isScrolled && isListView && isFixed
-          ? styles.componentFixedPosition
-          : null,
-      ]);
-    }
 
     const gridButtonClasses = classnames([
       styles.gridView,
@@ -110,7 +91,7 @@ export class StakePoolsSearch extends Component<Props> {
     ]);
 
     return (
-      <div className={componentClasses}>
+      <div className={styles.component}>
         <div className={styles.container}>
           <SVGInline svg={searchIcon} className={styles.searchIcon} />
           <Input

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsSearch.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsSearch.scss
@@ -4,19 +4,6 @@
   position: initial;
   transition: position 1s ease-out, top 1s ease-out;
   width: 100%;
-
-  &.componentFixedPosition {
-    background-color: var(--theme-main-body-background-color);
-    box-shadow: 0 2.5px 10px 0
-      var(--theme-staking-stake-pool-tooltip-shadow-color);
-    height: 70px;
-    margin-left: -20px;
-    margin-right: -20px;
-    padding: 10px 20px;
-    position: fixed;
-    width: calc(100% - 84px);
-    z-index: 100;
-  }
 }
 
 .container {

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
@@ -149,29 +149,21 @@ type Props = {
   numberOfRankedStakePools: number,
   selectedPoolId?: ?number,
   onOpenExternalLink: Function,
-  maintainFixed?: boolean,
-  isScrolled?: boolean,
   currentLocale: string,
+  onTableHeaderMouseEnter: Function,
+  onTableHeaderMouseLeave: Function,
 };
 
 type State = {
   isPreloading: boolean,
   stakePoolsOrder: string,
   stakePoolsSortBy: string,
-  isFixedTableHeaderActive: boolean,
-  isFixedSearchBarActive: boolean,
-  fixedTableHeaderPosition: number,
-  fixedSearchBarPosition: number,
 };
 
 const initialState = {
   isPreloading: true,
   stakePoolsOrder: 'asc',
   stakePoolsSortBy: 'ranking',
-  isFixedTableHeaderActive: false,
-  isFixedSearchBarActive: false,
-  fixedTableHeaderPosition: 250,
-  fixedSearchBarPosition: 186,
 };
 
 @observer
@@ -185,9 +177,7 @@ export class StakePoolsTable extends Component<Props, State> {
     showWithSelectButton: false,
   };
 
-  state = {
-    ...initialState,
-  };
+  state = { ...initialState };
 
   scrollableDomElement: ?HTMLElement = null;
 
@@ -230,20 +220,15 @@ export class StakePoolsTable extends Component<Props, State> {
       containerClassName,
       numberOfRankedStakePools,
       listName,
-      maintainFixed,
-      isScrolled,
       onSelect,
       selectedPoolId,
       setListActive,
       isListActive,
       currentLocale,
+      onTableHeaderMouseEnter,
+      onTableHeaderMouseLeave,
     } = this.props;
-    const {
-      isPreloading,
-      stakePoolsSortBy,
-      stakePoolsOrder,
-      isFixedTableHeaderActive,
-    } = this.state;
+    const { isPreloading, stakePoolsSortBy, stakePoolsOrder } = this.state;
     const { intl } = this.context;
     const componentClasses = classNames([styles.component, listName]);
 
@@ -253,20 +238,6 @@ export class StakePoolsTable extends Component<Props, State> {
           <LoadingSpinner big />
         </div>
       );
-    let tableHeaderClasses: string = '';
-    if (isScrolled) {
-      tableHeaderClasses = classNames([
-        styles.tableHeader,
-        isScrolled && isFixedTableHeaderActive ? styles.fixedTableHeader : null,
-      ]);
-    } else {
-      tableHeaderClasses = classNames([
-        styles.tableHeader,
-        isScrolled && (isFixedTableHeaderActive || maintainFixed)
-          ? styles.fixedTableHeader
-          : null,
-      ]);
-    }
 
     const sortedStakePoolList = orderBy(
       stakePoolsList.map((stakePool) => {
@@ -414,7 +385,10 @@ export class StakePoolsTable extends Component<Props, State> {
           {sortedStakePoolList.length > 0 && (
             <BorderedBox>
               <table>
-                <thead className={tableHeaderClasses}>
+                <thead
+                  onMouseEnter={onTableHeaderMouseEnter}
+                  onMouseLeave={onTableHeaderMouseLeave}
+                >
                   <tr>
                     <StakePoolsTableHeader
                       availableTableHeaders={availableTableHeaders}

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTable.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTable.scss
@@ -98,62 +98,43 @@
 
     thead {
       background: var(--theme-bordered-box-background-color);
+      border-radius: 4px 4px 0 0;
       box-shadow: 0 10px 10px -10px rgba(0, 0, 0, 0.2);
       display: block;
       margin: -20px -20px 0;
       padding: 0 20px;
       position: sticky;
       top: 0;
-      z-index: 1000;
+      z-index: 999;
 
       tr {
         border: 0;
         display: flex;
         justify-content: space-between;
         width: 100%;
-      }
-    }
 
-    .tableHeader {
-      &.fixedTableHeader {
-        background-color: var(--theme-bordered-box-background-color);
-        border-left: var(--theme-bordered-box-border);
-        border-right: var(--theme-bordered-box-border);
-        box-shadow: 0 10px 10px -10px var(--theme-staking-stake-pool-tooltip-shadow-color);
-        height: 40px;
-        left: 104px;
-        padding: 0 10px;
-        position: fixed;
-        top: 204px;
-        width: calc(100% - 124px);
-        z-index: 99;
-
-        tr {
-          display: flex;
-          padding: 0 10px;
-        }
-      }
-
-      :global {
-        .SimpleTooltip_root {
-          .SimpleTooltip_bubble {
-            .SimpleBubble_bubble {
-              font-family: var(--font-regular);
-              font-weight: 400;
-              line-height: 19.04px;
-              text-align: left;
-              text-transform: initial;
-              transform: translate(-50px, 0);
-              white-space: normal;
-              width: 230px;
-            }
-          }
-        }
-        th:nth-child(8) {
+        :global {
           .SimpleTooltip_root {
             .SimpleTooltip_bubble {
               .SimpleBubble_bubble {
-                margin-left: -35px;
+                font-family: var(--font-regular);
+                font-weight: 400;
+                line-height: 19.04px;
+                text-align: left;
+                text-transform: initial;
+                transform: translate(-50px, 0);
+                white-space: normal;
+                width: 230px;
+              }
+            }
+          }
+
+          th:nth-child(8) {
+            .SimpleTooltip_root {
+              .SimpleTooltip_bubble {
+                .SimpleBubble_bubble {
+                  margin-left: -35px;
+                }
               }
             }
           }

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
@@ -8,7 +8,6 @@ import moment from 'moment';
 import classNames from 'classnames';
 import { getRelativePosition } from '../../../utils/domManipulation';
 import {
-  bigNumbersToFormattedNumbers,
   formattedWalletAmount,
   toFixedUserFormat,
 } from '../../../utils/formatters';
@@ -197,7 +196,7 @@ export class StakePoolsTableBody extends Component<
       const pledge = new BigNumber(get(stakePool, 'pledge', ''));
       const retiring = get(stakePool, 'retiring', '');
       const memberRewards = get(stakePool, 'potentialRewards', '');
-      const potentialRewards = memberRewards
+      const potentialRewards = !memberRewards.isZero()
         ? formattedWalletAmount(memberRewards)
         : '-';
       const retirement =
@@ -221,7 +220,7 @@ export class StakePoolsTableBody extends Component<
           }
         >
           <td>
-            {memberRewards ? rank : '-'}
+            {!memberRewards.isZero() ? rank : '-'}
             {isHighlighted && (
               <TooltipPool
                 stakePool={stakePool}
@@ -267,7 +266,7 @@ export class StakePoolsTableBody extends Component<
           </td>
           <td>{costValue}</td>
           <td>{`${toFixedUserFormat(margin, 2)}%`}</td>
-          <td>{formattedWalletAmount(producedBlocks, false, false)}</td>
+          <td>{toFixedUserFormat(producedBlocks, 0)}</td>
           <td>{potentialRewards}</td>
           <td>{pledgeValue}</td>
           <td>

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -513,7 +513,7 @@ export default class TooltipPool extends Component<Props, State> {
         key: 'ranking',
         value: (
           <div className={styles.ranking}>
-            {IS_RANKING_DATA_AVAILABLE && potentialRewards ? (
+            {IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero() ? (
               <span
                 style={{
                   background: getColorFromRange(ranking, {
@@ -609,7 +609,7 @@ export default class TooltipPool extends Component<Props, State> {
         value: (
           <div className={styles.defaultColor}>
             <span className={styles.defaultColorContent}>
-              {formattedWalletAmount(producedBlocks, false, false)}
+              {toFixedUserFormat(producedBlocks, 0)}
             </span>
           </div>
         ),
@@ -618,7 +618,7 @@ export default class TooltipPool extends Component<Props, State> {
         key: 'potentialRewards',
         value: (
           <div className={styles.defaultColor}>
-            {potentialRewards ? (
+            {!potentialRewards.isZero() ? (
               <span className={styles.defaultColorContent}>
                 {formattedWalletAmount(potentialRewards)}
               </span>
@@ -718,7 +718,7 @@ export default class TooltipPool extends Component<Props, State> {
     ]);
     const colorBandStyles = classnames([
       styles.colorBand,
-      IS_RANKING_DATA_AVAILABLE && potentialRewards
+      IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero()
         ? null
         : styles.greyColorBand,
     ]);
@@ -731,7 +731,7 @@ export default class TooltipPool extends Component<Props, State> {
         aria-hidden
         style={componentStyle}
       >
-        {IS_RANKING_DATA_AVAILABLE && potentialRewards ? (
+        {IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero() ? (
           <div className={colorBandStyles} style={colorBandStyle} />
         ) : (
           <div className={colorBandStyles} />

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -286,9 +286,11 @@ export default class TooltipPool extends Component<Props, State> {
       arrowBottom,
       arrowLeft
     );
-    const colorBandStyle = {
-      background: color,
-    };
+    const colorBandStyle = !this.isGreyColor
+      ? {
+          background: color,
+        }
+      : {};
 
     this.setState({
       componentStyle,
@@ -443,12 +445,16 @@ export default class TooltipPool extends Component<Props, State> {
         top,
         bottom,
       };
-    if (tooltipPosition === 'bottom')
-      return {
+    if (tooltipPosition === 'bottom') {
+      const borderStyle = !this.isGreyColor && {
         borderBottomColor: this.props.color,
+      };
+      return {
+        ...borderStyle,
         left,
         top,
       };
+    }
     return {
       right,
       top,
@@ -469,6 +475,13 @@ export default class TooltipPool extends Component<Props, State> {
   onIdMouseOut = () => {
     this.setState({ idCopyFeedback: false });
   };
+
+  get isGreyColor() {
+    return (
+      IS_RANKING_DATA_AVAILABLE &&
+      this.props.stakePool.potentialRewards.isZero()
+    );
+  }
 
   renderDescriptionFields = () => {
     const { isIncentivizedTestnet } = global;
@@ -513,7 +526,7 @@ export default class TooltipPool extends Component<Props, State> {
         key: 'ranking',
         value: (
           <div className={styles.ranking}>
-            {IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero() ? (
+            {!this.isGreyColor ? (
               <span
                 style={{
                   background: getColorFromRange(ranking, {
@@ -705,6 +718,7 @@ export default class TooltipPool extends Component<Props, State> {
     const arrowClassnames = classnames([
       styles.arrow,
       styles[`tooltipPosition${capitalize(tooltipPosition)}`],
+      this.isGreyColor ? styles.greyArrow : null,
     ]);
 
     const retirementFromNow = retiring
@@ -712,15 +726,13 @@ export default class TooltipPool extends Component<Props, State> {
       : '';
 
     const idCopyIcon = idCopyFeedback ? copyCheckmarkIcon : copyIcon;
-    const hoverContentStyles = classnames([
+    const hoverContentClassnames = classnames([
       styles.hoverContent,
       idCopyFeedback ? styles.checkIcon : styles.copyIcon,
     ]);
-    const colorBandStyles = classnames([
+    const colorBandClassnames = classnames([
       styles.colorBand,
-      IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero()
-        ? null
-        : styles.greyColorBand,
+      this.isGreyColor ? styles.greyColorBand : null,
     ]);
 
     return (
@@ -731,11 +743,7 @@ export default class TooltipPool extends Component<Props, State> {
         aria-hidden
         style={componentStyle}
       >
-        {IS_RANKING_DATA_AVAILABLE && !potentialRewards.isZero() ? (
-          <div className={colorBandStyles} style={colorBandStyle} />
-        ) : (
-          <div className={colorBandStyles} />
-        )}
+        <div className={colorBandClassnames} style={colorBandStyle} />
         <div className={arrowClassnames} style={arrowStyle} />
         <div className={styles.container}>
           <h3 className={styles.name}>{name}</h3>
@@ -765,7 +773,7 @@ export default class TooltipPool extends Component<Props, State> {
                 skin={TooltipSkin}
                 tip={intl.formatMessage(messages.copyIdTooltipLabel)}
               >
-                <div className={hoverContentStyles}>
+                <div className={hoverContentClassnames}>
                   <p className={styles.hoverContentBackground}>
                     {id} <SVGInline svg={idCopyIcon} />
                   </p>

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -700,15 +700,7 @@ export default class TooltipPool extends Component<Props, State> {
       idCopyFeedback,
     } = this.state;
 
-    const {
-      id,
-      name,
-      description,
-      ticker,
-      homepage,
-      potentialRewards,
-      retiring,
-    } = stakePool;
+    const { id, name, description, ticker, homepage, retiring } = stakePool;
 
     const componentClassnames = classnames([
       styles.component,

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -103,9 +103,9 @@
     :global {
       .SVGInline {
         align-items: center;
-        display: flex;
+        display: flex !important;
         justify-content: center;
-        padding: 0 4px;
+        padding: 0 4px !important;
       }
     }
 

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -207,10 +207,9 @@
       left: -10px;
       top: -11px;
     }
-  }
-
-  &.greyArrow {
-    border-bottom-color: var(--theme-staking-stake-pool-grey-color);
+    &.greyArrow {
+      border-bottom-color: var(--theme-staking-stake-pool-grey-color);
+    }
   }
 
   &.tooltipPositionLeft {

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -209,6 +209,10 @@
     }
   }
 
+  &.greyArrow {
+    border-bottom-color: var(--theme-staking-stake-pool-grey-color);
+  }
+
   &.tooltipPositionLeft {
     border-left-color: var(--theme-staking-stake-pool-tooltip-border-color);
     border-width: 11px 0 11px 11px;

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -207,6 +207,7 @@
       left: -10px;
       top: -11px;
     }
+
     &.greyArrow {
       border-bottom-color: var(--theme-staking-stake-pool-grey-color);
     }

--- a/source/renderer/app/components/widgets/BackToTopButton.js
+++ b/source/renderer/app/components/widgets/BackToTopButton.js
@@ -17,6 +17,7 @@ type Props = {
   scrollableElementClassName: string,
   buttonTopPosition: number,
   scrollTopToActivate: number,
+  isForceHidden?: boolean,
 };
 
 type State = {
@@ -31,6 +32,7 @@ export default class BackToTopButton extends Component<Props, State> {
   static defaultProps = {
     scrollTopToActivate: 20,
     buttonTopPosition: 20,
+    isForceHidden: false,
   };
 
   state = {
@@ -99,11 +101,14 @@ export default class BackToTopButton extends Component<Props, State> {
   render() {
     const { intl } = this.context;
     const { isActive } = this.state;
-    const { buttonTopPosition } = this.props;
+    const { buttonTopPosition, isForceHidden } = this.props;
     const componentStyles = classnames(styles.component, {
       [styles.isActive]: isActive,
     });
     const top = isActive ? buttonTopPosition : buttonTopPosition - 10;
+
+    if (isForceHidden) return null;
+
     return (
       <button
         style={{ top }}

--- a/source/renderer/app/components/widgets/BackToTopButton.scss
+++ b/source/renderer/app/components/widgets/BackToTopButton.scss
@@ -8,7 +8,6 @@
   left: 50%;
   line-height: 1.17;
   margin-left: 42px;
-  opacity: 0.98;
   opacity: 0;
   padding: 6px 12px;
   position: fixed;

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -5246,13 +5246,13 @@
         "description": "All wallets item of dropdown.",
         "end": {
           "column": 3,
-          "line": 42
+          "line": 43
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingAllWallets",
         "start": {
           "column": 21,
-          "line": 38
+          "line": 39
         }
       },
       {
@@ -5260,13 +5260,13 @@
         "description": "All wallets description after dropdown.",
         "end": {
           "column": 3,
-          "line": 47
+          "line": 48
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingAllWalletsEnd",
         "start": {
           "column": 24,
-          "line": 43
+          "line": 44
         }
       },
       {
@@ -5274,13 +5274,13 @@
         "description": "All wallets description before dropdown.",
         "end": {
           "column": 3,
-          "line": 53
+          "line": 54
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingAllWalletsStart",
         "start": {
           "column": 26,
-          "line": 48
+          "line": 49
         }
       },
       {
@@ -5288,13 +5288,13 @@
         "description": "Ranking description.",
         "end": {
           "column": 3,
-          "line": 59
+          "line": 60
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingDescription",
         "start": {
           "column": 22,
-          "line": 54
+          "line": 55
         }
       },
       {
@@ -5302,13 +5302,13 @@
         "description": "Ranking learn more url.",
         "end": {
           "column": 3,
-          "line": 64
+          "line": 65
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingLearnMoreUrl",
         "start": {
           "column": 23,
-          "line": 60
+          "line": 61
         }
       },
       {
@@ -5316,13 +5316,13 @@
         "description": "One wallet description after dropdown.",
         "end": {
           "column": 3,
-          "line": 69
+          "line": 70
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingOneWalletEnd",
         "start": {
           "column": 23,
-          "line": 65
+          "line": 66
         }
       },
       {
@@ -5330,13 +5330,13 @@
         "description": "One wallet description before dropdown.",
         "end": {
           "column": 3,
-          "line": 75
+          "line": 76
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingOneWalletStart",
         "start": {
           "column": 25,
-          "line": 70
+          "line": 71
         }
       },
       {
@@ -5344,13 +5344,13 @@
         "description": "Select wallet item of dropdown.",
         "end": {
           "column": 3,
-          "line": 80
+          "line": 81
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingSelectWallet",
         "start": {
           "column": 23,
-          "line": 76
+          "line": 77
         }
       },
       {
@@ -5358,13 +5358,13 @@
         "description": "Select wallet description after dropdown.",
         "end": {
           "column": 3,
-          "line": 85
+          "line": 86
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingSelectWalletEnd",
         "start": {
           "column": 26,
-          "line": 81
+          "line": 82
         }
       },
       {
@@ -5372,13 +5372,13 @@
         "description": "Select wallet description before dropdown.",
         "end": {
           "column": 3,
-          "line": 90
+          "line": 91
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingSelectWalletStart",
         "start": {
           "column": 28,
-          "line": 86
+          "line": 87
         }
       },
       {
@@ -5386,13 +5386,13 @@
         "description": "Circulating supply slider tooltip.",
         "end": {
           "column": 3,
-          "line": 95
+          "line": 96
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingExtraTooltip",
         "start": {
           "column": 23,
-          "line": 91
+          "line": 92
         }
       },
       {
@@ -5400,13 +5400,13 @@
         "description": "Saturation point slider tooltip.",
         "end": {
           "column": 3,
-          "line": 100
+          "line": 101
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingMaxTooltip",
         "start": {
           "column": 21,
-          "line": 96
+          "line": 97
         }
       },
       {
@@ -5414,13 +5414,13 @@
         "description": "Minimum ADA required for staking slider tooltip.",
         "end": {
           "column": 3,
-          "line": 105
+          "line": 106
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.rankingMinTooltip",
         "start": {
           "column": 21,
-          "line": 101
+          "line": 102
         }
       },
       {
@@ -5428,13 +5428,13 @@
         "description": "Learn more action of ranking panel.",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 111
         },
         "file": "source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js",
         "id": "staking.stakePools.learnMore",
         "start": {
           "column": 19,
-          "line": 106
+          "line": 107
         }
       }
     ],
@@ -5765,13 +5765,13 @@
         "description": "\"Rank\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 56
+          "line": 55
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.ranking",
         "start": {
           "column": 11,
-          "line": 52
+          "line": 51
         }
       },
       {
@@ -5779,13 +5779,13 @@
         "description": "\"Rank\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 62
+          "line": 61
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.rankingTooltip",
         "start": {
           "column": 18,
-          "line": 57
+          "line": 56
         }
       },
       {
@@ -5793,13 +5793,13 @@
         "description": "\"Live stake\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 67
+          "line": 66
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.relativeStake",
         "start": {
           "column": 17,
-          "line": 63
+          "line": 62
         }
       },
       {
@@ -5807,13 +5807,13 @@
         "description": "\"Live stake\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 73
+          "line": 72
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.relativeStakeTooltip",
         "start": {
           "column": 24,
-          "line": 68
+          "line": 67
         }
       },
       {
@@ -5821,13 +5821,13 @@
         "description": "\"Pool margin\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 78
+          "line": 77
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.profitMargin",
         "start": {
           "column": 16,
-          "line": 74
+          "line": 73
         }
       },
       {
@@ -5835,13 +5835,13 @@
         "description": "\"Pool margin\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 84
+          "line": 83
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.profitMarginTooltip",
         "start": {
           "column": 23,
-          "line": 79
+          "line": 78
         }
       },
       {
@@ -5849,13 +5849,13 @@
         "description": "\"Cost per epoch\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 89
+          "line": 88
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.costPerEpoch",
         "start": {
           "column": 16,
-          "line": 85
+          "line": 84
         }
       },
       {
@@ -5863,13 +5863,13 @@
         "description": "\"Cost per epoch\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 95
+          "line": 94
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.costPerEpochTooltip",
         "start": {
           "column": 23,
-          "line": 90
+          "line": 89
         }
       },
       {
@@ -5877,13 +5877,13 @@
         "description": "\"Blocks\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 100
+          "line": 99
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.producedBlocks",
         "start": {
           "column": 18,
-          "line": 96
+          "line": 95
         }
       },
       {
@@ -5891,13 +5891,13 @@
         "description": "\"Blocks\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 106
+          "line": 105
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.producedBlocksTooltip",
         "start": {
           "column": 25,
-          "line": 101
+          "line": 100
         }
       },
       {
@@ -5905,13 +5905,13 @@
         "description": "\"Rewards\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 111
+          "line": 110
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.potentialRewards",
         "start": {
           "column": 20,
-          "line": 107
+          "line": 106
         }
       },
       {
@@ -5919,13 +5919,13 @@
         "description": "\"Rewards\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 117
+          "line": 116
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.potentialRewardsTooltip",
         "start": {
           "column": 27,
-          "line": 112
+          "line": 111
         }
       },
       {
@@ -5933,13 +5933,13 @@
         "description": "\"Retirement\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 122
+          "line": 121
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.retirement",
         "start": {
           "column": 14,
-          "line": 118
+          "line": 117
         }
       },
       {
@@ -5947,13 +5947,13 @@
         "description": "\"Saturation\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 127
+          "line": 126
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.saturation",
         "start": {
           "column": 14,
-          "line": 123
+          "line": 122
         }
       },
       {
@@ -5961,13 +5961,13 @@
         "description": "\"Saturation\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 133
+          "line": 132
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.saturationTooltip",
         "start": {
           "column": 21,
-          "line": 128
+          "line": 127
         }
       },
       {
@@ -5975,13 +5975,13 @@
         "description": "\"Pledge\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 138
+          "line": 137
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.pledge",
         "start": {
           "column": 10,
-          "line": 134
+          "line": 133
         }
       },
       {
@@ -5989,13 +5989,13 @@
         "description": "\"Pledge\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 144
+          "line": 143
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.pledgeTooltip",
         "start": {
           "column": 17,
-          "line": 139
+          "line": 138
         }
       },
       {
@@ -6003,13 +6003,13 @@
         "description": "\"Delegate to this pool\" Button for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 150
+          "line": 149
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.delegateButton",
         "start": {
           "column": 18,
-          "line": 145
+          "line": 144
         }
       },
       {
@@ -6017,13 +6017,13 @@
         "description": "Experimental tooltip label",
         "end": {
           "column": 3,
-          "line": 155
+          "line": 154
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.experimentalTooltipLabel",
         "start": {
           "column": 28,
-          "line": 151
+          "line": 150
         }
       },
       {
@@ -6031,13 +6031,13 @@
         "description": "copyId tooltip label",
         "end": {
           "column": 3,
-          "line": 160
+          "line": 159
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.copyIdTooltipLabel",
         "start": {
           "column": 22,
-          "line": 156
+          "line": 155
         }
       },
       {
@@ -6045,13 +6045,13 @@
         "description": "Data not available yet label",
         "end": {
           "column": 3,
-          "line": 165
+          "line": 164
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.noDataDashTooltip",
         "start": {
           "column": 26,
-          "line": 161
+          "line": 160
         }
       }
     ],

--- a/source/renderer/app/themes/daedalus/cardano.js
+++ b/source/renderer/app/themes/daedalus/cardano.js
@@ -762,7 +762,7 @@ export const CARDANO_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': '#ffffff',
     '--theme-staking-stake-pool-border-color': '#d2d3d3',
     '--theme-staking-stake-pool-glow-color': '#7cfeb54c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(94, 96, 102, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#b2b3b6',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(94, 96, 102, 0.1)',
     '--theme-staking-progress-label-light': '#ffffff',
     '--theme-staking-stake-pool-retirement-background-color': '#ea4c5b',

--- a/source/renderer/app/themes/daedalus/dark-blue.js
+++ b/source/renderer/app/themes/daedalus/dark-blue.js
@@ -766,7 +766,7 @@ export const DARK_BLUE_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': '#314259',
     '--theme-staking-stake-pool-border-color': '#314259',
     '--theme-staking-stake-pool-glow-color': '#7cfeb54c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(233, 244, 254, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#93a1b0',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(233, 244, 254, 0.1)',
     '--theme-staking-progress-label-light': 'rgba(233, 244, 254, 0.7)',
     '--theme-staking-stake-pool-retirement-background-color': '#ea4c5b',

--- a/source/renderer/app/themes/daedalus/dark-cardano.js
+++ b/source/renderer/app/themes/daedalus/dark-cardano.js
@@ -744,7 +744,7 @@ export const DARK_CARDANO_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-border-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-glow-color': '#1fc1c34c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(255, 255, 255, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#434554',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(255, 255, 255, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#ffffff',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/themes/daedalus/flight-candidate.js
+++ b/source/renderer/app/themes/daedalus/flight-candidate.js
@@ -744,7 +744,7 @@ export const FLIGHT_CANDIDATE_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-border-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-glow-color': '#ffb9234c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(255, 255, 255, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#434554',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(255, 255, 255, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#ffffff',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/themes/daedalus/incentivized-testnet.js
+++ b/source/renderer/app/themes/daedalus/incentivized-testnet.js
@@ -747,7 +747,7 @@ export const INCENTIVIZED_TESTNET_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-border-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-glow-color': '#eb22564c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(255, 255, 255, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#434554',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(255, 255, 255, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#ffffff',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/themes/daedalus/light-blue.js
+++ b/source/renderer/app/themes/daedalus/light-blue.js
@@ -759,7 +759,7 @@ export const LIGHT_BLUE_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': '#fafbfc',
     '--theme-staking-stake-pool-border-color': '#c6cdd6',
     '--theme-staking-stake-pool-glow-color': 'rgba(0, 149, 255, 0.3)',
-    '--theme-staking-stake-pool-grey-color': 'rgba(94, 96, 102, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#b2b3b6',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(94, 96, 102, 0.1)',
     '--theme-staking-progress-label-light': '#fafbfc',
     '--theme-staking-stake-pool-retirement-background-color': '#ea4c5b',

--- a/source/renderer/app/themes/daedalus/shelley-testnet.js
+++ b/source/renderer/app/themes/daedalus/shelley-testnet.js
@@ -744,7 +744,7 @@ export const SHELLEY_TESTNET_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-border-color': 'rgba(42, 43, 60, 1)',
     '--theme-staking-stake-pool-glow-color': '#898ee64c',
-    '--theme-staking-stake-pool-grey-color': 'rgba(255, 255, 255, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#434554',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(255, 255, 255, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#ffffff',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/themes/daedalus/white.js
+++ b/source/renderer/app/themes/daedalus/white.js
@@ -753,7 +753,7 @@ export const WHITE_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': '#fff',
     '--theme-staking-stake-pool-border-color': 'rgba(45, 45, 45, 0.1)',
     '--theme-staking-stake-pool-glow-color': 'rgba(94, 96, 102, 0.07)',
-    '--theme-staking-stake-pool-grey-color': 'rgba(45, 45, 45, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#b2b3b6',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(45, 45, 45, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#2d2d2d',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/themes/daedalus/yellow.js
+++ b/source/renderer/app/themes/daedalus/yellow.js
@@ -753,7 +753,7 @@ export const YELLOW_THEME_OUTPUT = {
     '--theme-staking-stake-pool-background-color': '#ffffff',
     '--theme-staking-stake-pool-border-color': '#e1dac6',
     '--theme-staking-stake-pool-glow-color': 'rgba(45, 45, 45, 0.14)',
-    '--theme-staking-stake-pool-grey-color': 'rgba(45, 45, 45, 0.5)',
+    '--theme-staking-stake-pool-grey-color': '#b2b3b6',
     '--theme-staking-stake-pool-grey-bg-color': 'rgba(45, 45, 45, 0.1)',
     '--theme-staking-stake-pools-search-icon-color': '#2d2d2d',
     '--theme-staking-stake-pool-saturation-background-color':

--- a/source/renderer/app/utils/formatters.js
+++ b/source/renderer/app/utils/formatters.js
@@ -70,20 +70,6 @@ export const shortNumber = (value: number | BigNumber): string => {
   return formattedAmount;
 };
 
-export const bigNumbersToFormattedNumbers = (
-  value: BigNumber,
-  shorterNumber?: boolean
-): string => {
-  const formattedValue = formattedWalletAmount(value, false, !shorterNumber);
-  const splitValues = formattedValue.split(',');
-  let result = '';
-  splitValues.map((item) => {
-    result += item;
-    return true;
-  });
-  return result;
-};
-
 export const formattedAmountToNaturalUnits = (amount: string): string => {
   const cleanedAmount = amount
     .replace(/\./g, '') // removes all the dot separators

--- a/storybook/stories/staking/StakePoolsTable.stories.js
+++ b/storybook/stories/staking/StakePoolsTable.stories.js
@@ -87,6 +87,8 @@ export const StakePoolsTableStory = (props: Props) => (
             })
           ).length
         }
+        onTableHeaderMouseEnter={() => {}}
+        onTableHeaderMouseLeave={() => {}}
       />
     </div>
   </React.Fragment>


### PR DESCRIPTION
This PR fixes various UI/UX issues on the "Stake pools" screen:
- "Table view" header rendering over stake pool tooltip for stake pools in "Stake pools you are delegating to" section 
- Ranking shown for stake pools without nonmyopic member rewards data (should be "-") 
- "Back to top" button shown over the column explanation tooltips in the "Table view" header
- Stake pool slider not showing values in selected number formatting 
- "Produced blocks" value in stake pool tooltip and in the "Table view" displayed in "short" number format (should be the full number)

## Screenshots

### "Table view" header rendering over stake pool tooltip for stake pools in "Stake pools you are delegating to" section 

<img width="1150" alt="Screenshot 2020-10-26 at 15 24 15" src="https://user-images.githubusercontent.com/376611/97186006-0d956480-17a1-11eb-8a52-a57e44828f05.png">
<img width="1150" alt="Screenshot 2020-10-26 at 15 24 23" src="https://user-images.githubusercontent.com/376611/97186015-10905500-17a1-11eb-8c86-7957af0e703e.png">

### Ranking shown for stake pools without nonmyopic member rewards data (should be "-")  / "Back to top" button shown over the column explanation tooltips in the "Table view" header

<img width="1150" alt="Screenshot 2020-10-26 at 15 26 14" src="https://user-images.githubusercontent.com/376611/97186152-3c133f80-17a1-11eb-9df3-d5805d76a706.png">
<img width="1150" alt="Screenshot 2020-10-26 at 15 25 55" src="https://user-images.githubusercontent.com/376611/97186176-41708a00-17a1-11eb-8029-59f930049a08.png">

### Stake pool slider not showing values in selected number formatting 

<img width="1150" alt="Screenshot 2020-10-26 at 15 24 48" src="https://user-images.githubusercontent.com/376611/97186369-80064480-17a1-11eb-9cbe-2181e5c6bc6a.png">
<img width="1150" alt="Screenshot 2020-10-26 at 15 24 32" src="https://user-images.githubusercontent.com/376611/97186394-85638f00-17a1-11eb-96e7-068598d3b304.png">

### "Produced blocks" value in stake pool tooltip and in the "Table view" displayed in "short" number format (should be the full number)

<img width="1150" alt="Screenshot 2020-10-26 at 15 25 16" src="https://user-images.githubusercontent.com/376611/97186443-94e2d800-17a1-11eb-9a9c-ea5a33ce0e1b.png">
<img width="1150" alt="Screenshot 2020-10-26 at 15 25 36" src="https://user-images.githubusercontent.com/376611/97186468-9a402280-17a1-11eb-8ced-26c093dff0ea.png">


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
