### PR TITLE
Fix race condition in CardanoNode.start and unhandled rejection in CardanoNode._storeData

### DIFF
--- a/source/main/cardano/CardanoNode.js
+++ b/source/main/cardano/CardanoNode.js
@@ -961,7 +961,11 @@ export class CardanoNode {
     new Promise((resolve, reject) => {
       try {
         // saves current port/pid in file system
-        store.set(identifier, data);
+        if (data !== undefined) {
+          store.set(identifier, data);
+        } else {
+          store.delete(identifier);
+        }
         this._log.info(`CardanoNode: ${identifier} stored successfully`);
         resolve();
       } catch (error) {


### PR DESCRIPTION
This PR fixes #2746 and #2748.

The problem was that `handleCheckDiskSpace` was called twice in very quick succession, once [from `main/index.js`](https://github.com/input-output-hk/daedalus/blob/5b329b9ee99ccf99daff296b9e9f7e1b434cf7ef/source/main/index.js#L212) and once [from `NetworkStatusStore._checkDiskSpace`](https://github.com/input-output-hk/daedalus/blob/e94535da2acb021661657ca0448d6155d5aa2605/source/renderer/app/stores/NetworkStatusStore.js#L242) via IPC.

In case a `mainnet-PREVIOUS-CARDANO-PID` was existing, Daedalus could then attempt to start two Cardano nodes in parallel, forgetting the existence of the first and watching only the second, which would then keep crashing because of `DbLocked`. This is because `_canBeStarted` is asynchronous and calls `_ensurePreviousCardanoNodeIsNotRunning`, which will take a few milliseconds if a `mainnet-PREVIOUS-CARDANO-PID` exists. Since this is called _before_ the state is set to `STARTING`, there is nothing preventing another start from commencing while the first one is waiting for `_canBeStarted` to return.

For some reason, it wouldn't work even when the other node was killed while Daedalus was running, as following attempts to restart the node would cause an error, and _somehow_ it would then again start another instance. I didn't debug into this too much, but I noticed that `_storeData` when called with undefined PID would cause an unhandled rejection because `ElectronStore` throws `TypeError: Use delete() to remove values` when called with `undefined` as data, which I fixed by actually calling `delete` in this case, and that solved the restart too.

**Note: I don't really understand the development and review process of this repository, and I don't have a test setup. I'm just trying to share the solution that worked for me. To test, I just applied the same changes manually in the webpacked JS. Feel free to implement it differently in your own PR and discard this one, as I'm not sure I followed best practices or proper procedures at all. (For example, while this works, it causes the second parallel request to be rejected, which turns up as error in the devtools.)**

_By the way there are much fewer changes than it may appear, because I wrapped a large block of code in `try`/`finally`._

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
