### PR TITLE
[DDW-432] Stake pool ranking logic update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Features
 
+- Updated stake pool ranking logic to display the same rank for all stake pools without potential rewards ([PR 2226](https://github.com/input-output-hk/daedalus/pull/2226))
 - Replaced several tooltips with new react-polymorph `PopOver` component ([PR 2210](https://github.com/input-output-hk/daedalus/pull/2210), [PR 2223](https://github.com/input-output-hk/daedalus/pull/2223))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Features
 
-- Updated stake pool ranking logic to display the same rank for all stake pools without potential rewards ([PR 2226](https://github.com/input-output-hk/daedalus/pull/2226))
+- Updated stake pool ranking logic to display the same rank for all stake pools without potential rewards ([PR 2227](https://github.com/input-output-hk/daedalus/pull/2227))
 - Replaced several tooltips with new react-polymorph `PopOver` component ([PR 2210](https://github.com/input-output-hk/daedalus/pull/2210), [PR 2223](https://github.com/input-output-hk/daedalus/pull/2223))
 
 ### Fixes

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { orderBy } from 'lodash';
 import classNames from 'classnames';
-import { defineMessages, intlShape } from 'react-intl';
+import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
 import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
 import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
 import styles from './StakePoolsTable.scss';
@@ -22,7 +22,7 @@ const messages = defineMessages({
   tableHeaderRankTooltip: {
     id: 'staking.stakePools.tooltip.rankingTooltip',
     defaultMessage:
-      '!!!A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.',
+      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
     description: '"Rank" tooltip for the Stake Pools Table.',
   },
   tableHeaderTicker: {
@@ -283,7 +283,11 @@ export class StakePoolsTable extends Component<Props, State> {
             key="ranking"
             isOpeningUpward={false}
             skin={TooltipSkin}
-            tip={intl.formatMessage(messages.tableHeaderRankTooltip)}
+            tip={
+              <div className={styles.tooltipWithHTMLContent}>
+                <FormattedHTMLMessage {...messages.tableHeaderRankTooltip} />
+              </div>
+            }
           >
             {intl.formatMessage(messages.tableHeaderRank)}
           </Tooltip>

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTable.js
@@ -22,7 +22,7 @@ const messages = defineMessages({
   tableHeaderRankTooltip: {
     id: 'staking.stakePools.tooltip.rankingTooltip',
     defaultMessage:
-      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
+      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>*Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
     description: '"Rank" tooltip for the Stake Pools Table.',
   },
   tableHeaderTicker: {

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTable.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTable.scss
@@ -113,6 +113,21 @@
         justify-content: space-between;
         width: 100%;
 
+        .tooltipWithHTMLContent {
+          p {
+            -webkit-box-orient: horizontal;
+            display: block;
+            -webkit-line-clamp: none;
+            overflow: visible;
+            text-overflow: clip;
+            word-break: normal;
+
+            & + p {
+              margin-top: 6px;
+            }
+          }
+        }
+
         :global {
           .SimpleTooltip_root {
             .SimpleTooltip_bubble {
@@ -271,6 +286,13 @@
         .stakePoolReference {
           font-family: var(--font-medium);
         }
+      }
+
+      .asterisk {
+        font-family: Verdana;
+        margin-right: -8px;
+        opacity: 50%;
+        width: 8px;
       }
 
       .saturation {

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
@@ -220,7 +220,14 @@ export class StakePoolsTableBody extends Component<
           }
         >
           <td>
-            {!memberRewards.isZero() ? rank : numberOfRankedStakePools + 1}
+            {!memberRewards.isZero() ? (
+              rank
+            ) : (
+              <>
+                {numberOfRankedStakePools + 1}
+                <span className={styles.asterisk}>*</span>
+              </>
+            )}
             {isHighlighted && (
               <TooltipPool
                 stakePool={stakePool}

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsTableBody.js
@@ -195,10 +195,10 @@ export class StakePoolsTableBody extends Component<
       const producedBlocks = get(stakePool, 'producedBlocks', '');
       const pledge = new BigNumber(get(stakePool, 'pledge', ''));
       const retiring = get(stakePool, 'retiring', '');
-      const memberRewards = get(stakePool, 'potentialRewards', '');
-      const potentialRewards = !memberRewards.isZero()
-        ? formattedWalletAmount(memberRewards)
-        : '-';
+      const memberRewards = new BigNumber(
+        get(stakePool, 'potentialRewards', '')
+      );
+      const potentialRewards = formattedWalletAmount(memberRewards);
       const retirement =
         retiring && moment(retiring).locale(intl.locale).fromNow(true);
       const pledgeValue = formattedWalletAmount(pledge, false, false);
@@ -220,7 +220,7 @@ export class StakePoolsTableBody extends Component<
           }
         >
           <td>
-            {!memberRewards.isZero() ? rank : '-'}
+            {!memberRewards.isZero() ? rank : numberOfRankedStakePools + 1}
             {isHighlighted && (
               <TooltipPool
                 stakePool={stakePool}

--- a/source/renderer/app/components/staking/widgets/ThumbPoolContent.js
+++ b/source/renderer/app/components/staking/widgets/ThumbPoolContent.js
@@ -46,7 +46,14 @@ export default class ThumbPoolContent extends Component<Props> {
         <div className={styles.ticker}>{ticker}</div>
         {IS_RANKING_DATA_AVAILABLE ? (
           <div className={styles.ranking} style={{ color }}>
-            {nonMyopicMemberRewards ? ranking : numberOfRankedStakePools + 1}
+            {nonMyopicMemberRewards ? (
+              ranking
+            ) : (
+              <>
+                {numberOfRankedStakePools + 1}
+                <sup>*</sup>
+              </>
+            )}
           </div>
         ) : (
           <div className={styles.noDataDash}>

--- a/source/renderer/app/components/staking/widgets/ThumbPoolContent.js
+++ b/source/renderer/app/components/staking/widgets/ThumbPoolContent.js
@@ -44,9 +44,9 @@ export default class ThumbPoolContent extends Component<Props> {
     return (
       <div className={componentClassnames}>
         <div className={styles.ticker}>{ticker}</div>
-        {IS_RANKING_DATA_AVAILABLE && nonMyopicMemberRewards ? (
+        {IS_RANKING_DATA_AVAILABLE ? (
           <div className={styles.ranking} style={{ color }}>
-            {ranking}
+            {nonMyopicMemberRewards ? ranking : numberOfRankedStakePools + 1}
           </div>
         ) : (
           <div className={styles.noDataDash}>
@@ -62,7 +62,7 @@ export default class ThumbPoolContent extends Component<Props> {
             />
           </div>
         )}
-        {IS_RANKING_DATA_AVAILABLE && nonMyopicMemberRewards ? (
+        {IS_RANKING_DATA_AVAILABLE ? (
           <>
             {retiring && (
               <div className={styles.clock}>

--- a/source/renderer/app/components/staking/widgets/ThumbPoolContent.scss
+++ b/source/renderer/app/components/staking/widgets/ThumbPoolContent.scss
@@ -25,7 +25,16 @@
   .ranking {
     font-size: 20px;
     font-weight: bold;
+    position: relative;
     text-align: center;
+
+    sup {
+      font-family: Verdana;
+      font-size: 14px;
+      margin-left: -1px;
+      position: absolute;
+      top: -2px;
+    }
   }
 
   .noDataDash {

--- a/source/renderer/app/components/staking/widgets/ThumbSelectedPool.js
+++ b/source/renderer/app/components/staking/widgets/ThumbSelectedPool.js
@@ -26,13 +26,9 @@ export default class ThumbSelectedPool extends Component<Props> {
       numberOfRankedStakePools,
     } = this.props;
 
-    const { ticker, retiring, ranking, nonMyopicMemberRewards } =
-      stakePool || {};
+    const { ticker, retiring, ranking } = stakePool || {};
     const rankColor =
-      stakePool &&
-      !retiring &&
-      IS_RANKING_DATA_AVAILABLE &&
-      nonMyopicMemberRewards
+      stakePool && !retiring && IS_RANKING_DATA_AVAILABLE
         ? getColorFromRange(ranking, numberOfRankedStakePools)
         : null;
 

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -477,10 +477,7 @@ export default class TooltipPool extends Component<Props, State> {
   };
 
   get isGreyColor() {
-    return (
-      IS_RANKING_DATA_AVAILABLE &&
-      this.props.stakePool.potentialRewards.isZero()
-    );
+    return !IS_RANKING_DATA_AVAILABLE;
   }
 
   renderDescriptionFields = () => {
@@ -526,7 +523,7 @@ export default class TooltipPool extends Component<Props, State> {
         key: 'ranking',
         value: (
           <div className={styles.ranking}>
-            {!this.isGreyColor ? (
+            {IS_RANKING_DATA_AVAILABLE ? (
               <span
                 style={{
                   background: getColorFromRange(ranking, {
@@ -536,7 +533,9 @@ export default class TooltipPool extends Component<Props, State> {
                   }),
                 }}
               >
-                {ranking}
+                {!potentialRewards.isZero()
+                  ? ranking
+                  : numberOfRankedStakePools + 1}
               </span>
             ) : (
               <div className={styles.noDataDash}>
@@ -631,15 +630,9 @@ export default class TooltipPool extends Component<Props, State> {
         key: 'potentialRewards',
         value: (
           <div className={styles.defaultColor}>
-            {!potentialRewards.isZero() ? (
-              <span className={styles.defaultColorContent}>
-                {formattedWalletAmount(potentialRewards)}
-              </span>
-            ) : (
-              <div className={styles.noDataDash}>
-                <SVGInline svg={noDataDashSmallImage} />
-              </div>
-            )}
+            <span className={styles.defaultColorContent}>
+              {formattedWalletAmount(potentialRewards)}
+            </span>
           </div>
         ),
       },

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -61,7 +61,7 @@ const messages = defineMessages({
   rankingTooltip: {
     id: 'staking.stakePools.tooltip.rankingTooltip',
     defaultMessage:
-      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
+      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>*Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
     description: '"Rank" tooltip for the Stake Pools Tooltip page.',
   },
   relativeStake: {

--- a/source/renderer/app/components/staking/widgets/TooltipPool.js
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.js
@@ -1,7 +1,12 @@
 // @flow
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
-import { defineMessages, intlShape, FormattedMessage } from 'react-intl';
+import {
+  defineMessages,
+  intlShape,
+  FormattedMessage,
+  FormattedHTMLMessage,
+} from 'react-intl';
 import { Button } from 'react-polymorph/lib/components/Button';
 import { Tooltip } from 'react-polymorph/lib/components/Tooltip';
 import { TooltipSkin } from 'react-polymorph/lib/skins/simple/TooltipSkin';
@@ -56,7 +61,7 @@ const messages = defineMessages({
   rankingTooltip: {
     id: 'staking.stakePools.tooltip.rankingTooltip',
     defaultMessage:
-      '!!!A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.',
+      '!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>',
     description: '"Rank" tooltip for the Stake Pools Tooltip page.',
   },
   relativeStake: {
@@ -533,9 +538,14 @@ export default class TooltipPool extends Component<Props, State> {
                   }),
                 }}
               >
-                {!potentialRewards.isZero()
-                  ? ranking
-                  : numberOfRankedStakePools + 1}
+                {!potentialRewards.isZero() ? (
+                  ranking
+                ) : (
+                  <>
+                    {numberOfRankedStakePools + 1}
+                    <span className={styles.asterisk}>*</span>
+                  </>
+                )}
               </span>
             ) : (
               <div className={styles.noDataDash}>
@@ -646,7 +656,13 @@ export default class TooltipPool extends Component<Props, State> {
               <Tooltip
                 key={field.key}
                 skin={TooltipSkin}
-                tip={intl.formatMessage(messages[`${field.key}Tooltip`])}
+                tip={
+                  <div className={styles.tooltipWithHTMLContent}>
+                    <FormattedHTMLMessage
+                      {...messages[`${field.key}Tooltip`]}
+                    />
+                  </div>
+                }
               >
                 <div className={styles.labelContainer}>
                   <div className={styles.fieldLabel}>

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -473,6 +473,21 @@
         }
       }
 
+      .tooltipWithHTMLContent {
+        p {
+          -webkit-box-orient: horizontal;
+          display: block;
+          -webkit-line-clamp: none;
+          overflow: visible;
+          text-overflow: clip;
+          word-break: normal;
+
+          & + p {
+            margin-top: 6px;
+          }
+        }
+      }
+
       :global {
         .SimpleTooltip_root {
           .SimpleTooltip_bubble {
@@ -571,6 +586,11 @@
 
   .ranking {
     position: relative;
+
+    .asterisk {
+      font-family: Verdana;
+      padding: 0 !important;
+    }
   }
 }
 

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -5504,7 +5504,7 @@
         }
       },
       {
-        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
+        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>*Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
         "description": "\"Rank\" tooltip for the Stake Pools Table.",
         "end": {
           "column": 3,
@@ -5775,7 +5775,7 @@
         }
       },
       {
-        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
+        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>*Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
         "description": "\"Rank\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -5504,7 +5504,7 @@
         }
       },
       {
-        "defaultMessage": "!!!A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.",
+        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
         "description": "\"Rank\" tooltip for the Stake Pools Table.",
         "end": {
           "column": 3,
@@ -5765,27 +5765,27 @@
         "description": "\"Rank\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 55
+          "line": 60
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.ranking",
         "start": {
           "column": 11,
-          "line": 51
+          "line": 56
         }
       },
       {
-        "defaultMessage": "!!!A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.",
+        "defaultMessage": "!!!<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
         "description": "\"Rank\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 61
+          "line": 66
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.rankingTooltip",
         "start": {
           "column": 18,
-          "line": 56
+          "line": 61
         }
       },
       {
@@ -5793,13 +5793,13 @@
         "description": "\"Live stake\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 71
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.relativeStake",
         "start": {
           "column": 17,
-          "line": 62
+          "line": 67
         }
       },
       {
@@ -5807,13 +5807,13 @@
         "description": "\"Live stake\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 72
+          "line": 77
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.relativeStakeTooltip",
         "start": {
           "column": 24,
-          "line": 67
+          "line": 72
         }
       },
       {
@@ -5821,13 +5821,13 @@
         "description": "\"Pool margin\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 77
+          "line": 82
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.profitMargin",
         "start": {
           "column": 16,
-          "line": 73
+          "line": 78
         }
       },
       {
@@ -5835,13 +5835,13 @@
         "description": "\"Pool margin\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 83
+          "line": 88
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.profitMarginTooltip",
         "start": {
           "column": 23,
-          "line": 78
+          "line": 83
         }
       },
       {
@@ -5849,13 +5849,13 @@
         "description": "\"Cost per epoch\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 88
+          "line": 93
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.costPerEpoch",
         "start": {
           "column": 16,
-          "line": 84
+          "line": 89
         }
       },
       {
@@ -5863,13 +5863,13 @@
         "description": "\"Cost per epoch\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 94
+          "line": 99
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.costPerEpochTooltip",
         "start": {
           "column": 23,
-          "line": 89
+          "line": 94
         }
       },
       {
@@ -5877,13 +5877,13 @@
         "description": "\"Blocks\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 99
+          "line": 104
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.producedBlocks",
         "start": {
           "column": 18,
-          "line": 95
+          "line": 100
         }
       },
       {
@@ -5891,13 +5891,13 @@
         "description": "\"Blocks\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 105
+          "line": 110
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.producedBlocksTooltip",
         "start": {
           "column": 25,
-          "line": 100
+          "line": 105
         }
       },
       {
@@ -5905,13 +5905,13 @@
         "description": "\"Rewards\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 115
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.potentialRewards",
         "start": {
           "column": 20,
-          "line": 106
+          "line": 111
         }
       },
       {
@@ -5919,13 +5919,13 @@
         "description": "\"Rewards\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 116
+          "line": 121
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.potentialRewardsTooltip",
         "start": {
           "column": 27,
-          "line": 111
+          "line": 116
         }
       },
       {
@@ -5933,13 +5933,13 @@
         "description": "\"Retirement\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 121
+          "line": 126
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.retirement",
         "start": {
           "column": 14,
-          "line": 117
+          "line": 122
         }
       },
       {
@@ -5947,13 +5947,13 @@
         "description": "\"Saturation\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 126
+          "line": 131
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.saturation",
         "start": {
           "column": 14,
-          "line": 122
+          "line": 127
         }
       },
       {
@@ -5961,13 +5961,13 @@
         "description": "\"Saturation\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 132
+          "line": 137
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.saturationTooltip",
         "start": {
           "column": 21,
-          "line": 127
+          "line": 132
         }
       },
       {
@@ -5975,13 +5975,13 @@
         "description": "\"Pledge\" for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 137
+          "line": 142
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.pledge",
         "start": {
           "column": 10,
-          "line": 133
+          "line": 138
         }
       },
       {
@@ -5989,13 +5989,13 @@
         "description": "\"Pledge\" tooltip for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 143
+          "line": 148
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.pledgeTooltip",
         "start": {
           "column": 17,
-          "line": 138
+          "line": 143
         }
       },
       {
@@ -6003,13 +6003,13 @@
         "description": "\"Delegate to this pool\" Button for the Stake Pools Tooltip page.",
         "end": {
           "column": 3,
-          "line": 149
+          "line": 154
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.delegateButton",
         "start": {
           "column": 18,
-          "line": 144
+          "line": 149
         }
       },
       {
@@ -6017,13 +6017,13 @@
         "description": "Experimental tooltip label",
         "end": {
           "column": 3,
-          "line": 154
+          "line": 159
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.experimentalTooltipLabel",
         "start": {
           "column": 28,
-          "line": 150
+          "line": 155
         }
       },
       {
@@ -6031,13 +6031,13 @@
         "description": "copyId tooltip label",
         "end": {
           "column": 3,
-          "line": 159
+          "line": 164
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.tooltip.copyIdTooltipLabel",
         "start": {
           "column": 22,
-          "line": 155
+          "line": 160
         }
       },
       {
@@ -6045,13 +6045,13 @@
         "description": "Data not available yet label",
         "end": {
           "column": 3,
-          "line": 164
+          "line": 169
         },
         "file": "source/renderer/app/components/staking/widgets/TooltipPool.js",
         "id": "staking.stakePools.noDataDashTooltip",
         "start": {
           "column": 26,
-          "line": 160
+          "line": 165
         }
       }
     ],

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -493,7 +493,7 @@
   "staking.stakePools.tooltip.profitMargin": "Pool margin:",
   "staking.stakePools.tooltip.profitMarginTooltip": "The pool's profit, defined as the rewards percentage kept by the pool from the stake that was delegated to it.",
   "staking.stakePools.tooltip.ranking": "Rank:",
-  "staking.stakePools.tooltip.rankingTooltip": "A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.",
+  "staking.stakePools.tooltip.rankingTooltip": "<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
   "staking.stakePools.tooltip.relativeStake": "Live stake:",
   "staking.stakePools.tooltip.relativeStakeTooltip": "Measures the amount of stake pledged by the pool plus the amount of stake currently delegated to the pool, versus the total amount in the system.",
   "staking.stakePools.tooltip.retirement": "Retirement in {retirementFromNow}",

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -493,7 +493,7 @@
   "staking.stakePools.tooltip.profitMargin": "Pool margin:",
   "staking.stakePools.tooltip.profitMarginTooltip": "The pool's profit, defined as the rewards percentage kept by the pool from the stake that was delegated to it.",
   "staking.stakePools.tooltip.ranking": "Rank:",
-  "staking.stakePools.tooltip.rankingTooltip": "<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>* Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
+  "staking.stakePools.tooltip.rankingTooltip": "<p>A hierarchical ranking based on the potential rewards you will earn if you delegate the intended amount of stake to this pool, assuming that it reaches saturation.</p><p>*Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.</p>",
   "staking.stakePools.tooltip.relativeStake": "Live stake:",
   "staking.stakePools.tooltip.relativeStakeTooltip": "Measures the amount of stake pledged by the pool plus the amount of stake currently delegated to the pool, versus the total amount in the system.",
   "staking.stakePools.tooltip.retirement": "Retirement in {retirementFromNow}",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -493,7 +493,7 @@
   "staking.stakePools.tooltip.profitMargin": "プールマージン：",
   "staking.stakePools.tooltip.profitMarginTooltip": "プールが得る利益としてプールが設定した、プールに委任されたステークへの報酬から差し引く割合",
   "staking.stakePools.tooltip.ranking": "ランク：",
-  "staking.stakePools.tooltip.rankingTooltip": "対象プールに意図した量のステークを委任することにより得られる見込み報酬に基づいたランキングで、計算は飽和状態を想定",
+  "staking.stakePools.tooltip.rankingTooltip": "<p>対象プールに意図した量のステークを委任することにより得られる見込み報酬に基づいたランキングで、計算は飽和状態を想定。</p><p>*見込み報酬額の見積もりがゼロのステークプールはランキングが同じになります。見込み報酬額がゼロより大きなプールを増やすには、ステークスライダーをより高額に設定してください。</p>",
   "staking.stakePools.tooltip.relativeStake": "ライブステーク：",
   "staking.stakePools.tooltip.relativeStakeTooltip": "システムのステーク総量に対する、プールに出資されたステークと現在委任されているステークの合計",
   "staking.stakePools.tooltip.retirement": "あと{retirementFromNow}で終了",


### PR DESCRIPTION
This PR updates stake pool ranking logic to display the same rank for all stake pools without potential rewards.

Specification:
- Design: https://zpl.io/2p5dz9l
- Requirements: https://docs.google.com/document/d/1jgoaZ_CUXh6z66Eb7K7cXwhN-yw6Iv1fu0fgDVGwcpM/edit#heading=h.mq51cxvzrjz (last page)
- Text copy:

English:
> *Stake pools with the potential rewards estimated at zero have the same ranking. Please set the stake slider to a higher value for more pools to get potential rewards estimated at more than zero.
 
Japanese:
> *見込み報酬額の見積もりがゼロのステークプールはランキングが同じになります。見込み報酬額がゼロより大きなプールを増やすには、ステークスライダーをより高額に設定してください。

## Screenshots

![Screenshot 2020-11-03 at 13 30 38](https://user-images.githubusercontent.com/376611/97985615-c75f8700-1dd8-11eb-84e9-f9fb82a218b0.png)

![Screenshot 2020-11-03 at 13 24 10](https://user-images.githubusercontent.com/376611/97985130-1a850a00-1dd8-11eb-9fa7-9c955c01067e.png)

![Screenshot 2020-11-03 at 13 30 24](https://user-images.githubusercontent.com/376611/97985622-c9c1e100-1dd8-11eb-8246-32c176fb772e.png)

![Screenshot 2020-11-03 at 13 24 33](https://user-images.githubusercontent.com/376611/97985167-2bce1680-1dd8-11eb-9b1b-a6217720b7c2.png)


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test stake pool ranks in order to make sure all stake pools without potential rewards have the same rank and color

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
