### PR TITLE
[DDW-684] Fix stake pools pop over description scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Changelog
 
 ### Fixes
 
-- Fixed pool description scrolling and styling ([PR 2556](https://github.com/input-output-hk/daedalus/pull/2564))
+- Fixed pool description scrolling and styling ([PR 2556](https://github.com/input-output-hk/daedalus/pull/2564), [PR 2568](https://github.com/input-output-hk/daedalus/pull/2568))
 - Fixed external currencies not appearing when not connected ([PR 2556](https://github.com/input-output-hk/daedalus/pull/2556))
 
 ### Chores

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -272,7 +272,6 @@ $tooltip-width: 280px;
 }
 
 .description {
-  box-sizing: border-box;
   color: var(--theme-staking-stake-pool-tooltip-text-color);
   font-size: 14px;
   line-height: 1.36;

--- a/source/renderer/app/components/staking/widgets/TooltipPool.scss
+++ b/source/renderer/app/components/staking/widgets/TooltipPool.scss
@@ -272,16 +272,28 @@ $tooltip-width: 280px;
 }
 
 .description {
+  box-sizing: border-box;
   color: var(--theme-staking-stake-pool-tooltip-text-color);
   font-size: 14px;
   line-height: 1.36;
   margin-bottom: 4px;
-  margin-right: -5px;
   max-height: 57px;
   overflow-y: auto;
-  // keep text content in bounds when no scroll bar is visible:
-  padding-right: 5px;
+  padding-right: 6px;
   word-break: break-word;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-button {
+    display: block;
+    height: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border: none;
+  }
 }
 
 .table {


### PR DESCRIPTION
This PR fixes the scrollbar for stake pools pop-over descriptions which had several issues.

- The scrollbar didn't "start the top" but was positioned somewhere in the middle of the description text.
- Even if you scrolled down to the "bottom" of the text the bar was far away from the bottom of the description box.
- The scrollbar thumb was quite small

![grafik](https://user-images.githubusercontent.com/172414/118488805-6831e600-b71c-11eb-8cd1-780bc7e91bed.png)


## How this was fixed

The original issue (vertical thumb position offset, reported by @miorsufianiohk) was caused by our global scrollbar styles which use scrollbar `border` to position the thin thumb within a bigger track (which might be the only way to achieve this if you want the track have some specific bg color). Since that's not required in the case of the stake pool description field (it only needs to show a thin scrollbar on the right side) this was reverted to a more traditional way to style the scrollbar.

## Screenshots

This is how the fixed version looks like:

https://user-images.githubusercontent.com/172414/118488063-a5e23f00-b71b-11eb-87c6-a6bf63238339.mp4

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test that the stake pools pop-over descriptions scrollbar works / looks correctly in all cases

## Test Cases

```Gherkin
Scenario 1: Scrollbar working as expected
Given I am on Staking -> (Delegation center | Stake pools)
And a stake pool popup is displayed
And the stake pool description is long
And the scrollbar is displayed
And the scrollbar thumb appears at the top of the track
And I can move it down to the bottom by scrolling
```

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
