### PR TITLE
Fix transaction initialization issue on device reconnect

### DIFF
--- a/source/renderer/app/stores/HardwareWalletsStore.js
+++ b/source/renderer/app/stores/HardwareWalletsStore.js
@@ -1,6 +1,6 @@
 // @flow
 import { observable, action, runInAction, computed } from 'mobx';
-import { get, map, find, findLast, filter, includes } from 'lodash';
+import { get, map, find, findLast, includes } from 'lodash';
 import semver from 'semver';
 import { TransactionSigningMode } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import Store from './lib/Store';
@@ -1660,20 +1660,20 @@ export default class HardwareWalletsStore extends Store {
     if (disconnected && deviceType === DeviceTypes.LEDGER) {
       // Remove all stored Ledger instances from LC - both pending and paired (with software Wallets)
       logger.debug('[HW-DEBUG] HWStore - device disconnected');
-      const recognizedLedgerDevices = filter(
+
+      const recognizedLedgerDevice = find(
         hardwareWalletDevices,
-        (hardwareWalletDevice) =>
-          hardwareWalletDevice.deviceType === DeviceTypes.LEDGER &&
-          hardwareWalletDevice.path === path
+        (hardwareWalletDevice) => hardwareWalletDevice.path === path
       );
 
-      // Delete or pending or paired Ledger device
-      map(recognizedLedgerDevices, (recognizedLedgerDevice) => {
-        logger.debug('[HW-DEBUG] HWStore - UNSET: ', recognizedLedgerDevice.id);
-        return this._unsetHardwareWalletDevice({
+      if (recognizedLedgerDevice) {
+        logger.debug('[HW-DEBUG] HWStore - Remove Device from LC', {
+          recognizedLedgerDevice,
+        });
+        await this._unsetHardwareWalletDevice({
           deviceId: recognizedLedgerDevice.id,
         });
-      });
+      }
 
       logger.debug('[HW-DEBUG] HWStore - GET Paired and set to disconnected');
       const recognizedLedgerWallet = find(


### PR DESCRIPTION
This PR introduces a fix for re-initiating transactions when the device reconnected.

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test - https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1619773694483800?thread_ts=1619706724.474400&cid=GGKFXSKC6

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
