### PR TITLE
[DDW-683] Prevent stake pools list reloading when slide didn't change position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added jest library for unit testing ([PR 2633](https://github.com/input-output-hk/daedalus/pull/2633))
 - Updated `cardano-launcher` to version `0.20211105.1` and added Cardano Node RTS flags which improve resource usage ([PR 2735](https://github.com/input-output-hk/daedalus/pull/2735), [PR 2741](https://github.com/input-output-hk/daedalus/pull/2741))
 
+### Features
+
+- Updated slider component to only execute onAfterChange if slider had moved ([PR 2766](https://github.com/input-output-hk/daedalus/pull/2766))
+
 ## 4.5.2
 
 ### Fixes

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsRanking.js
@@ -29,7 +29,7 @@ import {
 } from '../../../config/stakingConfig';
 import WalletsDropdown from '../../widgets/forms/WalletsDropdown';
 import ButtonLink from '../../widgets/ButtonLink';
-import Slider from '../../widgets/Slider';
+import { Slider } from '../../widgets/Slider';
 import styles from './StakePoolsRanking.scss';
 
 const messages = defineMessages({

--- a/source/renderer/app/components/widgets/Slider.js
+++ b/source/renderer/app/components/widgets/Slider.js
@@ -104,9 +104,9 @@ export default class Slider extends Component<Props, State> {
         </div>
         <RcSlider
           {...rest}
-          onBeforeChange={(e) => this.setState({ initialValue: e })}
-          onAfterChange={(e) => {
-            if (e !== this.state.initialValue && rest.onAfterChange) {
+          onBeforeChange={(e: number) => this.setState({ initialValue: e })}
+          onAfterChange={(e: number) => {
+            if (e !== this.state.initialValue && !!rest.onAfterChange) {
               rest.onAfterChange(e);
             }
           }}

--- a/source/renderer/app/components/widgets/Slider.js
+++ b/source/renderer/app/components/widgets/Slider.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import { observer } from 'mobx-react';
 import BigNumber from 'bignumber.js';
 import RcSlider from 'rc-slider';
@@ -45,78 +45,69 @@ type Props = {
   ariaValueTextFormatterForHandle?: Function,
 };
 
-type State = {
-  initialValue: number,
-};
+export const Slider = observer((props: Props) => {
+  const [initialValue, setInitialValue] = useState<number | null>(null);
+  const {
+    showTooltip,
+    minTooltip,
+    maxTooltip,
+    minDisplayValue,
+    maxDisplayValue,
+    displayValue,
+    showRawValue,
+    ...rest
+  } = props;
+  const { min, max, value } = rest;
 
-@observer
-export default class Slider extends Component<Props, State> {
-  static defaultProps = {
-    min: 0,
-    max: 100,
-    value: 0,
-  };
-  state: State = {
-    initialValue: 0,
-  };
+  const valueMarkLeftPosition =
+    max === min ? `0` : `${((value - min) / (max - min)) * 100}%`;
+  const valueMarkStyle = { left: valueMarkLeftPosition };
+  const formattedValue = showRawValue
+    ? displayValue || value
+    : new BigNumber(value).toFormat(0);
 
-  render() {
-    const {
-      showTooltip,
-      minTooltip,
-      maxTooltip,
-      minDisplayValue,
-      maxDisplayValue,
-      displayValue,
-      showRawValue,
-      ...rest
-    } = this.props;
-    const { min, max, value } = rest;
-
-    const valueMarkLeftPosition =
-      max === min ? `0` : `${((value - min) / (max - min)) * 100}%`;
-    const valueMarkStyle = { left: valueMarkLeftPosition };
-    const formattedValue = showRawValue
-      ? displayValue || value
-      : new BigNumber(value).toFormat(0);
-
-    return (
-      <div className={styles.component}>
-        <div className={styles.upperMarks}>
-          <div className={styles.minMark}>
-            {showTooltip ? (
-              <PopOver content={minTooltip}>
-                {shortNumber(minDisplayValue || min)}
-              </PopOver>
-            ) : (
-              shortNumber(minDisplayValue || min)
-            )}
-          </div>
-          <div className={styles.maxMark}>
-            {showTooltip ? (
-              <PopOver content={maxTooltip}>
-                {shortNumber(maxDisplayValue || max)}
-              </PopOver>
-            ) : (
-              shortNumber(maxDisplayValue || max)
-            )}
-          </div>
+  return (
+    <div className={styles.component}>
+      <div className={styles.upperMarks}>
+        <div className={styles.minMark}>
+          {showTooltip ? (
+            <PopOver content={minTooltip}>
+              {shortNumber(minDisplayValue || min)}
+            </PopOver>
+          ) : (
+            shortNumber(minDisplayValue || min)
+          )}
         </div>
-        <RcSlider
-          {...rest}
-          onBeforeChange={(e: number) => this.setState({ initialValue: e })}
-          onAfterChange={(e: number) => {
-            if (e !== this.state.initialValue && !!rest.onAfterChange) {
-              rest.onAfterChange(e);
-            }
-          }}
-        />
-        <div className={styles.lowerMarks}>
-          <div className={styles.valueMark} style={valueMarkStyle}>
-            {formattedValue}
-          </div>
+        <div className={styles.maxMark}>
+          {showTooltip ? (
+            <PopOver content={maxTooltip}>
+              {shortNumber(maxDisplayValue || max)}
+            </PopOver>
+          ) : (
+            shortNumber(maxDisplayValue || max)
+          )}
         </div>
       </div>
-    );
-  }
-}
+      <RcSlider
+        {...rest}
+        onBeforeChange={(e: number) => {
+          if (!initialValue) setInitialValue(e);
+        }}
+        onChange={(e: number) => {
+          rest.onChange(e);
+        }}
+        onAfterChange={(e: number) => {
+          if (e !== initialValue && !!rest.onAfterChange) {
+            rest.onAfterChange(e);
+          }
+          setInitialValue(null);
+        }}
+      />
+      <div className={styles.lowerMarks}>
+        <div className={styles.valueMark} style={valueMarkStyle}>
+          {formattedValue}
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/source/renderer/app/components/widgets/Slider.js
+++ b/source/renderer/app/components/widgets/Slider.js
@@ -45,12 +45,19 @@ type Props = {
   ariaValueTextFormatterForHandle?: Function,
 };
 
+type State = {
+  initialValue: number,
+};
+
 @observer
-export default class Slider extends Component<Props> {
+export default class Slider extends Component<Props, State> {
   static defaultProps = {
     min: 0,
     max: 100,
     value: 0,
+  };
+  state: State = {
+    initialValue: 0,
   };
 
   render() {
@@ -95,7 +102,15 @@ export default class Slider extends Component<Props> {
             )}
           </div>
         </div>
-        <RcSlider {...rest} />
+        <RcSlider
+          {...rest}
+          onBeforeChange={(e) => this.setState({ initialValue: e })}
+          onAfterChange={(e) => {
+            if (e !== this.state.initialValue && rest.onAfterChange) {
+              rest.onAfterChange(e);
+            }
+          }}
+        />
         <div className={styles.lowerMarks}>
           <div className={styles.valueMark} style={valueMarkStyle}>
             {formattedValue}


### PR DESCRIPTION
This PR checks whether the slider has moved, before executing the onAfterChange function.

## Todos

- [x] Update slider onAfterChange

## Screenshots
<img width="905" alt="Screenshot 2021-12-01 at 10 33 07" src="https://user-images.githubusercontent.com/7581002/144222317-e7611f18-8be7-4e02-b49c-7ac1f91c4303.png">
<img width="905" alt="Screenshot 2021-12-01 at 10 33 12" src="https://user-images.githubusercontent.com/7581002/144222335-d51ab2ce-c74f-4f6d-9a83-45121b72926b.png">
<img width="905" alt="Screenshot 2021-12-01 at 10 34 10" src="https://user-images.githubusercontent.com/7581002/144222348-ca9f40a1-0950-4a69-8ffc-b97f779b5372.png">
<img width="905" alt="Screenshot 2021-12-01 at 10 33 24" src="https://user-images.githubusercontent.com/7581002/144222355-ea97ce2d-7a2f-459c-a154-c36a8765a252.png">

---

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test

---

## Review Checklist

### Basics

- [ ] PR has been assigned and has appropriate labels (`feature`/`bug`/`chore`, `release-x.x.x`)
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR has default-sized Daedalus window screenshots or animated GIFs of important UI changes:
  - [ ] In English
  - [ ] In Japanese
- [ ] CHANGELOG entry has been added to the top of the appropriate section (*Features*, *Fixes*, *Chores*) and is linked to the correct PR on GitHub
- [ ] Automated tests: All acceptance and unit tests are passing (`yarn test`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *development* build (`yarn dev`)
- [ ] Manual tests (minimum tests should cover newly added feature/fix): App works correctly in *production* build (`yarn package` / CI builds)
- [ ] There are no *flow* errors or warnings (`yarn flow:test`)
- [ ] There are no *lint* errors or warnings (`yarn lint`)
- [ ] There are no *prettier* errors or warnings (`yarn prettier:check`)
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] UI changes look good in all themes (Alexander Rukin)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality
- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with flow
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing
- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review
- [ ] Merge the PR
- [ ] Delete the source branch
- [ ] Move the ticket to `done` column on the YouTrack board
- [ ] Update Slack QA thread by marking it with a green checkmark
