### PR TITLE
[DDW-528] Spacing issues with "i" icon on "Set password" dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 
 ### Fixes
 
+- Fixed misalignment of the "i" icon on the "Set password" dialog ([PR 2337](https://github.com/input-output-hk/daedalus/pull/2337))
 - Removed steps counter from the "Success" wallet restoration dialog step ([PR 2335](https://github.com/input-output-hk/daedalus/pull/2335))
 
 ### Chores

--- a/source/renderer/app/components/wallet/settings/ChangeSpendingPasswordDialog.js
+++ b/source/renderer/app/components/wallet/settings/ChangeSpendingPasswordDialog.js
@@ -299,7 +299,7 @@ export default class ChangeSpendingPasswordDialog extends Component<Props> {
           )}
 
           <div className={newPasswordClasses}>
-            <div className={styles.spendingPasswordField}>
+            <div className={spendingPasswordClasses}>
               <PasswordInput
                 {...newPasswordField.bind()}
                 onKeyPress={this.handleSubmitOnEnter}

--- a/source/renderer/app/components/wallet/settings/ChangeSpendingPasswordDialog.scss
+++ b/source/renderer/app/components/wallet/settings/ChangeSpendingPasswordDialog.scss
@@ -26,7 +26,7 @@
 
       > span {
         height: 12px;
-        left: 145px;
+        left: 158px;
         outline: none;
         position: absolute;
         top: 4px;
@@ -35,6 +35,16 @@
 
       &.jpLangTooltipIcon {
         > span {
+          left: 134px !important;
+        }
+      }
+
+      .currentPassword + span {
+        left: 145px !important;
+      }
+
+      &.jpLangTooltipIcon {
+        .currentPassword + span {
           left: 135px !important;
         }
       }


### PR DESCRIPTION
This PR fixes the misalignment of the "i" icon on the "Set password" dialog.

## Screenshots

![Screenshot 2021-02-03 at 15 32 25](https://user-images.githubusercontent.com/376611/106761887-8c6a2b00-6635-11eb-98d2-237df270f878.png)
![Screenshot 2021-02-03 at 15 32 00](https://user-images.githubusercontent.com/376611/106761897-8e33ee80-6635-11eb-8cff-1e6aaab18f9f.png)

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Pair HW device with Daedalus, then exit Daedalus and remove config.json file from the state dir - this will make Daedalus think your HW is actually a software wallet with no password set. Then you can test this out by opening the summary screen of that wallet and entering the "Set password" dialog from there...

---
## Test Cases

**Scenario 1 - Check "i" icon on "Set password" dialog**
```Gherkin
Given that I am on the "Set password" dialog
When I validate the "i" icon 
Then I can see it is displayed next to "Spending password"
And it does not overlaps the text
```

**Scenario 2 - Hover "i" icon on "Set password" dialog**
```Gherkin
Given that I am on the "Set password" dialog
When I hover the "i" icon 
Then a tooltip with information about password managing is displayed over the icon
```

---
## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
