### PR TITLE
[DDW-657] Fix blank currency selection after updating to 4.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixes
 
+- Fixed blank currency selection after updating to 4.0.5 ([PR 2529](https://github.com/input-output-hk/daedalus/pull/2529))
 - Fixed hardware wallets confirmation crashing issue when device is in "Busy" state ([PR 2522](https://github.com/input-output-hk/daedalus/pull/2522))
 - Fixed hardware wallets spending password issue ([PR 2519](https://github.com/input-output-hk/daedalus/pull/2519))
 

--- a/source/renderer/app/api/utils/localStorage.js
+++ b/source/renderer/app/api/utils/localStorage.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable consistent-return */
 
-import { includes, without } from 'lodash';
+import { includes, without, get } from 'lodash';
 import { electronStoreConversation } from '../../ipc/electronStoreConversation';
 import { WalletMigrationStatuses } from '../../stores/WalletMigrationStore';
 import {
@@ -188,11 +188,33 @@ export default class LocalStorageApi {
   unsetDataLayerMigrationAcceptance = (): Promise<void> =>
     LocalStorageApi.unset(keys.DATA_LAYER_MIGRATION_ACCEPTANCE);
 
-  getCurrencySelected = (): Promise<Currency | DeprecatedCurrency> =>
-    LocalStorageApi.get(keys.CURRENCY_SELECTED, CURRENCY_DEFAULT_SELECTED);
+  getCurrencySelected = async (): Promise<string> => {
+    const localCurrencySelected: Promise<
+      Currency | DeprecatedCurrency | string
+    > = await LocalStorageApi.get(
+      keys.CURRENCY_SELECTED,
+      CURRENCY_DEFAULT_SELECTED
+    );
+    if (typeof localCurrencySelected === 'string') return localCurrencySelected;
+    /**
+     *
+     * Prior versions were storing the whole Currency object,
+     * which could lead different formats (e.g. currency.code or currency.symbol)
+     * It now stores only the currency code string,
+     * but we need to account for users storing old formats
+     *
+     * In this case, we also set the correct local code value
+     *
+     */
+    const localCurrencyCode: string =
+      get(localCurrencySelected, 'code') ||
+      get(localCurrencySelected, 'symbol');
+    this.setCurrencySelected(localCurrencyCode);
+    return localCurrencyCode;
+  };
 
-  setCurrencySelected = (currency: Currency): Promise<void> =>
-    LocalStorageApi.set(keys.CURRENCY_SELECTED, currency);
+  setCurrencySelected = (currencyCode: string): Promise<void> =>
+    LocalStorageApi.set(keys.CURRENCY_SELECTED, currencyCode);
 
   unsetCurrencySelected = (): Promise<void> =>
     LocalStorageApi.unset(keys.CURRENCY_SELECTED);

--- a/source/renderer/app/api/utils/localStorage.js
+++ b/source/renderer/app/api/utils/localStorage.js
@@ -18,7 +18,7 @@ import type {
   DeviceType,
 } from '../../../../common/types/hardware-wallets.types';
 import type { StorageKey } from '../../../../common/types/electron-store.types';
-import type { Currency } from '../../types/currencyTypes';
+import type { Currency, DeprecatedCurrency } from '../../types/currencyTypes';
 import {
   CURRENCY_IS_ACTIVE_BY_DEFAULT,
   CURRENCY_DEFAULT_SELECTED,
@@ -188,7 +188,7 @@ export default class LocalStorageApi {
   unsetDataLayerMigrationAcceptance = (): Promise<void> =>
     LocalStorageApi.unset(keys.DATA_LAYER_MIGRATION_ACCEPTANCE);
 
-  getCurrencySelected = (): Promise<Currency> =>
+  getCurrencySelected = (): Promise<Currency | DeprecatedCurrency> =>
     LocalStorageApi.get(keys.CURRENCY_SELECTED, CURRENCY_DEFAULT_SELECTED);
 
   setCurrencySelected = (currency: Currency): Promise<void> =>

--- a/source/renderer/app/config/currencyConfig.js
+++ b/source/renderer/app/config/currencyConfig.js
@@ -18,7 +18,6 @@ import type {
   RequestName,
   Currency,
   LocalizedCurrency,
-  DeprecatedCurrency,
 } from '../types/currencyTypes';
 import type { Locale } from '../../../common/types/locales.types';
 

--- a/source/renderer/app/config/currencyConfig.js
+++ b/source/renderer/app/config/currencyConfig.js
@@ -18,6 +18,7 @@ import type {
   RequestName,
   Currency,
   LocalizedCurrency,
+  DeprecatedCurrency,
 } from '../types/currencyTypes';
 import type { Locale } from '../../../common/types/locales.types';
 
@@ -70,3 +71,6 @@ export const getLocalizedCurrency = (
   ...omit(rawCurrency, ['name']),
   name: rawCurrency.name[currentLocale] || rawCurrency.name[LOCALES.english],
 });
+
+export const getCurrencyFromCode = (code: string): Currency =>
+  currenciesList[code];

--- a/source/renderer/app/stores/WalletsStore.js
+++ b/source/renderer/app/stores/WalletsStore.js
@@ -351,10 +351,7 @@ export default class WalletsStore extends Store {
 
     // Check if the user has already selected a currency
     // Otherwise applies the default currency
-    const localCurrencySelected = await this.api.localStorage.getCurrencySelected();
-    const localCurrencyCode =
-      get(localCurrencySelected, 'code') ||
-      get(localCurrencySelected, 'symbol');
+    const localCurrencyCode = await this.api.localStorage.getCurrencySelected();
     const currencySelected = getCurrencyFromCode(localCurrencyCode);
 
     runInAction(() => {
@@ -422,7 +419,7 @@ export default class WalletsStore extends Store {
     if (currencySelected) {
       this.currencySelected = currencySelected;
       this.getCurrencyRate();
-      await this.api.localStorage.setCurrencySelected(currencySelected);
+      await this.api.localStorage.setCurrencySelected(currencySelected.code);
     }
   };
 

--- a/source/renderer/app/stores/WalletsStore.js
+++ b/source/renderer/app/stores/WalletsStore.js
@@ -35,6 +35,7 @@ import {
   CURRENCY_REQUEST_RATE_INTERVAL,
   getLocalizedCurrency,
   getLocalizedCurrenciesList,
+  getCurrencyFromCode,
 } from '../config/currencyConfig';
 import type {
   WalletKind,
@@ -350,7 +351,11 @@ export default class WalletsStore extends Store {
 
     // Check if the user has already selected a currency
     // Otherwise applies the default currency
-    const currencySelected = await this.api.localStorage.getCurrencySelected();
+    const localCurrencySelected = await this.api.localStorage.getCurrencySelected();
+    const localCurrencyCode =
+      get(localCurrencySelected, 'code') ||
+      get(localCurrencySelected, 'symbol');
+    const currencySelected = getCurrencyFromCode(localCurrencyCode);
 
     runInAction(() => {
       this.currencyIsActive = currencyIsActive;

--- a/source/renderer/app/types/currencyTypes.js
+++ b/source/renderer/app/types/currencyTypes.js
@@ -18,6 +18,13 @@ export type LocalizedCurrency = {
   id?: string,
 };
 
+export type DeprecatedCurrency = {
+  symbol: string,
+  name: string,
+  decimalDigits?: number,
+  id?: string,
+};
+
 export type Request = HttpOptions | Function;
 
 export type RequestName = 'list' | 'rate';


### PR DESCRIPTION
This PR fixes blank currency selection after updating to 4.0.5

## Todos

- [x] Change the localStorage to store only the currency code
- [x] update Wallets store to grab the currency from the local stored currency code



**Old localStorage currency format**

```json
	"staging-CURRENCY-SELECTED": {
		"symbol": "brl",
		"decimalDigits": 2,
		"name": "Brazilian Real",
		"symbolNative": ""
	}
```

**New localStorage currency format**

```json
	"staging-CURRENCY-SELECTED": "brl"
```

## Steps to test

**Daedalus builds**

1. Run a Daedalus version older than 4.0.5 and set a currency different than USD;
2. Run Daedalus 4.0.5 version: the currency should be broken as described at the [Jira card](https://jira.iohk.io/browse/DDW-657);
3. Run this PR's build: the currency feature should be working normally.

**Running Daedalus locally**

1. Set the `CURRENCY-SELECTED` value at `config.json` to:

```json
	"[ENVIRONMENT]-CURRENCY-SELECTED": {
		"symbol": "brl",
		"decimalDigits": 2,
		"name": "Brazilian Real",
		"symbolNative": ""
	}
```
2. Run Daedalus in the `develop` branch: the currency should be broken as described at the [Jira card](https://jira.iohk.io/browse/DDW-657);
3. Run Daedalus in the branch `fix/ddw-657-fix-blank-currency-selection-after-updating-to-4-0-5`: the currency feature should be working normally.

## Screenshots

**With error**

![image](https://user-images.githubusercontent.com/1504716/115416569-46514c00-a1ce-11eb-969d-e9c70cac0bb4.png)
![image](https://user-images.githubusercontent.com/1504716/115416593-4b160000-a1ce-11eb-9851-3ea37a1ce825.png)

**Without error**

![Screen Shot 2021-04-20 at 11 47 03](https://user-images.githubusercontent.com/1504716/115416498-38033000-a1ce-11eb-8781-137d2e53e29f.png)
![Screen Shot 2021-04-20 at 11 47 10](https://user-images.githubusercontent.com/1504716/115416510-39ccf380-a1ce-11eb-85c8-d9a8f015a4de.png)
![Screen Shot 2021-04-20 at 11 47 17](https://user-images.githubusercontent.com/1504716/115416514-3a658a00-a1ce-11eb-969a-0f3652751788.png)
![Screen Shot 2021-04-20 at 11 47 22](https://user-images.githubusercontent.com/1504716/115416516-3afe2080-a1ce-11eb-817f-e82db0048f0f.png)


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1618930348418000)
- [Jira card](https://jira.iohk.io/browse/DDW-657)
- [ ] Test

---

### Test Scenario

**Scenario 1 - Validate is the balance is displayed on other currencies**
```gherkin
Given that Daedalus 4.0.4 is installed
And It has a wallet
And the option to show balance in other currencies is enabled in "Settings- Wallets"
When I update to 4.0.5
And I check the option to show balance in other currencies
Then I can see the dropdown maintains the selection as it was on 4.0.4
And I can see the balance on the wallet is displayed on the selected currency
````
---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
