### PR TITLE
[DDW-703] Undelegate a wallet

### DIFF
--- a/source/renderer/app/components/staking/delegation-center/DelegationCenter.js
+++ b/source/renderer/app/components/staking/delegation-center/DelegationCenter.js
@@ -15,7 +15,6 @@ type Props = {
   numberOfStakePools: number,
   numberOfRankedStakePools: number,
   onDelegate: Function,
-  onUndelegate: Function,
   networkTip: ?TipInfo,
   epochLength: ?number,
   nextEpoch: ?NextEpoch,
@@ -40,7 +39,6 @@ export default class DelegationCenter extends Component<Props> {
       numberOfStakePools,
       numberOfRankedStakePools,
       onDelegate,
-      onUndelegate,
       networkTip,
       epochLength,
       nextEpoch,
@@ -73,7 +71,6 @@ export default class DelegationCenter extends Component<Props> {
           numberOfStakePools={numberOfStakePools}
           numberOfRankedStakePools={numberOfRankedStakePools}
           onDelegate={onDelegate}
-          onUndelegate={onUndelegate}
           getStakePoolById={getStakePoolById}
           nextEpoch={nextEpoch}
           futureEpoch={futureEpoch}

--- a/source/renderer/app/components/staking/delegation-center/DelegationCenterBody.js
+++ b/source/renderer/app/components/staking/delegation-center/DelegationCenterBody.js
@@ -34,7 +34,6 @@ type Props = {
   numberOfStakePools: number,
   numberOfRankedStakePools: number,
   onDelegate: Function,
-  onUndelegate: Function,
   getStakePoolById: Function,
   isLoading: boolean,
   nextEpoch: ?NextEpoch,
@@ -62,7 +61,6 @@ export default class DelegationCenterBody extends Component<Props> {
       numberOfStakePools,
       numberOfRankedStakePools,
       onDelegate,
-      onUndelegate,
       getStakePoolById,
       isLoading,
       nextEpoch,
@@ -123,7 +121,6 @@ export default class DelegationCenterBody extends Component<Props> {
                   numberOfStakePools={numberOfStakePools}
                   numberOfRankedStakePools={numberOfRankedStakePools}
                   onDelegate={() => onDelegate(wallet.id)}
-                  onUndelegate={() => onUndelegate(wallet.id)}
                   delegatedStakePool={getStakePoolById(
                     wallet.delegatedStakePoolId
                   )}

--- a/source/renderer/app/components/staking/delegation-center/WalletRow.js
+++ b/source/renderer/app/components/staking/delegation-center/WalletRow.js
@@ -84,7 +84,6 @@ type Props = {
   numberOfStakePools: number,
   numberOfRankedStakePools: number,
   onDelegate: Function,
-  onUndelegate: Function,
   getStakePoolById: Function,
   nextEpochNumber: number,
   futureEpochNumber: number,
@@ -220,7 +219,6 @@ export default class WalletRow extends Component<Props, WalletRowState> {
       numberOfRankedStakePools,
       getStakePoolById,
       onDelegate,
-      onUndelegate,
       nextEpochNumber,
       futureEpochNumber,
       currentTheme,
@@ -230,12 +228,8 @@ export default class WalletRow extends Component<Props, WalletRowState> {
     } = this.props;
     const { highlightedPoolId } = this.state;
 
-    // @TODO - remove once quit stake pool delegation is connected with rewards balance
-    const isUndelegateBlocked = true;
-
     const syncingProgress = get(syncState, 'progress.quantity', '');
     const notDelegatedText = intl.formatMessage(messages.notDelegated);
-    const removeDelegationText = intl.formatMessage(messages.removeDelegation);
     const delegateText = intl.formatMessage(messages.delegate);
     const redelegateText = intl.formatMessage(messages.redelegate);
 
@@ -456,16 +450,6 @@ export default class WalletRow extends Component<Props, WalletRowState> {
                 ) : (
                   <div className={styles.nonDelegatedText}>
                     {notDelegatedText}
-                  </div>
-                )}
-                {futurePendingDelegatedStakePoolId && !isUndelegateBlocked && (
-                  <div
-                    className={actionButtonStyles}
-                    role="presentation"
-                    onClick={onUndelegate}
-                    key="undelegate"
-                  >
-                    {removeDelegationText}
                   </div>
                 )}
                 <div

--- a/source/renderer/app/components/wallet/settings/UndelegateWalletBox.js
+++ b/source/renderer/app/components/wallet/settings/UndelegateWalletBox.js
@@ -1,0 +1,95 @@
+// @flow
+import type { Node } from 'react';
+import React, { useCallback } from 'react';
+import { injectIntl, intlShape } from 'react-intl';
+import BorderedBox from '../../widgets/BorderedBox';
+import styles from './WalletSettings.scss';
+import UndelegateWalletButton from './UndelegateWalletButton';
+import DelegateWalletButton from './DelegateWalletButton';
+import UndelegateWalletConfirmationDialog from './UndelegateWalletConfirmationDialog';
+import getWalletSettingsMessages from './WalletSettings.messages';
+
+type Props = {
+  intl: intlShape.isRequired,
+  isDelegating: boolean,
+  isDialogOpen: Function,
+  isRestoring: boolean,
+  isSyncing: boolean,
+  onBlockForm: Function,
+  onDelegateClick: Function,
+  openDialogAction: Function,
+  undelegateWalletDialogContainer: Node,
+  updateDataForActiveDialogAction: Function,
+  walletId: string,
+};
+
+const UndelegateWalletBox = ({
+  intl,
+  isDelegating,
+  isRestoring,
+  isSyncing,
+  isDialogOpen,
+  undelegateWalletDialogContainer,
+  walletId,
+  onBlockForm,
+  onDelegateClick,
+  openDialogAction,
+  updateDataForActiveDialogAction,
+}: Props): Node => {
+  const messages = getWalletSettingsMessages();
+
+  const headerMessage = isDelegating
+    ? intl.formatMessage(messages.undelegateWalletHeader)
+    : intl.formatMessage(messages.delegateWalletHeader);
+  let warningMessage = null;
+  if (isDelegating) {
+    warningMessage =
+      isRestoring || isSyncing
+        ? intl.formatMessage(messages.undelegateWalletDisabledWarning)
+        : intl.formatMessage(messages.undelegateWalletWarning);
+  } else {
+    warningMessage =
+      isRestoring || isSyncing
+        ? intl.formatMessage(messages.delegateWalletDisabledWarning)
+        : intl.formatMessage(messages.delegateWalletWarning);
+  }
+
+  const onUndelegateWalletClick = useCallback(async () => {
+    onBlockForm();
+    openDialogAction({
+      dialog: UndelegateWalletConfirmationDialog,
+    });
+    updateDataForActiveDialogAction({
+      data: { walletId },
+    });
+  });
+
+  return (
+    <>
+      <BorderedBox className={styles.undelegateWalletBox}>
+        <span>{headerMessage}</span>
+        <div className={styles.contentBox}>
+          <div>
+            <p>{warningMessage}</p>
+          </div>
+          {isDelegating ? (
+            <UndelegateWalletButton
+              disabled={isRestoring || isSyncing}
+              onUndelegate={onUndelegateWalletClick}
+            />
+          ) : (
+            <DelegateWalletButton
+              disabled={isRestoring || isSyncing}
+              onDelegate={onDelegateClick}
+            />
+          )}
+        </div>
+      </BorderedBox>
+      {isDialogOpen(UndelegateWalletConfirmationDialog)
+        ? undelegateWalletDialogContainer
+        : false}
+    </>
+  );
+};
+
+export default injectIntl(UndelegateWalletBox);

--- a/source/renderer/app/components/wallet/settings/UndelegateWalletConfirmationDialog.js
+++ b/source/renderer/app/components/wallet/settings/UndelegateWalletConfirmationDialog.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
 import { get } from 'lodash';
-import { defineMessages, intlShape, FormattedHTMLMessage } from 'react-intl';
+import { intlShape, FormattedHTMLMessage } from 'react-intl';
 import vjf from 'mobx-react-form/lib/validators/VJF';
 import classnames from 'classnames';
 import { Checkbox } from 'react-polymorph/lib/components/Checkbox';
@@ -22,85 +22,9 @@ import styles from './UndelegateWalletConfirmationDialog.scss';
 import globalMessages from '../../../i18n/global-messages';
 import LocalizableError from '../../../i18n/LocalizableError';
 import { submitOnEnter } from '../../../utils/form';
+import getUndelegateWalletConfirmationDialogMessages from './UndelegateWalletConfirmationDialog.messages';
 
-const messages = defineMessages({
-  title: {
-    id: 'wallet.settings.undelegate.dialog.title',
-    defaultMessage: '!!!Undelegate',
-    description: 'Title for the "Undelegate wallet" dialog.',
-  },
-  confirmButtonLabel: {
-    id: 'wallet.settings.undelegate.dialog.confirmButtonLabel',
-    defaultMessage: '!!!Undelegate',
-    description:
-      'Label for the "Undelegate" button in the undelegate wallet dialog.',
-  },
-  descriptionWithTicker: {
-    id: 'wallet.settings.undelegate.dialog.descriptionWithTicker',
-    defaultMessage:
-      '!!!<p>The stake from your wallet <strong>{walletName}</strong> is currently delegated to the <strong>[{stakePoolTicker}] {stakePoolName}</strong> stake pool.</p><p>Do you want to undelegate your stake and stop earning rewards?</p>',
-    description:
-      'Description of current delegation of wallet in the "Undelegate wallet" dialog.',
-  },
-  descriptionWithUnknownTicker: {
-    id: 'wallet.settings.undelegate.dialog.descriptionWithUnknownTicker',
-    defaultMessage:
-      '!!!<p>The stake from your wallet <strong>{walletName}</strong> is currently delegated to the <strong>{stakePoolTicker}</strong> stake pool.</p><p>Do you want to undelegate your stake and stop earning rewards?</p>',
-    description:
-      'Description of current delegation of wallet in the "Undelegate wallet" dialog.',
-  },
-  unknownStakePoolLabel: {
-    id: 'wallet.settings.undelegate.dialog.unknownStakePoolLabel',
-    defaultMessage: '!!!unknown',
-    description: 'unknown stake pool label in the "Undelegate wallet" dialog.',
-  },
-  confirmUnsupportNotice: {
-    id: 'wallet.settings.undelegate.dialog.confirmUnsupportNotice',
-    defaultMessage:
-      '!!!I understand that I am not supporting the Cardano network when my stake is undelegated.',
-    description:
-      'Notice to confirm if the user understands unsupporting Cardano network after undelegation',
-  },
-  confirmIneligibleNotice: {
-    id: 'wallet.settings.undelegate.dialog.confirmIneligibleNotice',
-    defaultMessage:
-      '!!!I understand that I will not be eligible to earn rewards when my stake is undelegated.',
-    description:
-      'Notice to confirm if the user understands non-earning rewards after undelegation',
-  },
-  feesLabel: {
-    id: 'wallet.settings.undelegate.dialog.feesLabel',
-    defaultMessage: '!!!Fees',
-    description: 'Fees label in the "Undelegate wallet" dialog.',
-  },
-  depositLabel: {
-    id: 'wallet.settings.undelegate.dialog.depositLabel',
-    defaultMessage: '!!!Deposits reclaimed',
-    description: 'Deposits reclaimed label in the "Undelegate wallet" dialog.',
-  },
-  spendingPasswordLabel: {
-    id: 'wallet.settings.undelegate.dialog.spendingPasswordLabel',
-    defaultMessage: '!!!Spending password',
-    description: 'Spending password label in the "Undelegate wallet" dialog.',
-  },
-  spendingPasswordPlaceholder: {
-    id: 'wallet.settings.undelegate.dialog.spendingPasswordPlaceholder',
-    defaultMessage: '!!!Type your spending password here',
-    description:
-      'Spending password placeholder in the "Undelegate wallet" dialog.',
-  },
-  passwordErrorMessage: {
-    id: 'wallet.settings.undelegate.dialog.passwordError',
-    defaultMessage: '!!!Incorrect spending password.',
-    description: 'Label for password error in the "Undelegate wallet" dialog.',
-  },
-  calculatingFees: {
-    id: 'wallet.settings.undelegate.dialog.calculatingFees',
-    defaultMessage: '!!!Calculating fees',
-    description:
-      '"Calculating fees" message in the "Undelegate wallet" dialog.',
-  },
-});
+const messages = getUndelegateWalletConfirmationDialogMessages();
 
 messages.fieldIsRequired = globalMessages.fieldIsRequired;
 

--- a/source/renderer/app/components/wallet/settings/UndelegateWalletConfirmationDialog.messages.js
+++ b/source/renderer/app/components/wallet/settings/UndelegateWalletConfirmationDialog.messages.js
@@ -1,0 +1,91 @@
+// @flow
+import { defineMessages } from 'react-intl';
+import type { ReactIntlMessage } from '../../../types/i18nTypes';
+
+const getUndelegateWalletConfirmationDialogMessages = (): {
+  [string]: ReactIntlMessage,
+} =>
+  defineMessages({
+    title: {
+      id: 'wallet.settings.undelegate.dialog.title',
+      defaultMessage: '!!!Undelegate',
+      description: 'Title for the "Undelegate wallet" dialog.',
+    },
+    confirmButtonLabel: {
+      id: 'wallet.settings.undelegate.dialog.confirmButtonLabel',
+      defaultMessage: '!!!Undelegate',
+      description:
+        'Label for the "Undelegate" button in the undelegate wallet dialog.',
+    },
+    descriptionWithTicker: {
+      id: 'wallet.settings.undelegate.dialog.descriptionWithTicker',
+      defaultMessage:
+        '!!!<p>The stake from your wallet <strong>{walletName}</strong> is currently delegated to the <strong>[{stakePoolTicker}] {stakePoolName}</strong> stake pool.</p><p>Do you want to undelegate your stake and stop earning rewards?</p>',
+      description:
+        'Description of current delegation of wallet in the "Undelegate wallet" dialog.',
+    },
+    descriptionWithUnknownTicker: {
+      id: 'wallet.settings.undelegate.dialog.descriptionWithUnknownTicker',
+      defaultMessage:
+        '!!!<p>The stake from your wallet <strong>{walletName}</strong> is currently delegated to the <strong>{stakePoolTicker}</strong> stake pool.</p><p>Do you want to undelegate your stake and stop earning rewards?</p>',
+      description:
+        'Description of current delegation of wallet in the "Undelegate wallet" dialog.',
+    },
+    unknownStakePoolLabel: {
+      id: 'wallet.settings.undelegate.dialog.unknownStakePoolLabel',
+      defaultMessage: '!!!unknown',
+      description:
+        'unknown stake pool label in the "Undelegate wallet" dialog.',
+    },
+    confirmUnsupportNotice: {
+      id: 'wallet.settings.undelegate.dialog.confirmUnsupportNotice',
+      defaultMessage:
+        '!!!I understand that I am not supporting the Cardano network when my stake is undelegated.',
+      description:
+        'Notice to confirm if the user understands unsupporting Cardano network after undelegation',
+    },
+    confirmIneligibleNotice: {
+      id: 'wallet.settings.undelegate.dialog.confirmIneligibleNotice',
+      defaultMessage:
+        '!!!I understand that I will not be eligible to earn rewards when my stake is undelegated.',
+      description:
+        'Notice to confirm if the user understands non-earning rewards after undelegation',
+    },
+    feesLabel: {
+      id: 'wallet.settings.undelegate.dialog.feesLabel',
+      defaultMessage: '!!!Fees',
+      description: 'Fees label in the "Undelegate wallet" dialog.',
+    },
+    depositLabel: {
+      id: 'wallet.settings.undelegate.dialog.depositLabel',
+      defaultMessage: '!!!Deposits reclaimed',
+      description:
+        'Deposits reclaimed label in the "Undelegate wallet" dialog.',
+    },
+    spendingPasswordLabel: {
+      id: 'wallet.settings.undelegate.dialog.spendingPasswordLabel',
+      defaultMessage: '!!!Spending password',
+      description: 'Spending password label in the "Undelegate wallet" dialog.',
+    },
+    spendingPasswordPlaceholder: {
+      id: 'wallet.settings.undelegate.dialog.spendingPasswordPlaceholder',
+      defaultMessage: '!!!Type your spending password here',
+      description:
+        'Spending password placeholder in the "Undelegate wallet" dialog.',
+    },
+
+    passwordErrorMessage: {
+      id: 'wallet.settings.undelegate.dialog.passwordError',
+      defaultMessage: '!!!Incorrect spending password.',
+      description:
+        'Label for password error in the "Undelegate wallet" dialog.',
+    },
+    calculatingFees: {
+      id: 'wallet.settings.undelegate.dialog.calculatingFees',
+      defaultMessage: '!!!Calculating fees',
+      description:
+        '"Calculating fees" message in the "Undelegate wallet" dialog.',
+    },
+  });
+
+export default getUndelegateWalletConfirmationDialogMessages;

--- a/source/renderer/app/components/wallet/settings/WalletSettings.js
+++ b/source/renderer/app/components/wallet/settings/WalletSettings.js
@@ -2,7 +2,7 @@
 import type { Node } from 'react';
 import React, { Component } from 'react';
 import { observer } from 'mobx-react';
-import { defineMessages, intlShape } from 'react-intl';
+import { intlShape } from 'react-intl';
 import moment from 'moment';
 import LocalizableError from '../../../i18n/LocalizableError';
 import {
@@ -30,89 +30,10 @@ import ICOPublicKeyDialog from './ICOPublicKeyDialog';
 import ICOPublicKeyQRCodeDialog from './ICOPublicKeyQRCodeDialog';
 import WalletPublicKeyDialog from './WalletPublicKeyDialog';
 import WalletPublicKeyQRCodeDialog from './WalletPublicKeyQRCodeDialog';
-import type { ReactIntlMessage } from '../../../types/i18nTypes';
+import getWalletSettingsMessages from './WalletSettings.messages';
+import UndelegateWalletBox from './UndelegateWalletBox';
 
-export const messages: { [string]: ReactIntlMessage } = defineMessages({
-  assuranceLevelLabel: {
-    id: 'wallet.settings.assurance',
-    defaultMessage: '!!!Transaction assurance security level',
-    description:
-      'Label for the "Transaction assurance security level" dropdown.',
-  },
-  undelegateWalletHeader: {
-    id: 'wallet.settings.undelegateWallet.header',
-    defaultMessage: '!!!Undelegating your wallet',
-    description: 'Undelegate wallet header on the wallet settings page.',
-  },
-  undelegateWalletWarning: {
-    id: 'wallet.settings.undelegateWallet.warning',
-    defaultMessage:
-      '!!!If you are planning to stop using this wallet and remove all funds, you should first undelegate it to recover your 2 ada deposit. You will continue getting delegation rewards during the three Cardano epochs after undelegating your wallet.',
-    description: 'Undelegate wallet warning explaining the consequences.',
-  },
-  undelegateWalletDisabledWarning: {
-    id: 'wallet.settings.undelegateWallet.disabledWarning',
-    defaultMessage:
-      "!!!This wallet is synchronizing with the blockchain, so this wallet's delegation status is currently unknown, and undelegation is not possible.",
-    description:
-      'Undelegate wallet disabled warning explaining why it is disabled.',
-  },
-  delegateWalletHeader: {
-    id: 'wallet.settings.delegateWallet.header',
-    defaultMessage: '!!!Delegate your wallet',
-    description: 'Delegate wallet header on the wallet settings page.',
-  },
-  delegateWalletWarning: {
-    id: 'wallet.settings.delegateWallet.warning',
-    defaultMessage:
-      "!!!This wallet is not delegated. Please, delegate the stake from this wallet to earn rewards and support the Cardano network's security.",
-    description: 'Delegate wallet warning.',
-  },
-  delegateWalletDisabledWarning: {
-    id: 'wallet.settings.delegateWallet.disabledWarning',
-    defaultMessage:
-      "!!!This wallet is synchronizing with the blockchain, so this wallet's delegation status is currently unknown, and delegation is not possible.",
-    description:
-      'Delegate wallet disabled warning explaining why it is disabled.',
-  },
-  deleteWalletHeader: {
-    id: 'wallet.settings.deleteWallet.header',
-    defaultMessage: '!!!Delete wallet',
-    description: 'Delete wallet header on the wallet settings page.',
-  },
-  deleteWalletWarning1: {
-    id: 'wallet.settings.deleteWallet.warning1',
-    defaultMessage:
-      '!!!Once you delete this wallet it will be removed from the Daedalus interface and you will lose access to any remaining funds in the wallet. The only way to regain access after deletion is by restoring it using your wallet recovery phrase.',
-    description: 'Delete wallet warning explaining the consequences.',
-  },
-  deleteWalletWarning2: {
-    id: 'wallet.settings.deleteWallet.warning2',
-    defaultMessage:
-      '!!!You may wish to verify your recovery phrase before deletion to ensure that you can restore this wallet in the future, if desired.',
-    description: 'Delete wallet warning explaining the consequences.',
-  },
-  name: {
-    id: 'wallet.settings.name.label',
-    defaultMessage: '!!!Name',
-    description: 'Label for the "Name" text input on the wallet settings page.',
-  },
-  passwordLabel: {
-    id: 'wallet.settings.password',
-    defaultMessage: '!!!Password',
-    description: 'Label for the "Password" field.',
-  },
-  passwordLastUpdated: {
-    id: 'wallet.settings.passwordLastUpdated',
-    defaultMessage: '!!!Last updated',
-    description: 'Last updated X time ago message.',
-  },
-  passwordNotSet: {
-    id: 'wallet.settings.passwordNotSet',
-    defaultMessage: "!!!You still don't have password",
-    description: "You still don't have password set message.",
-  },
-});
+const messages = getWalletSettingsMessages();
 
 type Props = {
   walletId: string,
@@ -309,6 +230,13 @@ export default class WalletSettings extends Component<Props, State> {
   render() {
     const { intl } = this.context;
     const {
+      isDelegating,
+      isRestoring,
+      isSyncing,
+      undelegateWalletDialogContainer,
+      walletId,
+      onDelegateClick,
+      updateDataForActiveDialogAction,
       walletName,
       creationDate,
       spendingPasswordUpdateDate,
@@ -436,7 +364,22 @@ export default class WalletSettings extends Component<Props, State> {
           </>
         )}
 
-        {this.renderUndelegateWalletBox()}
+        {IS_WALLET_UNDELEGATION_ENABLED && !isLegacy && (
+          <UndelegateWalletBox
+            {...{
+              isDelegating,
+              isRestoring,
+              isSyncing,
+              isDialogOpen,
+              undelegateWalletDialogContainer,
+              walletId,
+              onBlockForm: this.onBlockForm,
+              onDelegateClick,
+              openDialogAction,
+              updateDataForActiveDialogAction,
+            }}
+          />
+        )}
         {this.renderDeleteWalletBox()}
       </div>
     );

--- a/source/renderer/app/components/wallet/settings/WalletSettings.messages.js
+++ b/source/renderer/app/components/wallet/settings/WalletSettings.messages.js
@@ -1,0 +1,89 @@
+// @flow
+import { defineMessages } from 'react-intl';
+import type { ReactIntlMessage } from '../../../types/i18nTypes';
+
+const getWalletSettingsMessages = (): { [string]: ReactIntlMessage } =>
+  defineMessages({
+    assuranceLevelLabel: {
+      id: 'wallet.settings.assurance',
+      defaultMessage: '!!!Transaction assurance security level',
+      description:
+        'Label for the "Transaction assurance security level" dropdown.',
+    },
+    undelegateWalletHeader: {
+      id: 'wallet.settings.undelegateWallet.header',
+      defaultMessage: '!!!Undelegating your wallet',
+      description: 'Undelegate wallet header on the wallet settings page.',
+    },
+    undelegateWalletWarning: {
+      id: 'wallet.settings.undelegateWallet.warning',
+      defaultMessage:
+        '!!!If you are planning to stop using this wallet and remove all funds, you should first undelegate it to recover your 2 ada deposit. You will continue getting delegation rewards during the three Cardano epochs after undelegating your wallet.',
+      description: 'Undelegate wallet warning explaining the consequences.',
+    },
+    undelegateWalletDisabledWarning: {
+      id: 'wallet.settings.undelegateWallet.disabledWarning',
+      defaultMessage:
+        "!!!This wallet is synchronizing with the blockchain, so this wallet's delegation status is currently unknown, and undelegation is not possible.",
+      description:
+        'Undelegate wallet disabled warning explaining why it is disabled.',
+    },
+    delegateWalletHeader: {
+      id: 'wallet.settings.delegateWallet.header',
+      defaultMessage: '!!!Delegate your wallet',
+      description: 'Delegate wallet header on the wallet settings page.',
+    },
+    delegateWalletWarning: {
+      id: 'wallet.settings.delegateWallet.warning',
+      defaultMessage:
+        "!!!This wallet is not delegated. Please, delegate the stake from this wallet to earn rewards and support the Cardano network's security.",
+      description: 'Delegate wallet warning.',
+    },
+    delegateWalletDisabledWarning: {
+      id: 'wallet.settings.delegateWallet.disabledWarning',
+      defaultMessage:
+        "!!!This wallet is synchronizing with the blockchain, so this wallet's delegation status is currently unknown, and delegation is not possible.",
+      description:
+        'Delegate wallet disabled warning explaining why it is disabled.',
+    },
+    deleteWalletHeader: {
+      id: 'wallet.settings.deleteWallet.header',
+      defaultMessage: '!!!Delete wallet',
+      description: 'Delete wallet header on the wallet settings page.',
+    },
+    deleteWalletWarning1: {
+      id: 'wallet.settings.deleteWallet.warning1',
+      defaultMessage:
+        '!!!Once you delete this wallet it will be removed from the Daedalus interface and you will lose access to any remaining funds in the wallet. The only way to regain access after deletion is by restoring it using your wallet recovery phrase.',
+      description: 'Delete wallet warning explaining the consequences.',
+    },
+    deleteWalletWarning2: {
+      id: 'wallet.settings.deleteWallet.warning2',
+      defaultMessage:
+        '!!!You may wish to verify your recovery phrase before deletion to ensure that you can restore this wallet in the future, if desired.',
+      description: 'Delete wallet warning explaining the consequences.',
+    },
+    name: {
+      id: 'wallet.settings.name.label',
+      defaultMessage: '!!!Name',
+      description:
+        'Label for the "Name" text input on the wallet settings page.',
+    },
+    passwordLabel: {
+      id: 'wallet.settings.password',
+      defaultMessage: '!!!Password',
+      description: 'Label for the "Password" field.',
+    },
+    passwordLastUpdated: {
+      id: 'wallet.settings.passwordLastUpdated',
+      defaultMessage: '!!!Last updated',
+      description: 'Last updated X time ago message.',
+    },
+    passwordNotSet: {
+      id: 'wallet.settings.passwordNotSet',
+      defaultMessage: "!!!You still don't have password",
+      description: "You still don't have password set message.",
+    },
+  });
+
+export default getWalletSettingsMessages;

--- a/source/renderer/app/config/walletsConfig.js
+++ b/source/renderer/app/config/walletsConfig.js
@@ -47,6 +47,6 @@ export const WALLET_ASSETS_ENABLED = true;
 // Byron wallet migration has been temporarily disabled due to missing Api support after Mary HF
 export const IS_BYRON_WALLET_MIGRATION_ENABLED = false;
 
-export const IS_WALLET_UNDELEGATION_ENABLED = false;
+export const IS_WALLET_UNDELEGATION_ENABLED = true;
 
 export const TRANSACTION_MIN_ADA_VALUE = 1;


### PR DESCRIPTION
This PR CHANGES.

The undelegation feature is partially completed. It is currently disabled since we needed to cover pending delegation statuses after a wallet is undelegated.

Important to understand: When wallet is undelegated, rewards address is deregistered so rewards cannot be collected. Even though a wallet will be earning rewards for two epochs after it was undelegated, the rewards will go to the Cardano treasury.

## Todos

- [ ] Todo
- [ ] Reenable the feature
- [ ] Update unedelgation wizard to display deposits that will be returned
- [ ] Update UI copy
- [ ] Update delegation center to display pending delegation preferences for a case when wallet is delegated in an epoch but rewards are going to the treasury.

## Screenshots


## Testing Checklist

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
