### PR TITLE
[DDW-601] Fix dropdown not appearing in the Stake Pools Settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 ### Fixes
 
 - Fixed delay on loading stake pool list after switching the SMASH server ([PR 2447](https://github.com/input-output-hk/daedalus/pull/2447))
+- Fixed dropdown not appearing in the Stake Pools Settings screen ([PR 2460](https://github.com/input-output-hk/daedalus/pull/2460))
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Changelog
 
 ### Fixes
 
-- Fixed delay on loading stake pool list after switching the SMASH server ([PR 2447](https://github.com/input-output-hk/daedalus/pull/2447))
 - Fixed dropdown not appearing in the Stake Pools Settings screen ([PR 2460](https://github.com/input-output-hk/daedalus/pull/2460))
+- Fixed delay on loading stake pool list after switching the SMASH server ([PR 2447](https://github.com/input-output-hk/daedalus/pull/2447))
 
 ### Chores
 

--- a/source/renderer/app/components/settings/categories/StakePoolsSettings.js
+++ b/source/renderer/app/components/settings/categories/StakePoolsSettings.js
@@ -241,9 +241,6 @@ export default class StakePoolsSettings extends Component<Props, State> {
         : '-';
 
     if (isSyncing) {
-      return null;
-    }
-    if (isSyncing) {
       return (
         <div className={styles.disabledSelect}>
           <div className={styles.label}>


### PR DESCRIPTION
This PR Fixes the SMASH server type dropdown not appearing in the Stake Pools Settings screen when syncing.

## Screenshots

**Incorrect**
![INC - EN](https://user-images.githubusercontent.com/1504716/111222065-18b72880-85ba-11eb-953f-00d5a40882e0.png)
![INC - JP](https://user-images.githubusercontent.com/1504716/111222068-18b72880-85ba-11eb-8236-15cd07bb5542.png)

**Correct**
![CO - EN](https://user-images.githubusercontent.com/1504716/111222056-16ed6500-85ba-11eb-861e-f4573d07e325.png)
![CO - JP](https://user-images.githubusercontent.com/1504716/111222063-181e9200-85ba-11eb-9e5e-8434c3db20d8.png)



---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

## Test Cases

```Gherkin
Scenario 1: Dropdown visible when app syncing
Given I am on Stake Pools settings screen
And the app is still syncing
When I observe the Smash server type dropdown
Then the dropdown is visible
And the syncing animation is presence on it
And it is disabled
```

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
