### PR TITLE
[DDW-747] Fix transaction localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## vNext
+
+### Fixes
+
+- Fixed transaction timestamps localization ([PR 2702](https://github.com/input-output-hk/daedalus/pull/2702))
+
 ## 4.4.0
 
 ### Features
@@ -8,7 +14,6 @@
 
 ### Fixes
 
-- Fixed transaction timestamps localization ([PR 2702](https://github.com/input-output-hk/daedalus/pull/2702))
 - Fixed wallet settings screen - no space at the bottom when scrolled down ([PR 2686](https://github.com/input-output-hk/daedalus/pull/2686))
 - Fixed the missing text for the DAPP static screens ([PR 2693](https://github.com/input-output-hk/daedalus/pull/2693))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fixed transaction timestamps localization ([PR 2702](https://github.com/input-output-hk/daedalus/pull/2702))
 - Fixed wallet settings screen - no space at the bottom when scrolled down ([PR 2686](https://github.com/input-output-hk/daedalus/pull/2686))
 - Fixed the missing text for the DAPP static screens ([PR 2693](https://github.com/input-output-hk/daedalus/pull/2693))
 

--- a/source/renderer/app/components/wallet/transactions/Transaction.js
+++ b/source/renderer/app/components/wallet/transactions/Transaction.js
@@ -576,7 +576,9 @@ export default class Transaction extends Component<Props, State> {
               <div className={styles.details}>
                 <div className={styles.type}>
                   {intl.formatMessage(messages.type, { typeOfTransaction })},{' '}
-                  {moment(data.date).format(currentTimeFormat)}
+                  {moment(data.date)
+                    .locale(intl.locale)
+                    .format(currentTimeFormat)}
                 </div>
                 {this.renderTxnStateTag()}
               </div>


### PR DESCRIPTION
This PR immediately localizes transaction timestamps when settings language is changed

## Todos

- [x] localize transaction timestamp

## Screenshots

https://user-images.githubusercontent.com/7581002/136828566-480ebd60-82f8-4b18-a605-888c4dd05445.mov

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---
## Test Scenarios

**Scenario 1 - Validate transactions after switching to Japanese**
```gherkin
Given that Daedalus is synced
And it has a synced wallet with transaction history
And the selected language is English
And the time format is 12 hs with AM/PM indicators
When I switch the language to Japanese
And I check the timestamp of a transaction without reloading Daedalus
Then I can see that the corresponding "AM/PM" translations are displayed next to the time
```
**Scenario 2 - Validate transactions after switching to English**
```gherkin
Given that Daedalus is synced
And it has a synced wallet with transaction history
And the selected language is Japanese
And the time format is 12 hs with AM/PM indicators
When I switch the language to English
And I check the timestamp of a transaction without reloading Daedalus
Then I can see that the "AM/PM" indicator is displayed next to the time
```
**Scenario 3 - Validate transactions after switching time indicators (English)**
```gherkin
Given that Daedalus is synced
And it has a synced wallet with transaction history
And the selected language is Japanese
And the time format is 24 hs without AM/PM indicators
When I switch the language to English
And change the time format to include AM/PM indicators
And I check the timestamp of a transaction without reloading Daedalus
Then I can see that the "AM/PM" indicator is displayed next to the time
```
**Scenario 4 - Validate transactions after switching time indicators (Japanese)**
```gherkin
Given that Daedalus is synced
And it has a synced wallet with transaction history
And the selected language is English
And the time format is 24 hs without AM/PM indicators
When I switch the language to Japanese
And change the time format to include AM/PM indicators
And I check the timestamp of a transaction without reloading Daedalus
Then I can see that the corresponding "AM/PM" translations are displayed next to the time
```

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
