### PR TITLE
[DDW-698] Can't insert notes on "Share Wallet Address" dialog for software wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## vNext
+
+### Fixes
+
+- Fixed notes field visibility for software wallets on Share Wallet Address dialog ([PR 2582](https://github.com/input-output-hk/daedalus/pull/2582))
+
 ## 4.1.0-FC1
 
 ### Features

--- a/source/renderer/app/components/wallet/receive/WalletReceiveDialog.js
+++ b/source/renderer/app/components/wallet/receive/WalletReceiveDialog.js
@@ -508,20 +508,20 @@ export default class WalletReceiveDialog extends Component<Props, State> {
               </div>
             </div>
           )}
-          {!isHardwareWallet ||
-            (selectedVerificationStatus ===
-              AddressVerificationCheckStatuses.VALID && (
-              <TextArea
-                className={styles.noteInput}
-                skin={TextAreaSkin}
-                autoResize={false}
-                rows={3}
-                maxLength={201}
-                {...noteInputField.bind({
-                  onChange: this.handleChange(noteInputField),
-                })}
-              />
-            ))}
+          {(!isHardwareWallet ||
+            selectedVerificationStatus ===
+              AddressVerificationCheckStatuses.VALID) && (
+            <TextArea
+              className={styles.noteInput}
+              skin={TextAreaSkin}
+              autoResize={false}
+              rows={3}
+              maxLength={201}
+              {...noteInputField.bind({
+                onChange: this.handleChange(noteInputField),
+              })}
+            />
+          )}
         </div>
       </Dialog>
     );


### PR DESCRIPTION
This PR fixes issue with note field on Share Wallet Address dialog for software wallets.

## Screenshots

<img width="1149" alt="Screen Shot 2021-06-03 at 11 40 30 AM" src="https://user-images.githubusercontent.com/15862062/120624178-b5be8a80-c460-11eb-81fe-9908748badd4.png">

<img width="1148" alt="Screen Shot 2021-06-03 at 11 45 53 AM" src="https://user-images.githubusercontent.com/15862062/120624806-5745dc00-c461-11eb-8733-14cd354c3d41.png">

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1622716415102500?thread_ts=1622662562.098700&cid=GGKFXSKC6)
- [ ] Test Share Wallet Address dialog on software wallet
- [ ] Test Share Wallet Address dialog on hardware wallet

---
## Test Scenarios
**Scenario 1 - Check notes are visible for software wallet**
```gherkin
Given that I have a software wallet
And I am on the "Share wallet address" dialog on this wallet
When I check the dialog
Then I can see that the input to insert notes in the PDF is visible
And the information inserted there is visible when I export a PDF
```

**Scenario 2 - Check notes are visible for hardware wallet**
```gherkin
Given that I have a hardware wallet
And I am on the "Share wallet address" dialog on this wallet
And I have confirmed the address with the device
When I check the dialog
Then I can see that the input to insert notes in the PDF is visible
And the information inserted there is visible when I export a PDF
```
---
## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
