### PR TITLE
[DDW-584] Apply withdrawals to Hardware Wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changelog
 
 ### Chores
 
+- Withdrawals applied to the Hardware Wallets transactions ([PR 2408](https://github.com/input-output-hk/daedalus/pull/2408))
 - Adjusted hover PopOver styles on the first tile in the delegation center screen ([PR 2386](https://github.com/input-output-hk/daedalus/pull/2386))
 - Enabled selecting whole addresses and ids when selecting them to copy on transactions and summary screens ([PR 2370](https://github.com/input-output-hk/daedalus/pull/2370))
 - Added missing whitespace between amount and ADA in Japanese ([PR 2380](https://github.com/input-output-hk/daedalus/pull/2380))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,12 @@ Changelog
 
 ## vNext
 
+### Features
+
+- Enabled rewards withdrawals on hardware wallets ([PR 2408](https://github.com/input-output-hk/daedalus/pull/2408))
+
 ### Chores
 
-- Withdrawals applied to the Hardware Wallets transactions ([PR 2408](https://github.com/input-output-hk/daedalus/pull/2408))
 - Adjusted hover PopOver styles on the first tile in the delegation center screen ([PR 2386](https://github.com/input-output-hk/daedalus/pull/2386))
 
 ## 3.3.1

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "a37c9856b4d96286e3f01a95026c63b986ebbba0",
-        "sha256": "1mg8n58j2mjqhhzjb4p5yp8z06b9arh40pagi9rddil2f3vxzihm",
+        "rev": "b6810e8401b04b1d8a1a142f0b06b47cd6b51186",
+        "sha256": "0228p4jhi1cd55g9s4n2qdsvhc92bflnz5kg11ybkzfbp62ggjfi",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/a37c9856b4d96286e3f01a95026c63b986ebbba0.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/b6810e8401b04b1d8a1a142f0b06b47cd6b51186.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gitignore": {

--- a/source/common/types/hardware-wallets.types.js
+++ b/source/common/types/hardware-wallets.types.js
@@ -178,11 +178,9 @@ export type LedgerSignTransactionRequest = {
   ttl?: string,
   networkId: number,
   protocolMagic: number,
-  // $FlowFixMe
-  certificates: Array<?Certificate>, // TODO - add once certificates defined
-  // $FlowFixMe
-  withdrawals: Array<?Withdrawal>, // TODO - add once withdrawals defined
-  metadataHashHex: ?string, // TODO - add once metadata defined
+  certificates: Array<?Certificate>,
+  withdrawals: Array<?Withdrawal>,
+  metadataHashHex: ?string,
   reset?: boolean,
   devicePath: ?string,
   validityIntervalStartStr?: string,
@@ -196,6 +194,7 @@ export type TrezorSignTransactionRequest = {
   networkId: number,
   protocolMagic: number,
   certificates: Array<?Certificate>,
+  withdrawals: Array<?Withdrawal>,
   reset?: boolean,
   devicePath: string,
   validityIntervalStartStr?: string,

--- a/source/main/ipc/getHardwareWalletChannel.js
+++ b/source/main/ipc/getHardwareWalletChannel.js
@@ -590,6 +590,7 @@ export const handleHardwareWalletRequests = async (
       certificates,
       devicePath,
       validityIntervalStartStr,
+      withdrawals,
     } = params;
 
     if (!TrezorConnect) {
@@ -605,6 +606,7 @@ export const handleHardwareWalletRequests = async (
         protocolMagic,
         networkId,
         certificates,
+        withdrawals,
         validityIntervalStartStr,
       };
       const signedTransaction = await TrezorConnect.cardanoSignTransaction({

--- a/source/renderer/app/api/transactions/requests/selectCoins.js
+++ b/source/renderer/app/api/transactions/requests/selectCoins.js
@@ -1,12 +1,17 @@
 // @flow
 import { WalletUnits } from '../../../domains/Wallet';
 import type { RequestConfig } from '../../common/types';
-import type { TransactionPaymentData, CoinSelectionAmount } from '../types';
+import type {
+  TransactionPaymentData,
+  CoinSelectionAmount,
+  TransactionWithdrawalType,
+} from '../types';
 import type { DelegationAction } from '../../../types/stakingTypes';
 import { request } from '../../utils/request';
 
 export type PaymentsType = {
   payments: Array<TransactionPaymentData>,
+  withdrawal?: TransactionWithdrawalType,
 };
 
 export type DelegationType = {
@@ -19,6 +24,12 @@ export type DelegationType = {
 export type SelectCoinsRequestType = {
   walletId: string,
   data: PaymentsType | DelegationType,
+};
+
+export type SelectCoinsWithdrawalType = {
+  stake_address: string,
+  derivation_path: Array<string>,
+  amount: CoinSelectionAmount,
 };
 
 export type SelectCoinsResponseType = {
@@ -39,6 +50,7 @@ export type SelectCoinsResponseType = {
     amount: CoinSelectionAmount,
     derivation_path: Array<string>,
   }>,
+  withdrawals?: Array<SelectCoinsWithdrawalType>,
   certificates?: Array<{
     pool?: string,
     certificate_type: DelegationAction,
@@ -53,8 +65,8 @@ export type SelectCoinsResponseType = {
 export const selectCoins = (
   config: RequestConfig,
   { walletId, data }: SelectCoinsRequestType
-): Promise<SelectCoinsResponseType> =>
-  request(
+): Promise<SelectCoinsResponseType> => {
+  return request(
     {
       method: 'POST',
       path: `/v2/wallets/${walletId}/coin-selections/random`,
@@ -63,3 +75,4 @@ export const selectCoins = (
     {},
     data
   );
+};

--- a/source/renderer/app/api/transactions/types.js
+++ b/source/renderer/app/api/transactions/types.js
@@ -210,6 +210,14 @@ export type CoinSelectionCertificate = {
 
 export type CoinSelectionCertificates = Array<CoinSelectionCertificate>;
 
+export type CoinSelectionWithdrawal = {
+  stakeAddress: string,
+  derivationPath: Array<string>,
+  amount: CoinSelectionAmount,
+};
+
+export type CoinSelectionWithdrawals = Array<CoinSelectionWithdrawal>;
+
 export type CoinSelectionsDelegationRequestType = {
   walletId: string,
   poolId: string,
@@ -232,6 +240,7 @@ export type CoinSelectionsResponse = {
   certificates: CoinSelectionCertificates,
   deposits: BigNumber,
   depositsReclaimed: BigNumber,
+  withdrawals: Array<CoinSelectionWithdrawal>,
   fee: BigNumber,
 };
 

--- a/source/renderer/app/stores/HardwareWalletsStore.js
+++ b/source/renderer/app/stores/HardwareWalletsStore.js
@@ -1371,10 +1371,8 @@ export default class HardwareWalletsStore extends Store {
         devicePath,
       });
 
-      let unsignedTxWithdrawals = null;
-      if (withdrawals.length > 0) {
-        unsignedTxWithdrawals = ShelleyTxWithdrawal(withdrawals);
-      }
+      const unsignedTxWithdrawals =
+        withdrawals.length > 0 ? ShelleyTxWithdrawal(withdrawals) : null;
 
       // Prepare unsigned transaction structure for serialzation
       const unsignedTx = prepareTxAux({

--- a/source/renderer/app/stores/HardwareWalletsStore.js
+++ b/source/renderer/app/stores/HardwareWalletsStore.js
@@ -32,16 +32,19 @@ import {
   prepareTxAux,
   prepareBody,
   prepareLedgerCertificate,
+  prepareLedgerWithdrawal,
   CachedDeriveXpubFactory,
   ShelleyTxWitnessShelley,
   ShelleyTxInputFromUtxo,
   ShelleyTxOutput,
   ShelleyTxCert,
+  ShelleyTxWithdrawal,
 } from '../utils/shelleyLedger';
 import {
   prepareTrezorInput,
   prepareTrezorOutput,
-  prepareCertificate,
+  prepareTrezorCertificate,
+  prepareTrezorWithdrawal,
 } from '../utils/shelleyTrezor';
 import {
   DeviceModels,
@@ -1125,7 +1128,7 @@ export default class HardwareWalletsStore extends Store {
       throw new Error(`Missing Coins Selection for wallet: ${walletId}`);
     }
 
-    const { inputs, outputs, fee, certificates } = coinSelection;
+    const { inputs, outputs, fee, certificates, withdrawals } = coinSelection;
 
     const inputsData = map(inputs, (input) => {
       return prepareTrezorInput(input);
@@ -1135,8 +1138,12 @@ export default class HardwareWalletsStore extends Store {
       return prepareTrezorOutput(output);
     });
 
+    const withdrawalsData = map(withdrawals, (withdrawal) => {
+      return prepareTrezorWithdrawal(withdrawal);
+    });
+
     const certificatesData = map(certificates, (certificate) =>
-      prepareCertificate(certificate)
+      prepareTrezorCertificate(certificate)
     );
 
     const recognizedDevice = find(
@@ -1200,6 +1207,7 @@ export default class HardwareWalletsStore extends Store {
           ? HW_SHELLEY_CONFIG.NETWORK.MAINNET.trezorProtocolMagic
           : HW_SHELLEY_CONFIG.NETWORK.TESTNET.trezorProtocolMagic,
         certificates: certificatesData,
+        withdrawals: withdrawalsData,
         devicePath: recognizedDevicePath,
       });
 
@@ -1283,7 +1291,13 @@ export default class HardwareWalletsStore extends Store {
       this.hwDeviceStatus = HwDeviceStatuses.VERIFYING_TRANSACTION;
     });
     const { coinSelection } = this.txSignRequest;
-    const { inputs, outputs, certificates, fee: flatFee } = coinSelection;
+    const {
+      inputs,
+      outputs,
+      certificates,
+      fee: flatFee,
+      withdrawals,
+    } = coinSelection;
     logger.debug('[HW-DEBUG] HWStore - sign transaction Ledger: ', {
       walletId,
     });
@@ -1309,6 +1323,7 @@ export default class HardwareWalletsStore extends Store {
       outputsData.push(ledgerOutput);
     }
 
+    // Construct certificates
     const unsignedTxCerts = [];
     const _certificatesData = map(certificates, async (certificate) => {
       const accountAddress = await this._getRewardAccountAddress(
@@ -1323,12 +1338,17 @@ export default class HardwareWalletsStore extends Store {
       unsignedTxCerts.push(shelleyTxCert);
       return prepareLedgerCertificate(certificate);
     });
-
     const certificatesData = await Promise.all(_certificatesData);
+
+    // Construct Withdrawals
+    const _withdrawalsData = map(withdrawals, async (withdrawal) =>
+      prepareLedgerWithdrawal(withdrawal)
+    );
+    const withdrawalsData = await Promise.all(_withdrawalsData);
+
     const fee = formattedAmountToLovelace(flatFee.toString());
     const ttl = this._getTtl();
     const absoluteSlotNumber = this._getAbsoluteSlotNumber();
-    const withdrawals = [];
     const metadataHashHex = null;
     const { isMainnet } = this.environment;
 
@@ -1346,10 +1366,15 @@ export default class HardwareWalletsStore extends Store {
           ? HW_SHELLEY_CONFIG.NETWORK.MAINNET.protocolMagic
           : HW_SHELLEY_CONFIG.NETWORK.TESTNET.protocolMagic,
         certificates: certificatesData,
-        withdrawals,
+        withdrawals: withdrawalsData,
         metadataHashHex,
         devicePath,
       });
+
+      let unsignedTxWithdrawals = null;
+      if (withdrawals.length > 0) {
+        unsignedTxWithdrawals = ShelleyTxWithdrawal(withdrawals);
+      }
 
       // Prepare unsigned transaction structure for serialzation
       const unsignedTx = prepareTxAux({
@@ -1358,7 +1383,7 @@ export default class HardwareWalletsStore extends Store {
         fee,
         ttl,
         certificates: unsignedTxCerts,
-        withdrawals,
+        withdrawals: unsignedTxWithdrawals,
       });
 
       const signedWitnesses = await this._signWitnesses(

--- a/source/renderer/app/utils/shelleyTrezor.js
+++ b/source/renderer/app/utils/shelleyTrezor.js
@@ -10,6 +10,7 @@ import type {
   CoinSelectionInput,
   CoinSelectionOutput,
   CoinSelectionCertificate,
+  CoinSelectionWithdrawal,
 } from '../api/transactions/types';
 
 export const prepareTrezorInput = (input: CoinSelectionInput) => {
@@ -40,7 +41,7 @@ export const prepareTrezorOutput = (output: CoinSelectionOutput) => {
   };
 };
 
-export const prepareCertificate = (cert: CoinSelectionCertificate) => {
+export const prepareTrezorCertificate = (cert: CoinSelectionCertificate) => {
   if (cert.pool) {
     return {
       type: CERTIFICATE_TYPE[cert.certificateType],
@@ -51,6 +52,15 @@ export const prepareCertificate = (cert: CoinSelectionCertificate) => {
   return {
     type: CERTIFICATE_TYPE[cert.certificateType],
     path: derivationPathToString(cert.rewardAccountPath),
+  };
+};
+
+export const prepareTrezorWithdrawal = (
+  withdrawal: CoinSelectionWithdrawal
+) => {
+  return {
+    path: derivationPathToString(withdrawal.derivationPath),
+    amount: withdrawal.amount.quantity.toString(),
   };
 };
 


### PR DESCRIPTION
This PR introduces extended transaction signing / sending data with withdrawals with Hardware Wallets. Now we can use rewards along with Hardware wallets!

---

**NOTE: DO NOT MERGE**
- WBE bumped to the latest master where coin selection with withdrawals is included. We need to check this before merging @nikolaglumac  (REV: `b6810e8401b04b1d8a1a142f0b06b47cd6b51186`)

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1614274478028600)
- [ ] Try to send a transaction with an amount that contains `available wallet balance` + `rewards`. Test with Ledger and Trezor
- [ ] Once you sent Transaction using withdrawals (rewards) try to create also a regular transaction without rewards just to ensure that TX Send is working for all cases

**Withdrawals Example:**

- You have a wallet "Wallet Test"
- Wallet balance is 50 ADA (shown in sidebar)
- You earned 2 ADA as rewards
- This means that you have `walletBalance = 50`, `availableWalletBalance = 48`, `rewards = 2`
- Try to send `49 ADA` - this means that you want to send your `full wallet available balance without rewards` + `rewards` to cover the transaction amount.
- Once you start a process, first indicator is to see `withdrawals` on your HW device. After that, once tx sent, you can see rewards sent in transaction details e.g. summary screen.
- e.g. if you have 3 ADA from rewards and e.g. you needed just 1 ADA to cover all tx requirements, the rest rewards are returned as a changed output to the wallet and are included in the wallet available balance which ( you will not have withdrawals anymore).



## Test Cases

```Gherkin
Scenario 1: Transaction on no reward wallet
Given I have a wallet with enough ADA for transaction fee
And the wallet doesn't have any reward
When I send some ADA
Then it will be successful

Scenario 2: Delegate on no reward wallet
Given I have a wallet with enough ADA for delegation
And the wallet doesn't have any reward
When I delegate the wallet
Then it will be successful

Note: I put numbers to make it easier to visualise
Scenario 3: Available balance, reward presence (Send less than available balance)
Given I have a wallet with enough ADA for transaction fee
And the wallet has available balance 10 ADA and reward 5 ADA
When I send 8 ADA
Then the transaction will be successful
And the available balance will be 7 ADA-transaction fees

Note: I put numbers to make it easier to visualise
Scenario 4: Available balance, reward presence (Send greater than available balance)
Given I have a wallet with enough ADA for transaction fee
And the wallet has available balance 10 ADA and reward 5 ADA
When I send 12 ADA
Then the transaction will be successful
And the available balance will be 3 ADA-transaction fees

Note: I put numbers to make it easier to visualise
Scenario 5: Delegate to a pool: Available balance, reward presence (Available balance less than 10 ADA)
Given I have a wallet with enough ADA for transaction fee
And the wallet has available balance 8 ADA and reward 5 ADA
When I attempt to delegate to a pool
Then I won't be able to

Note: I put numbers to make it easier to visualise
Scenario 6: Delegate to a pool: Available balance, reward presence (Available balance >=  10 ADA)
Given I have a wallet with enough ADA for transaction fee
And the wallet has available balance 10 ADA and reward 5 ADA
When I delegate to a pool
Then it will be successful
And the reward remains at 5 ADA

Scenario 7: Available balance 1 ADA, reward presence 3 ADA
Given I have a wallet with available balance 1 ADA and reward 3 ADA
When I send 1 ADA
Then the transaction will be successful
And the available balance will be 3 ADA-transaction fees


Still under construction
```
---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
