### PR TITLE
More aarch64-darwin fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,8 @@ let
   pkgs = localLib.iohkNix.getPkgsDefault { inherit system config; };
   pkgsNative = localLib.iohkNix.getPkgsDefault {};
   sources = localLib.sources;
+  haskellNix = import sources."haskell.nix" {};
+  inherit (import haskellNix.sources.nixpkgs-unstable haskellNix.nixpkgsArgs) haskell-nix;
   walletPkgs = import "${sources.cardano-wallet}/nix" {};
   # only used for CLI, to be removed when upgraded to next node version
   nodePkgs = import "${sources.cardano-node}/nix" {};
@@ -315,7 +317,11 @@ let
     };
     rawapp-win64 = self.rawapp.override { win64 = true; };
     source = builtins.filterSource localLib.cleanSourceFilter ./.;
-    yaml2json = pkgs.haskell.lib.disableCabalFlag pkgs.haskellPackages.yaml "no-exe";
+    inherit ((haskell-nix.hackage-package { name = "yaml"; compiler-nix-name = "ghc8107"; cabalProject = ''
+      packages: .
+      package yaml
+        flags: -no-exe
+    ''; }).components.exes) yaml2json;
 
     electron = pkgs.callPackage ./installers/nix/electron.nix {};
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-wallet",
-        "rev": "664304966e8510df4df4eccb80ae5ce68c1cebd3",
-        "sha256": "0zvknqphvgrf0i6qjxc50fhj5b5j7d58j09xdq58862n8f8qc0bg",
+        "rev": "8169ac8d778adabb4ec0e4c86a5be00967490257",
+        "sha256": "1s4viy15km5shp9jb46lvqkbsn76layd7cmavgfbbb8lx7lpqr7l",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-wallet/archive/664304966e8510df4df4eccb80ae5ce68c1cebd3.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-wallet/archive/8169ac8d778adabb4ec0e4c86a5be00967490257.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gitignore": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-shell",
-        "rev": "fe14d02a18ecb4280f50da4706ac682b5543271c",
-        "sha256": "0qmkp572m433vp4rzpz7ph18z9q89901xlxc24j0gvh7ljx0b84f",
+        "rev": "2d93508a7c986a7a0b08cc912e3abc7908137e49",
+        "sha256": "0xada5xf2vfpdczgcvadrwhqpz6c2gl93h766wsza12blvnhpvci",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-shell/archive/fe14d02a18ecb4280f50da4706ac682b5543271c.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-shell/archive/2d93508a7c986a7a0b08cc912e3abc7908137e49.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-wallet": {

--- a/shell.nix
+++ b/shell.nix
@@ -57,7 +57,9 @@ let
       git python27 curl jq
       nodePackages.node-gyp nodePackages.node-pre-gyp
       gnumake
-      chromedriver
+      (if system == "aarch64-darwin"
+        then (localLib.iohkNix.getPkgs { system = "x86_64-darwin"; inherit config; }).chromedriver
+        else chromedriver)
       pkgconfig
       libusb
     ] ++ (localLib.optionals autoStartBackend [


### PR DESCRIPTION
Updates cardano-shell
Uses x86_64 for chromedriver (not sure if it will work, but the aarch64 one is marked as broken)
Fixes yaml2json
Uses cardano-wallet version with another `git` `build-tools` fix