### PR TITLE
Fix wallet restore dialog and continue disable check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fixed issues relating to minimum window size in Daedalus ([PR 2719](https://github.com/input-output-hk/daedalus/pull/2719))
 - Updated "Trezor T" image shown on the "Pair a hardware wallet device" dialog ([PR 2712](https://github.com/input-output-hk/daedalus/pull/2712))
 - Fixed transaction timestamps localization ([PR 2702](https://github.com/input-output-hk/daedalus/pull/2702))
-- Small UI/UX Fixes ([PR 2685](https://github.com/input-output-hk/daedalus/pull/2685))
+- Small UI/UX Fixes ([PR 2685](https://github.com/input-output-hk/daedalus/pull/2685), [PR 2745](https://github.com/input-output-hk/daedalus/pull/2745))
 
 ### Chores
 

--- a/source/renderer/app/containers/wallet/dialogs/wallet-restore/StepConfigurationContainer.js
+++ b/source/renderer/app/containers/wallet/dialogs/wallet-restore/StepConfigurationContainer.js
@@ -15,7 +15,6 @@ export default class ConfigurationDialogContainer extends Component<Props> {
 
   handleContinue = () => {
     this.props.actions.wallets.restoreWallet.trigger();
-    this.props.actions.wallets.restoreWalletEnd.trigger();
   };
 
   handleChange = (param: string, field: Object) =>
@@ -28,14 +27,19 @@ export default class ConfigurationDialogContainer extends Component<Props> {
     const { onClose, onBack, stores } = this.props;
     const { wallets, profile } = stores;
     const { currentLocale } = profile;
-    const { error, isExecuting } = wallets.restoreRequest;
-    const { walletName, spendingPassword, repeatPassword } = wallets;
+    const { error } = wallets.restoreRequest;
+    const {
+      walletName,
+      spendingPassword,
+      repeatPassword,
+      isRestoring,
+    } = wallets;
     const {
       error: certificateError,
     } = stores.wallets.getWalletRecoveryPhraseFromCertificateRequest;
     return (
       <ConfigurationDialog
-        isSubmitting={isExecuting}
+        isSubmitting={isRestoring}
         onClose={onClose}
         onContinue={this.handleContinue}
         onChange={this.handleChange}

--- a/source/renderer/app/containers/wallet/dialogs/wallet-restore/StepSuccessContainer.js
+++ b/source/renderer/app/containers/wallet/dialogs/wallet-restore/StepSuccessContainer.js
@@ -16,10 +16,10 @@ export default class SuccessDialogContainer extends Component<Props> {
   render() {
     const { stores, actions } = this.props;
     const { walletKindDaedalus, walletKindYoroi } = stores.wallets;
-    const { restoreWalletClose } = actions.wallets;
+    const { restoreWalletEnd } = actions.wallets;
     return (
       <SuccessDialog
-        onClose={() => restoreWalletClose.trigger()}
+        onClose={() => restoreWalletEnd.trigger()}
         walletKindDaedalus={walletKindDaedalus}
         walletKindYoroi={walletKindYoroi}
       />

--- a/source/renderer/app/stores/WalletsStore.js
+++ b/source/renderer/app/stores/WalletsStore.js
@@ -172,6 +172,8 @@ export default class WalletsStore extends Store {
 
   /* ----------  Delete Wallet  ---------- */
   @observable isDeleting: boolean = false;
+  /* ----------  Restore Wallet  ---------- */
+  @observable isRestoring: boolean = false;
 
   /* ----------  Paper Wallet  ---------- */
   @observable createPaperWalletCertificateStep = 0;
@@ -404,6 +406,7 @@ export default class WalletsStore extends Store {
     const { restoredWallet } = this;
     if (restoredWallet) {
       await this._patchWalletRequestWithNewWallet(restoredWallet);
+      this.goToWalletRoute(restoredWallet.id);
       this.refreshWalletsData();
       this._restoreWalletResetRequests();
       this._restoreWalletResetData();
@@ -668,7 +671,8 @@ export default class WalletsStore extends Store {
     return unscrambledRecoveryPhrase;
   };
 
-  _restore = async () => {
+  @action _restore = async () => {
+    this.isRestoring = true;
     // Pause polling in order to avoid fetching data for wallet we are about to restore
     // so that we remain on the "Add wallet" screen until user closes the TADA screen
     await this._pausePolling();
@@ -702,8 +706,11 @@ export default class WalletsStore extends Store {
         this.restoredWallet = restoredWallet;
         this.restoreWalletStep = 3;
       });
-    } catch (error) {
+    } finally {
       this._resumePolling();
+      runInAction('end wallet restore', () => {
+        this.isRestoring = false;
+      });
     }
   };
 


### PR DESCRIPTION
This PR fixes 2 issues in restoring wallets:

- Continue button could be pressed multiple times
- Wallet restore dialog state not reset correctly


---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
