### PR TITLE
[DDW-648] Fix stake pools list cutting off items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changelog
 =========
 
-## vNext
+## 4.0.5
+
+### Fixes
+
+- Fixed stake pool list cutting off items ([PR 2517](https://github.com/input-output-hk/daedalus/pull/2517))
+- Fixed fee calculation edge cases in wallet send form ([PR 2501](https://github.com/input-output-hk/daedalus/pull/2501))
+- Handle empty strings in transaction metadata correctly ([PR 2503](https://github.com/input-output-hk/daedalus/pull/2503))
 
 ### Chores
 
@@ -9,11 +15,6 @@ Changelog
 - Reduced the clock drift tolerance to 4,5 seconds ([PR 2510](https://github.com/input-output-hk/daedalus/pull/2510))
 - Updates Catalyst Fund4 dates ([PR 2495](https://github.com/input-output-hk/daedalus/pull/2495))
 - Updated `cardano-wallet` to revision `7df30796` ([PR 2495](https://github.com/input-output-hk/daedalus/pull/2495))
-
-### Fixes
-
-- Fixed fee calculation edge cases in wallet send form ([PR 2501](https://github.com/input-output-hk/daedalus/pull/2501))
-- Handle empty strings in transaction metadata correctly ([PR 2503](https://github.com/input-output-hk/daedalus/pull/2503)) 
 
 ## 4.0.4
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsList.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsList.js
@@ -1,4 +1,5 @@
 // @flow
+import { times } from 'lodash-es/util';
 import { observer } from 'mobx-react';
 import React, { useEffect, useState } from 'react';
 import type { ElementRef } from 'react';
@@ -64,10 +65,9 @@ export const StakePoolsList = observer((props: StakePoolsListProps) => {
 
   function rowRenderer(itemsPerRow, { index, key, style }) {
     const startIndex = itemsPerRow * index;
-    const stakePools = props.stakePoolsList.slice(
-      startIndex,
-      startIndex + itemsPerRow
-    );
+    const endIndex = startIndex + itemsPerRow;
+    const stakePools = props.stakePoolsList.slice(startIndex, endIndex);
+    const numberOfMissingRowItems = itemsPerRow - stakePools.length;
     return (
       <div key={key} style={style}>
         <div className={styles.tiles}>
@@ -89,6 +89,11 @@ export const StakePoolsList = observer((props: StakePoolsListProps) => {
               isGridRewardsView={props.isGridRewardsView}
             />
           ))}
+          {numberOfMissingRowItems > 0
+            ? times(numberOfMissingRowItems, () => (
+                <div className={styles.rowFillerItem} />
+              ))
+            : null}
         </div>
       </div>
     );
@@ -106,7 +111,7 @@ export const StakePoolsList = observer((props: StakePoolsListProps) => {
             if (!stakePoolsCount || !width) {
               return null;
             }
-            const itemsPerRow = Math.ceil(
+            const itemsPerRow = Math.floor(
               width / (POOL_THUMB_SIZE + POOL_THUMB_GRID_GAP)
             );
             const rowCount = Math.ceil(stakePoolsCount / itemsPerRow);

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsList.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsList.scss
@@ -13,10 +13,13 @@
 }
 
 .tiles {
-  display: grid;
-  grid-gap: 10px;
-  grid-template-columns: repeat(auto-fill, 80px);
+  display: flex;
+  gap: 10px;
   justify-content: space-between;
+}
+
+.rowFillerItem {
+  width: 80px;
 }
 
 .list {


### PR DESCRIPTION
This PR fixes an issue with stake pools list rendering where items get cut-off (hidden) on specific window sizes.

- Reverted to Math.floor picking of row items (to prevent overflows that caused this issue)
- Changed the way the row items are spaced (flexbox + space-between)
- Added filler items in rows that are not "complete" to ensure all rows are spaced the same way

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test that all stake pools are correctly shown on any window size
- [ ] Test that the spacing between the stake pools always looks good

---
## Test Scenarios

**Scenario 1: Order of stake pools’ ranking**
```gherkin
Given I am at Staking -> Stake pools
And the stake pools are fully loaded
When I observe the stake pools’ ranking
Then they are in numerical order
And the increase in ranking from one pool to the next pool is +1
And they are ordered in ascending order
```

**Scenario 2: Order of stake pools’ ranking after window resize**
```gherkin
Given I am at Staking -> Stake pools
And the stake pools are fully loaded
When I (decrease|increase) the window size
Then the stake pools’ ranking are in numerical order
And the increase in ranking from one pool to the next pool is +1
And they are ordered in ascending order
```

**Scenario 3: Stake pools are all present**
```gherkin
Given I am at Staking -> Stake pools
And the stake pools are fully loaded
When I observe the stake pools’ ranking
Then they are in numerical order
And all of the pools are present
```
---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
