### PR TITLE
[DDW-936] Fixes discreet tooltip appearing behind loading overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Removed SASS ts-lint ignore comments ([PR 2870](https://github.com/input-output-hk/daedalus/pull/2870))
 - Enabled debugging of the main process ([PR 2893](https://github.com/input-output-hk/daedalus/pull/2893))
 
+### Fixes
+
+- Fixed discrete tooltip being clipped by loading overlay when stake pools are adjusted ([PR 2902](https://github.com/input-output-hk/daedalus/pull/2902))
+
 ## 4.9.0
 
 ### Features

--- a/source/renderer/app/components/staking/stake-pools/StakePoolsRankingLoader.scss
+++ b/source/renderer/app/components/staking/stake-pools/StakePoolsRankingLoader.scss
@@ -8,5 +8,4 @@
   position: fixed;
   right: 0;
   top: 134px;
-  z-index: 5000;
 }


### PR DESCRIPTION
<!---
Briefly describe the change.
-->

This PR intends to fix a bug where we have the tooltip for discrete mode being partially covered by the loading screen overlay we get when adjusting stake pools.

## Screenshots

| ------------- | Before  | After |
| ------------- | ------------- | ------------- |
| EN | <img width="1791" alt="Screenshot 2022-03-04 at 14 21 31" src="https://user-images.githubusercontent.com/27725122/156780974-56dca32a-bc7a-4190-87d9-1cd302fd895e.png"> | <img width="1792" alt="Screenshot 2022-03-01 at 14 48 36" src="https://user-images.githubusercontent.com/27725122/156190920-c12c1222-74d8-4817-b5c4-5a07bd823367.png">  |
| JP | <img width="1783" alt="Screenshot 2022-03-04 at 14 21 03" src="https://user-images.githubusercontent.com/27725122/156781227-7f62040f-d418-4e5b-bcb6-26c39aa1eeea.png"> | <img width="1333" alt="Screenshot 2022-03-04 at 14 11 06" src="https://user-images.githubusercontent.com/27725122/156781369-3e08627a-2f6b-4569-ada8-7f89ec5b9bba.png"> |

<!---
Use the GitHub drag&drop feature to upload default-sized Daedalus window screenshots
or animated GIFs of important UI changes in both English and Japanese.
Do not use shadow or any effects. On macOS this can be accomplished the following way:
1. Use the Command+Shift+4 keyboard shortcut.
2. Press the Spacebar.
3. Hold the Option button and click the window you want to capture.
-->

## Testing Checklist

<!---
Open a thread on #daedalus-qa on Slack, mention `@daedalusqa` and `@daedalusteam`, link the thread below
-->

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Test that the tooltip for discrete mode overlaps the loading screen when adjusting pools and doesn't get clipped.

---

## Review Checklist

### Basics

- [ ] PR assigned to the PR author(s)
- [ ] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [ ] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [ ] All visual regression testing has been reviewed (assign `run Chromatic` label to PR to trigger the run)
- [ ] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [ ] PR link is added to a Jira ticket, ticket moved to In Review
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR contains screenshots (in case of UI changes)
- [ ] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
