### PR TITLE
Fix empty disk space calculation for some Linux distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixes
 
+- Fixed empty disk space calculation for some Linux distributions ([PR 2258](https://github.com/input-output-hk/daedalus/pull/2258))
 - Fixed the overlap of the "X" button in the stake pools search box ([PR 2251](https://github.com/input-output-hk/daedalus/pull/2251))
 
 ## 2.5.0

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -125,7 +125,7 @@ export const {
 export const appLogsFolderPath = logsPrefix;
 export const pubLogsFolderPath = path.join(appLogsFolderPath, 'pub');
 export const stateDirectoryPath = stateDir;
-export const stateDrive = isWindows ? stateDirectoryPath.slice(0, 2) : '/';
+export const stateDrive = isWindows ? stateDirectoryPath.slice(0, 2) : stateDir;
 export const buildLabel = getBuildLabel(
   build,
   network,

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -125,7 +125,6 @@ export const {
 export const appLogsFolderPath = logsPrefix;
 export const pubLogsFolderPath = path.join(appLogsFolderPath, 'pub');
 export const stateDirectoryPath = stateDir;
-export const stateDrive = isWindows ? stateDirectoryPath.slice(0, 2) : stateDir;
 export const buildLabel = getBuildLabel(
   build,
   network,

--- a/source/main/utils/handleDiskSpace.js
+++ b/source/main/utils/handleDiskSpace.js
@@ -11,7 +11,7 @@ import {
   DISK_SPACE_CHECK_MEDIUM_INTERVAL,
   DISK_SPACE_CHECK_SHORT_INTERVAL,
   DISK_SPACE_RECOMMENDED_PERCENTAGE,
-  stateDrive,
+  stateDirectoryPath,
 } from '../config';
 
 export const handleDiskSpace = (
@@ -28,7 +28,7 @@ export const handleDiskSpace = (
       const {
         free: diskSpaceAvailable,
         size: diskTotalSpace,
-      } = await checkDiskSpace(stateDrive);
+      } = await checkDiskSpace(stateDirectoryPath);
       const diskSpaceMissing = Math.max(
         diskSpaceRequired - diskSpaceAvailable,
         0


### PR DESCRIPTION
The Linux installer runs Daedalus inside a chroot, which lives in a temporary directory.

Some - perhaps most - Linux distros have the temporary directory as a tmpfs (RAM drive).

So when Daedalus checks the free space in /, it is reporting the amount of free space on the tmpfs - typically only a few GB.

This change makes Daedalus check the free space for the state directory.

In any case, this is a good thing to do, because the state directory (in the user's home directory) may be on a different partition to /.

### Testing

I haven't done any testing on this.

