### PR TITLE
[DDW-699] Fix Trezor transaction native tokens grouping issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 ### Fixes
 
+- Fixed Trezor transaction native tokens grouping issue ([PR 2594](https://github.com/input-output-hk/daedalus/pull/2594))
 - Fixed notes field visibility for software wallets on Share Wallet Address dialog ([PR 2582](https://github.com/input-output-hk/daedalus/pull/2582))
 
 ## 4.1.0

--- a/source/renderer/app/utils/shelleyLedger.js
+++ b/source/renderer/app/utils/shelleyLedger.js
@@ -10,6 +10,7 @@ import _ from 'lodash';
 import {
   derivationPathToLedgerPath,
   CERTIFICATE_TYPE,
+  groupTokensByPolicyId,
 } from './hardwareWalletUtils';
 import { deriveXpubChannel } from '../ipc/getHardwareWalletChannel';
 import { AddressStyles } from '../domains/WalletAddress';
@@ -117,38 +118,6 @@ export const ShelleyTxInputFromUtxo = (utxoInput: CoinSelectionInput) => {
     outputNo,
     encodeCBOR,
   };
-};
-
-export const groupTokensByPolicyId = (assets: CoinSelectionAssetsType) => {
-  const compareStringsCanonically = (string1: string, string2: string) =>
-    string1.length - string2.length || string1.localeCompare(string2);
-
-  const groupedAssets = {};
-  _(assets)
-    .orderBy(['policyId', 'assetName'], ['asc', 'asc'])
-    .groupBy(({ policyId }) => policyId)
-    .mapValues((tokens) =>
-      tokens.map(({ assetName, quantity, policyId }) => ({
-        assetName,
-        quantity,
-        policyId,
-      }))
-    )
-    .map((tokens, policyId) => ({
-      policyId,
-      assets: tokens.sort((token1, token2) =>
-        compareStringsCanonically(token1.assetName, token2.assetName)
-      ),
-    }))
-    .sort((token1, token2) =>
-      compareStringsCanonically(token1.policyId, token2.policyId)
-    )
-    .value()
-    .map((sortedAssetsGroup) => {
-      groupedAssets[sortedAssetsGroup.policyId] = sortedAssetsGroup.assets;
-      return groupedAssets;
-    });
-  return groupedAssets;
 };
 
 export const ShelleyTxOutputAssets = (assets: CoinSelectionAssetsType) => {

--- a/source/renderer/app/utils/shelleyTrezor.js
+++ b/source/renderer/app/utils/shelleyTrezor.js
@@ -1,6 +1,6 @@
 // @flow
 import { utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import _ from 'lodash';
+import { map } from 'lodash';
 import {
   derivationPathToString,
   CERTIFICATE_TYPE,
@@ -76,7 +76,7 @@ export const prepareTokenBundle = (assets: CoinSelectionAssetsType) => {
   const tokenObject = groupTokensByPolicyId(assets);
   const tokenObjectEntries = Object.entries(tokenObject);
 
-  const tokenBundle = _.map(tokenObjectEntries, ([policyId, tokens]) => {
+  const tokenBundle = map(tokenObjectEntries, ([policyId, tokens]) => {
     const tokenAmounts = tokens.map(({ assetName, quantity }) => ({
       assetNameBytes: assetName,
       amount: quantity.toString(),

--- a/source/renderer/app/utils/shelleyTrezor.js
+++ b/source/renderer/app/utils/shelleyTrezor.js
@@ -1,9 +1,10 @@
 // @flow
 import { utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
-import { map } from 'lodash';
+import _ from 'lodash';
 import {
   derivationPathToString,
   CERTIFICATE_TYPE,
+  groupTokensByPolicyId,
 } from './hardwareWalletUtils';
 
 import type {
@@ -11,6 +12,7 @@ import type {
   CoinSelectionOutput,
   CoinSelectionCertificate,
   CoinSelectionWithdrawal,
+  CoinSelectionAssetsType,
 } from '../api/transactions/types';
 
 export const prepareTrezorInput = (input: CoinSelectionInput) => {
@@ -22,11 +24,16 @@ export const prepareTrezorInput = (input: CoinSelectionInput) => {
 };
 
 export const prepareTrezorOutput = (output: CoinSelectionOutput) => {
+  let tokenBundle = [];
+  if (output.assets) {
+    tokenBundle = prepareTokenBundle(output.assets);
+  }
+
   if (output.derivationPath) {
     // Change output
     return {
       amount: output.amount.quantity.toString(),
-      tokenBundle: _getTokenBundle(output.assets),
+      tokenBundle,
       addressParameters: {
         addressType: 0, // BASE address
         path: derivationPathToString(output.derivationPath),
@@ -37,7 +44,7 @@ export const prepareTrezorOutput = (output: CoinSelectionOutput) => {
   return {
     address: output.address,
     amount: output.amount.quantity.toString(),
-    tokenBundle: _getTokenBundle(output.assets),
+    tokenBundle,
   };
 };
 
@@ -65,18 +72,19 @@ export const prepareTrezorWithdrawal = (
 };
 
 // Helper Methods
+export const prepareTokenBundle = (assets: CoinSelectionAssetsType) => {
+  const tokenObject = groupTokensByPolicyId(assets);
+  const tokenObjectEntries = Object.entries(tokenObject);
 
-const _getTokenBundle = (assets) => {
-  const constructedAssets = map(assets, (asset) => {
+  const tokenBundle = _.map(tokenObjectEntries, ([policyId, tokens]) => {
+    const tokenAmounts = tokens.map(({ assetName, quantity }) => ({
+      assetNameBytes: assetName,
+      amount: quantity.toString(),
+    }));
     return {
-      policyId: asset.policyId,
-      tokenAmounts: [
-        {
-          assetNameBytes: asset.assetName,
-          amount: asset.quantity.toString(),
-        },
-      ],
+      policyId,
+      tokenAmounts,
     };
   });
-  return constructedAssets;
+  return tokenBundle;
 };


### PR DESCRIPTION
This PR introduces a fix for the Trezor transaction native tokens grouping issue.

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)

Dedicated QA: @ManusMcCole 
**_Note:_** _This should be tested only with Trezor devices_

- [ ] Send transaction which contains only ADA, without native tokens
- [ ] Send transaction which contains ADA and one native token ( quantity is up to you )
- [ ] **Main Case:** Send transaction which contains multiple native tokens. But, pick at least 2 tokens with the same policyId. Example:
- 1 SadCoin (policy Id: 789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1)
- 1 TrueCoin (policy Id: 789ef8ae89617f34c07f7f6a12e4d65146f958c0bc15a97b4ff169f1)
- 2 TestCoin (policy Id: 6b8d07d69639e9413dd637a1a815a7323c69c86abbafb66dbfdb1aa7)
- 2 SomeCoin (policy Id: 2e6d83507419c027eac6eb9430b780c0793e2c1762b7bff56fbba6f5)
As you can see `SadCoin` and `TrueCoin`have the same Policy ID.

---
## Test Cases

```gherkin
Scenario 1 - Send ADA
Given that I have a Wallet fully loaded in Daedalus
When I send a transaction containing only ADA
Then it is succesfull 

Scenario 2 - Send ADA and a native token
Given that I have a Wallet fully loaded in Daedalus
When I send a transaction containing ADA and a native token
Then the transaction is succesfull

Scenario 3 - Send ADA and 2 native Tokens with the same policyid
Given that I have a Wallet fully loaded in Daedalus
When I attempt to send two native tokens In the same transaction with the same policyid
And they have the same policyID 
Then the transaction will be successfull
```

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
