### PR TITLE
[DDW-574] Update cardano-wallet and cardano-launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Changelog
 
 ### Chores
 
-- Updated `cardano-launcher` to version `0.20210215.0` ([PR 2362](https://github.com/input-output-hk/daedalus/pull/2362))
-- Updated `cardano-wallet` to version `2021-02-15` ([PR 2362](https://github.com/input-output-hk/daedalus/pull/2362))
+- Updated `cardano-launcher` to version `0.20210215.0` ([PR 2363](https://github.com/input-output-hk/daedalus/pull/2363))
+- Updated `cardano-wallet` to version `2021-02-15` ([PR 2363](https://github.com/input-output-hk/daedalus/pull/2363))
 - Updated `cardano-wallet` to version `2021-02-12` ([PR 2358](https://github.com/input-output-hk/daedalus/pull/2358))
 - Improved the error messages for the custom SMASH server url input ([PR 2355](https://github.com/input-output-hk/daedalus/pull/2355))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Changelog
 
 ### Chores
 
+- Updated `cardano-launcher` to version `0.20210215.0` ([PR 2362](https://github.com/input-output-hk/daedalus/pull/2362))
+- Updated `cardano-wallet` to version `2021-02-15` ([PR 2362](https://github.com/input-output-hk/daedalus/pull/2362))
 - Updated `cardano-wallet` to version `2021-02-12` ([PR 2358](https://github.com/input-output-hk/daedalus/pull/2358))
 - Improved the error messages for the custom SMASH server url input ([PR 2355](https://github.com/input-output-hk/daedalus/pull/2355))
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,38 @@ Daedalus - Cryptocurrency Wallet
 1. Run `yarn nix:shelley_qa` from `daedalus`.
 2. Run `yarn dev` from the subsequent `nix-shell`
 
+#### Native token metadata server
+
+Daedalus, by default, uses the following metadata server for all networks except for the mainnet: `https://metadata.cardano-testnet.iohkdev.io/`.
+
+It's also possible to use a mock server locally by running the following command in `nix-shell` prior to starting Daedalus:
+
+```
+$ mock-token-metadata-server ./utils/cardano/native-tokens/registry.json
+Mock metadata server running with url http://localhost:65432/
+```
+
+Then proceed to launch Daedalus and make sure to provide the mock token metadata server port:
+
+```
+$ TOKEN_METADATA_SERVER_PORT=65432 yarn dev
+```
+
+This enables you to modify the metadata directly by modifying the registry file directly:
+
+```
+$ vi ./utils/cardano/native-tokens/registry.json        # ..or any other editor, if you prefer
+```
+
+Use the following command to check if the mock server is working correctly:
+
+```
+$ curl -i -H "Content-type: application/json" --data '{"subjects":["789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1"],"properties":["name","description","acronym","unit","logo"]}'
+http://localhost:65432/metadata/query
+```
+... and expect a "200 OK" response.
+
+
 ### Running Daedalus with Jormungandr
 
 #### ITN Selfnode

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Mock metadata server running with url http://localhost:65432/
 Then proceed to launch Daedalus and make sure to provide the mock token metadata server port:
 
 ```
-$ TOKEN_METADATA_SERVER_PORT=65432 yarn dev
+$ MOCK_TOKEN_METADATA_SERVER_PORT=65432 yarn dev
 ```
 
 This enables you to modify the metadata directly by modifying the registry file directly:

--- a/default.nix
+++ b/default.nix
@@ -85,6 +85,7 @@ let
     cardano-wallet = import self.sources.cardano-wallet { inherit system; gitrev = self.sources.cardano-wallet.rev; crossSystem = crossSystem walletPkgs.lib; };
     cardano-wallet-native = import self.sources.cardano-wallet { inherit system; gitrev = self.sources.cardano-wallet.rev; };
     cardano-address = (import self.sources.cardano-wallet { inherit system; gitrev = self.sources.cardano-wallet.rev; crossSystem = crossSystem walletPkgs.lib; }).cardano-address;
+    mock-token-metadata-server = (import self.sources.cardano-wallet { inherit system; gitrev = self.sources.cardano-wallet.rev; crossSystem = crossSystem walletPkgs.lib; }).mock-token-metadata-server;
     cardano-shell = import self.sources.cardano-shell { inherit system; crossSystem = crossSystem shellPkgs.lib; };
     cardano-cli = (import self.sources.cardano-node { inherit system; crossSystem = crossSystem nodePkgs.lib; }).cardano-cli;
     cardano-node-cluster = let

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "d98f7084b092c74a3f2310ec4c9009b42d564f1f",
-        "sha256": "0gxp8adkymi5wfmclzxczkyx43mh6synhn5vlch995ah74xn33pn",
+        "rev": "a37c9856b4d96286e3f01a95026c63b986ebbba0",
+        "sha256": "1mg8n58j2mjqhhzjb4p5yp8z06b9arh40pagi9rddil2f3vxzihm",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/d98f7084b092c74a3f2310ec4c9009b42d564f1f.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/a37c9856b4d96286e3f01a95026c63b986ebbba0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gitignore": {

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "bs58": "4.0.1",
     "cardano-crypto.js": "5.3.6-rc.6",
     "cardano-js": "0.4.5",
-    "cardano-launcher": "0.20201014.0",
+    "cardano-launcher": "0.20210215.0",
     "cbor": "5.0.2",
     "check-disk-space": "2.1.0",
     "chroma-js": "2.1.0",

--- a/shell.nix
+++ b/shell.nix
@@ -51,6 +51,7 @@ let
       daedalusPkgs.daedalus-bridge
       daedalusPkgs.daedalus-installer
       daedalusPkgs.darwin-launcher
+      daedalusPkgs.mock-token-metadata-server
     ] ++ (with pkgs; [
       nix bash binutils coreutils curl gnutar
       git python27 curl jq

--- a/source/main/cardano/CardanoWalletLauncher.js
+++ b/source/main/cardano/CardanoWalletLauncher.js
@@ -7,7 +7,12 @@ import * as cardanoLauncher from 'cardano-launcher';
 import type { Launcher } from 'cardano-launcher';
 import type { NodeConfig } from '../config';
 import { environment } from '../environment';
-import { STAKE_POOL_REGISTRY_URL, TOKEN_METADATA_SERVER_URL } from '../config';
+import {
+  STAKE_POOL_REGISTRY_URL,
+  TOKEN_METADATA_SERVER_URL,
+  MOCK_TOKEN_METADATA_SERVER_URL,
+  MOCK_TOKEN_METADATA_SERVER_PORT,
+} from '../config';
 import {
   MAINNET,
   STAGING,
@@ -95,6 +100,8 @@ export async function CardanoWalletLauncher(walletOpts: WalletOpts): Launcher {
     await fs.copy('tls', tlsPath);
   }
 
+  let tokenMetadataServer;
+
   // This switch statement handles any node specific
   // configuration, prior to spawning the child process
   logger.info('Node implementation', { nodeImplementation });
@@ -128,10 +135,16 @@ export async function CardanoWalletLauncher(walletOpts: WalletOpts): Launcher {
         launcherConfig.networkName = TESTNET;
         logger.info('Launching Wallet with --testnet flag');
       }
-      if (cluster !== MAINNET) {
-        merge(launcherConfig, {
-          tokenMetadataServer: TOKEN_METADATA_SERVER_URL,
+      if (MOCK_TOKEN_METADATA_SERVER_PORT) {
+        tokenMetadataServer = `${MOCK_TOKEN_METADATA_SERVER_URL}:${MOCK_TOKEN_METADATA_SERVER_PORT}/`;
+      } else if (cluster !== MAINNET) {
+        tokenMetadataServer = TOKEN_METADATA_SERVER_URL;
+      }
+      if (tokenMetadataServer) {
+        logger.info('Launching Wallet with --token-metadata-server flag', {
+          tokenMetadataServer,
         });
+        merge(launcherConfig, { tokenMetadataServer });
       }
       merge(launcherConfig, { nodeConfig, tlsConfiguration });
       break;

--- a/source/main/cardano/CardanoWalletLauncher.js
+++ b/source/main/cardano/CardanoWalletLauncher.js
@@ -7,7 +7,7 @@ import * as cardanoLauncher from 'cardano-launcher';
 import type { Launcher } from 'cardano-launcher';
 import type { NodeConfig } from '../config';
 import { environment } from '../environment';
-import { STAKE_POOL_REGISTRY_URL } from '../config';
+import { STAKE_POOL_REGISTRY_URL, TOKEN_METADATA_SERVER_URL } from '../config';
 import {
   MAINNET,
   STAGING,
@@ -127,6 +127,11 @@ export async function CardanoWalletLauncher(walletOpts: WalletOpts): Launcher {
         // All clusters not flagged as staging except for Mainnet are treated as "Testnets"
         launcherConfig.networkName = TESTNET;
         logger.info('Launching Wallet with --testnet flag');
+      }
+      if (cluster !== MAINNET) {
+        merge(launcherConfig, {
+          tokenMetadataServer: TOKEN_METADATA_SERVER_URL,
+        });
       }
       merge(launcherConfig, { nodeConfig, tlsConfiguration });
       break;

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -175,3 +175,6 @@ export const STAKE_POOL_REGISTRY_URL = {
   qa:
     'https://explorer.qa.jormungandr-testnet.iohkdev.io/stakepool-registry/registry.zip',
 };
+
+export const TOKEN_METADATA_SERVER_URL =
+  'https://metadata.cardano-testnet.iohkdev.io/';

--- a/source/main/config.js
+++ b/source/main/config.js
@@ -176,5 +176,11 @@ export const STAKE_POOL_REGISTRY_URL = {
     'https://explorer.qa.jormungandr-testnet.iohkdev.io/stakepool-registry/registry.zip',
 };
 
+// Used for all non mainnet networks
 export const TOKEN_METADATA_SERVER_URL =
   'https://metadata.cardano-testnet.iohkdev.io/';
+
+// Used by mock-token-metadata-server
+export const MOCK_TOKEN_METADATA_SERVER_URL = 'http://localhost';
+export const MOCK_TOKEN_METADATA_SERVER_PORT =
+  process.env.MOCK_TOKEN_METADATA_SERVER_PORT || 0;

--- a/source/main/webpack.config.js
+++ b/source/main/webpack.config.js
@@ -72,6 +72,8 @@ module.exports = {
           'process.env.NETWORK': JSON.stringify(
             process.env.NETWORK || 'development'
           ),
+          'process.env.MOCK_TOKEN_METADATA_SERVER_PORT':
+            process.env.MOCK_TOKEN_METADATA_SERVER_PORT || 0,
           'process.env.MOBX_DEV_TOOLS': process.env.MOBX_DEV_TOOLS || 0,
           'process.env.BUILD_NUMBER': JSON.stringify(
             process.env.BUILD_NUMBER || 'dev'

--- a/utils/cardano/native-tokens/registry.json
+++ b/utils/cardano/native-tokens/registry.json
@@ -1,0 +1,13 @@
+{
+  "subjects": [
+    {
+      "subject": "789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1",
+      "name": { "value": "NiceCoin" },
+      "description": { "value": "A nice coin" },
+      "acronym": { "value": "NCN" },
+      "unit": { "value":{ "decimals": 9,"name": "GigaNice" } },
+      "url": { "value": "https://iohk.io" },
+      "logo": { "value": "QWxtb3N0IGEgbG9nbw==" }
+    }
+  ]
+}

--- a/utils/cardano/native-tokens/registry.json
+++ b/utils/cardano/native-tokens/registry.json
@@ -5,7 +5,7 @@
       "name": { "value": "NiceCoin" },
       "description": { "value": "A nice coin" },
       "acronym": { "value": "NCN" },
-      "unit": { "value":{ "decimals": 9,"name": "GigaNice" } },
+      "unit": { "value": { "decimals": 9, "name": "GigaNice" } },
       "url": { "value": "https://iohk.io" },
       "logo": { "value": "QWxtb3N0IGEgbG9nbw==" }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3921,9 +3921,9 @@ cardano-js@0.4.5:
     js-chain-libs-node "^0.3.0"
     ts-custom-error "^3.1.1"
 
-cardano-launcher@0.20201014.0:
-  version "0.20201014.0"
-  resolved "https://registry.yarnpkg.com/cardano-launcher/-/cardano-launcher-0.20201014.0.tgz#97c2de764303f833e9acc37a30f9ef22f5459346"
+cardano-launcher@0.20210215.0:
+  version "0.20210215.0"
+  resolved "https://registry.yarnpkg.com/cardano-launcher/-/cardano-launcher-0.20210215.0.tgz#c6dc8a602c69ff002433eddb9659d988eb2db5d0"
   dependencies:
     get-port "5.1.1"
     lodash "4.17.20"


### PR DESCRIPTION
This PR updates `cardano-wallet` to the latest release: https://github.com/input-output-hk/cardano-wallet/releases/tag/v2021-02-15.
It also updates `cardano-launcher` to the latest release "0.20210215.0" which includes support for passing the token metadata server argument to `cardano-wallet`.

#### Native token metadata server

Daedalus, by default, uses the following metadata server for all networks except for the mainnet: `https://metadata.cardano-testnet.iohkdev.io/`.

It's also possible to use a mock server locally by running the following command in `nix-shell` prior to starting Daedalus:

```
$ mock-token-metadata-server ./utils/cardano/native-tokens/registry.json
Mock metadata server running with url http://localhost:65432/
```

Then proceed to launch Daedalus and make sure to provide the mock token metadata server port:

```
$ MOCK_TOKEN_METADATA_SERVER_PORT=65432 yarn dev
```

This enables you to modify the metadata directly by modifying the registry file directly:

```
$ vi ./utils/cardano/native-tokens/registry.json        # ..or any other editor, if you prefer
```

Use the following command to check if the mock server is working correctly:

```
$ curl -i -H "Content-type: application/json" --data '{"subjects":["789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1"],"properties":["name","description","acronym","unit","logo"]}'
http://localhost:65432/metadata/query
```
... and expect a "200 OK" response.

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [x] Run regression tests: [testing-report](https://docs.google.com/spreadsheets/d/1dFX1Rrr2FAS8QZgEXqyKb6Swp3xn4YEcEx1eq_s90vU/edit#gid=0)

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
