### PR TITLE
[DDW-503] Show stake pool ID on the "Confirmation" step of the "Delegation" wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Changelog
 
 ### Chores
 
-- Showed stake pool ID on the "Confirmation" step of the "Delegation" wizard ([PR 2281](https://github.com/input-output-hk/daedalus/pull/2281))
+- Included stake pool ID on the "Confirmation" step of the "Delegation" wizard and enabled search by stake pool ID on the "Stake Pools" screen ([PR 2281](https://github.com/input-output-hk/daedalus/pull/2281))
 - Updated `iohk-nix` in order to fix `cardano-node` logging levels ([PR 2283](https://github.com/input-output-hk/daedalus/pull/2283))
 - Updated `@cardano-foundation/ledgerjs-hw-app-cardano` package to version `2.1.0` ([PR 2279](https://github.com/input-output-hk/daedalus/pull/2279))
 - Updated `ini` package ([PR 2278](https://github.com/input-output-hk/daedalus/pull/2278))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 
 ### Chores
 
+- Showed stake pool ID on the "Confirmation" step of the "Delegation" wizard ([PR 2281](https://github.com/input-output-hk/daedalus/pull/2281))
 - Updated `@cardano-foundation/ledgerjs-hw-app-cardano` package to version `2.1.0` ([PR 2279](https://github.com/input-output-hk/daedalus/pull/2279))
 - Updated `ini` package ([PR 2278](https://github.com/input-output-hk/daedalus/pull/2278))
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -191,10 +191,7 @@ gulp.task(
 
 gulp.task('test:e2e:watch', gulp.series('build:watch', 'test:e2e:nodemon'));
 
-gulp.task(
-  'purge:translations',
-  shell.task('rimraf ./translations/messages/source')
-);
+gulp.task('purge:translations', shell.task('rimraf ./translations/messages'));
 
 gulp.task('electron:inspector', shell.task('yarn electron:inspector'));
 

--- a/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js
+++ b/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js
@@ -53,6 +53,12 @@ const messages = defineMessages({
     description:
       'Description on the delegation setup "confirmation" step dialog.',
   },
+  stakePoolIdLabel: {
+    id: 'staking.delegationSetup.confirmation.step.dialog.stakePoolIdLabel',
+    defaultMessage: '!!!Stake pool ID',
+    description:
+      'Stake pool ID label on the delegation setup "confirmation" step dialog.',
+  },
   feesLabel: {
     id: 'staking.delegationSetup.confirmation.step.dialog.feesLabel',
     defaultMessage: '!!!Fees',
@@ -185,6 +191,7 @@ export default class DelegationStepsConfirmationDialog extends Component<Props> 
     const selectedWalletName = get(selectedWallet, 'name');
     const isHardwareWallet = get(selectedWallet, 'isHardwareWallet');
     const selectedPoolTicker = get(selectedPool, 'ticker');
+    const selectedPoolId = get(selectedPool, 'id');
     const spendingPasswordField = form.$('spendingPassword');
 
     const buttonLabel = !isSubmitting ? (
@@ -261,6 +268,13 @@ export default class DelegationStepsConfirmationDialog extends Component<Props> 
               }}
             />
           </p>
+
+          <div className={styles.stakePoolIdWrapper}>
+            <p className={styles.stakePoolIdLabel}>
+              {intl.formatMessage(messages.stakePoolIdLabel)}
+            </p>
+            <p className={styles.stakePoolId}>{selectedPoolId}</p>
+          </div>
 
           <div className={styles.feesWrapper}>
             <p className={styles.feesLabel}>

--- a/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.scss
+++ b/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.scss
@@ -14,15 +14,23 @@
       }
     }
 
+    .stakePoolIdWrapper,
     .feesWrapper {
       font-family: var(--font-medium);
       font-weight: 500;
       line-height: 1.38;
       margin-bottom: 20px;
 
+      .stakePoolIdLabel,
       .feesLabel {
         color: var(--theme-delegation-steps-confirmation-fees-label-color);
         margin-bottom: 6px;
+      }
+
+      .stakePoolId {
+        color: var(--theme-delegation-steps-confirmation-description-color);
+        font-family: var(--font-light);
+        line-height: 1.38;
       }
 
       .calculatingFeesLabel {

--- a/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.scss
+++ b/source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.scss
@@ -30,7 +30,7 @@
       .stakePoolId {
         color: var(--theme-delegation-steps-confirmation-description-color);
         font-family: var(--font-light);
-        line-height: 1.38;
+        user-select: text;
       }
 
       .calculatingFeesLabel {

--- a/source/renderer/app/components/staking/stake-pools/helpers.js
+++ b/source/renderer/app/components/staking/stake-pools/helpers.js
@@ -2,7 +2,7 @@
 import StakePool from '../../../domains/StakePool';
 import type { StakePoolProps } from '../../../domains/StakePool';
 
-const searchFields = ['ticker', 'name'];
+const searchFields = ['id', 'ticker', 'name'];
 
 const stakePoolsListSearch = (stakePool: StakePoolProps, rawSearch: string) => {
   const search = rawSearch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').trim();

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -3882,17 +3882,31 @@
         }
       },
       {
-        "defaultMessage": "!!!Fees",
-        "description": "Fees label on the delegation setup \"confirmation\" step dialog.",
+        "defaultMessage": "!!!Stake pool ID",
+        "description": "Stake pool ID label on the delegation setup \"confirmation\" step dialog.",
         "end": {
           "column": 3,
           "line": 61
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
+        "id": "staking.delegationSetup.confirmation.step.dialog.stakePoolIdLabel",
+        "start": {
+          "column": 20,
+          "line": 56
+        }
+      },
+      {
+        "defaultMessage": "!!!Fees",
+        "description": "Fees label on the delegation setup \"confirmation\" step dialog.",
+        "end": {
+          "column": 3,
+          "line": 67
+        },
+        "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.feesLabel",
         "start": {
           "column": 13,
-          "line": 56
+          "line": 62
         }
       },
       {
@@ -3900,13 +3914,13 @@
         "description": "Placeholder for \"spending password\"",
         "end": {
           "column": 3,
-          "line": 67
+          "line": 73
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.spendingPasswordPlaceholder",
         "start": {
           "column": 31,
-          "line": 62
+          "line": 68
         }
       },
       {
@@ -3914,13 +3928,13 @@
         "description": "Label for \"spending password\"",
         "end": {
           "column": 3,
-          "line": 73
+          "line": 79
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.spendingPasswordLabel",
         "start": {
           "column": 25,
-          "line": 68
+          "line": 74
         }
       },
       {
@@ -3928,13 +3942,13 @@
         "description": "Label for continue button on the delegation setup \"confirmation\" step dialog.",
         "end": {
           "column": 3,
-          "line": 79
+          "line": 85
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.confirmButtonLabel",
         "start": {
           "column": 22,
-          "line": 74
+          "line": 80
         }
       },
       {
@@ -3942,13 +3956,13 @@
         "description": "Label for \"Cancel\" button on the delegation setup \"confirmation\" step dialog.",
         "end": {
           "column": 3,
-          "line": 85
+          "line": 91
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.cancelButtonLabel",
         "start": {
           "column": 21,
-          "line": 80
+          "line": 86
         }
       },
       {
@@ -3956,13 +3970,13 @@
         "description": "\"Calculating fees\" message in the \"Undelegate\" dialog.",
         "end": {
           "column": 3,
-          "line": 90
+          "line": 96
         },
         "file": "source/renderer/app/components/staking/delegation-setup-wizard/DelegationStepsConfirmationDialog.js",
         "id": "staking.delegationSetup.confirmation.step.dialog.calculatingFees",
         "start": {
           "column": 19,
-          "line": 86
+          "line": 92
         }
       }
     ],
@@ -10697,13 +10711,13 @@
         "description": "Title for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 32
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.title",
         "start": {
           "column": 9,
-          "line": 27
+          "line": 28
         }
       },
       {
@@ -10711,13 +10725,13 @@
         "description": "Description for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 37
+          "line": 38
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.description",
         "start": {
           "column": 15,
-          "line": 32
+          "line": 33
         }
       },
       {
@@ -10725,13 +10739,13 @@
         "description": "Empty wallet description for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 43
+          "line": 44
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.emptyWallet",
         "start": {
           "column": 15,
-          "line": 38
+          "line": 39
         }
       },
       {
@@ -10739,13 +10753,13 @@
         "description": "\"Find out more\" link on the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 48
+          "line": 49
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.findOutMoreLink",
         "start": {
           "column": 19,
-          "line": 44
+          "line": 45
         }
       },
       {
@@ -10753,13 +10767,13 @@
         "description": "\"Find out more\" link URL on the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 54
+          "line": 55
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.findOutMoreLinkUrl",
         "start": {
           "column": 22,
-          "line": 49
+          "line": 50
         }
       },
       {
@@ -10767,13 +10781,13 @@
         "description": "Label X for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 59
+          "line": 60
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.labelX",
         "start": {
           "column": 10,
-          "line": 55
+          "line": 56
         }
       },
       {
@@ -10781,13 +10795,13 @@
         "description": "Label Y for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 64
+          "line": 65
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.labelY",
         "start": {
           "column": 10,
-          "line": 60
+          "line": 61
         }
       },
       {
@@ -10795,13 +10809,13 @@
         "description": "Number of pending transactions for the \"Wallet Utxos\" screen.",
         "end": {
           "column": 3,
-          "line": 71
+          "line": 72
         },
         "file": "source/renderer/app/components/wallet/utxo/WalletUtxo.js",
         "id": "wallet.settings.utxos.pendingTransactions",
         "start": {
           "column": 23,
-          "line": 65
+          "line": 66
         }
       }
     ],

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -356,6 +356,7 @@
   "staking.delegationSetup.confirmation.step.dialog.feesLabel": "Fees",
   "staking.delegationSetup.confirmation.step.dialog.spendingPasswordLabel": "Spending password",
   "staking.delegationSetup.confirmation.step.dialog.spendingPasswordPlaceholder": "Enter your password",
+  "staking.delegationSetup.confirmation.step.dialog.stakePoolIdLabel": "Stake pool ID",
   "staking.delegationSetup.confirmation.step.dialog.stepIndicatorLabel": "STEP {currentStep} OF {totalSteps}",
   "staking.delegationSetup.confirmation.step.dialog.title": "Confirm Delegation",
   "staking.delegationSetup.intro.step.dialog.cancelButtonLabel": "Cancel",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -356,6 +356,7 @@
   "staking.delegationSetup.confirmation.step.dialog.feesLabel": "手数料",
   "staking.delegationSetup.confirmation.step.dialog.spendingPasswordLabel": "送信時パスワード",
   "staking.delegationSetup.confirmation.step.dialog.spendingPasswordPlaceholder": "パスワードを入力してください",
+  "staking.delegationSetup.confirmation.step.dialog.stakePoolIdLabel": "ステークプールID",
   "staking.delegationSetup.confirmation.step.dialog.stepIndicatorLabel": "ステップ{currentStep}/{totalSteps}",
   "staking.delegationSetup.confirmation.step.dialog.title": "委任を確認する",
   "staking.delegationSetup.intro.step.dialog.cancelButtonLabel": "キャンセル",


### PR DESCRIPTION
This PR updated "Confirmation" step of the "Delegation" wizard to show stake pool ID.
[Jira Ticket](https://jira.iohk.io/browse/DDW-503)

## Todos
- [x] Show stake pool ID on the "Confirmation" step of the "Delegation" wizard
- [x] Make stake pool ID searchable

## Testing Checklist
- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1608199573054900)

### App
- [x] Go to `Staking` => `Stake pools` screen
- [x] Try searching stake pool by inputing stake pool id in search field and make sure search is working fine
- [x] Select one stake pool and click on the `Delegate to this pool` button to open `Delegate Wallet` modal
- [x] Click on `Continue` button, select one wallet, and then click on `Continue` button 2 times to be at `Confirm Delegation` step
- [x] Make sure `Stake pool ID` is shown on this step

## Test Cases

**Scenario 1: Pool id is displayed at last delegation step**
Given I have a wallet
And the wallet contains at least the minimum ada required for delegation
And I am on Stake Pool -> Delegation Center
And I have selected (delegate|redelegate) button
And in 'DELEGATE WALLET' dialog I have selected 'Continue'
And in Step 1 of 3 - DELEGATE WALLET I have selected 'Continue'
And in Step 2 of 3 - CHOOSE A STAKE POOL I have selected a pool
When in Step 2 of 3 - CHOOSE A STAKE POOL I select Continue'
Then dialog Step 3 of 3 - CONFIRM DELEGATION is displayed
And pool id is displayed below 'Stake pool ID' 

**Scenario 2: Able to search pool id in Step 2 delegation step**
Given I have a wallet
And the wallet contains at least the minimum ada required for delegation
And I am on Stake Pool -> Delegation Center
And I have selected (delegate|redelegate) button
And in 'DELEGATE WALLET' dialog I have selected 'Continue'
And in Step 1 of 3 - DELEGATE WALLET I have selected 'Continue'
And dialog Step 2 of 3 - CHOOSE A STAKE POOL is displayed
When I search for the 'poolId' in the 'Search stake pools' field
Then the searched pool will be shown underneath the 'Search stake pools' field
|poolId|
|--|
|`<poolId>`|
|`the front half of <poolId>`|

**Scenario 3: Able to search pool id in Stake Pool -> Stake pools**
Given I am on Stake Pool -> Stake pools
And I am on (tile|list) view
When I search for the 'poolId' in the 'Search stake pools' field
Then the searched pool will be shown underneath the 'Search stake pools' field
|poolId|
|--|
|`<poolId>`|
|`the front half of <poolId>`|

## Test Summary

For build 15671:

|Test cases | Results|Note|
|-----------|----|----|
|Scenario 1|Pass||
|Scenario 2|Pass||
|Scenario 3|Pass||


English
![image](https://user-images.githubusercontent.com/6207747/102475518-cf812800-400e-11eb-9596-4050dc376670.png)
![image](https://user-images.githubusercontent.com/6207747/102475573-de67da80-400e-11eb-89b6-70d6adf49742.png)

Japanese
![image](https://user-images.githubusercontent.com/6207747/102475638-f7708b80-400e-11eb-97c2-cc6e35023122.png)
![image](https://user-images.githubusercontent.com/6207747/102475687-08b99800-400f-11eb-8e3f-b52e42e21ec3.png)


## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes and shows some screenshots or animated GIFs of important UI changes
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
