### PR TITLE
[DDW-942] Design ASCII display for when a token doesn't have a name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Addes ASCII name to token header when metadata name is missing ([PR 2904](https://github.com/input-output-hk/daedalus/pull/2904))
+- Added ASCII name to token header when metadata name is missing ([PR 2904](https://github.com/input-output-hk/daedalus/pull/2904))
 - Improved IPC by reducing the amount of messages from periodic events ([PR 2892](https://github.com/input-output-hk/daedalus/pull/2892))
 - Improved RTS flags splash screen message ([PR 2901](https://github.com/input-output-hk/daedalus/pull/2901))
 - Implemented error message when trying to leave wallet without enough ada to support tokens ([PR 2783](https://github.com/input-output-hk/daedalus/pull/2783))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Addes ASCII name to token header when metadata name is missing ([PR 2904](https://github.com/input-output-hk/daedalus/pull/2904))
 - Improved IPC by reducing the amount of messages from periodic events ([PR 2892](https://github.com/input-output-hk/daedalus/pull/2892))
 - Improved RTS flags splash screen message ([PR 2901](https://github.com/input-output-hk/daedalus/pull/2901))
 - Implemented error message when trying to leave wallet without enough ada to support tokens ([PR 2783](https://github.com/input-output-hk/daedalus/pull/2783))

--- a/source/renderer/app/components/assets/Asset.scss
+++ b/source/renderer/app/components/assets/Asset.scss
@@ -75,6 +75,10 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  &.ascii {
+    color: var(--theme-tokens-list-header-text-color);
+  }
 }
 
 .metadata {

--- a/source/renderer/app/components/assets/Asset.spec.tsx
+++ b/source/renderer/app/components/assets/Asset.spec.tsx
@@ -5,39 +5,37 @@ import '@testing-library/jest-dom';
 import Asset from './Asset';
 import { TestDecorator } from '../../../../../tests/_utils/TestDecorator';
 
-const assets = [
-  {
-    policyId: 'policyId',
-    assetName: '54657374636f696e',
-    quantity: new BigNumber(1),
-    fingerprint: 'fingerprint',
-    metadata: {
-      name: 'Testcoin',
-      description: 'Test coin',
-    },
-    uniqueId: 'uniqueId',
-    decimals: 1,
-    recommendedDecimals: null,
+const assetWithMetadataName = {
+  policyId: 'policyId',
+  assetName: '54657374636f696e',
+  quantity: new BigNumber(1),
+  fingerprint: 'fingerprint',
+  metadata: {
+    name: 'Testcoin',
+    description: 'Test coin',
   },
-  {
-    policyId: 'policyId',
-    assetName: '436f696e74657374',
-    quantity: new BigNumber(1),
-    fingerprint: 'fingerprint',
-    uniqueId: 'uniqueId',
-    decimals: 1,
-    recommendedDecimals: null,
-  },
-  {
-    policyId: 'policyId',
-    assetName: '',
-    quantity: new BigNumber(1),
-    fingerprint: 'fingerprint',
-    uniqueId: 'uniqueId',
-    decimals: 1,
-    recommendedDecimals: null,
-  },
-];
+  uniqueId: 'uniqueId',
+  decimals: 1,
+  recommendedDecimals: null,
+};
+const assetWitoutMetadataName = {
+  policyId: 'policyId',
+  assetName: '436f696e74657374',
+  quantity: new BigNumber(1),
+  fingerprint: 'fingerprint',
+  uniqueId: 'uniqueId',
+  decimals: 1,
+  recommendedDecimals: null,
+};
+const assetWithoutName = {
+  policyId: 'policyId',
+  assetName: '',
+  quantity: new BigNumber(1),
+  fingerprint: 'fingerprint',
+  uniqueId: 'uniqueId',
+  decimals: 1,
+  recommendedDecimals: null,
+};
 
 describe('Asset', () => {
   afterEach(cleanup);
@@ -45,16 +43,16 @@ describe('Asset', () => {
   test('Should display asset metadata name', () => {
     render(
       <TestDecorator>
-        <Asset asset={assets[0]} />
+        <Asset asset={assetWithMetadataName} />
       </TestDecorator>
     );
     expect(screen.queryByTestId('assetName')).toHaveTextContent('Testcoin');
   });
 
-  test('Should display asset ASCII name', () => {
+  test('Should display asset ASCII name when metadata name is not available', () => {
     render(
       <TestDecorator>
-        <Asset asset={assets[1]} />
+        <Asset asset={assetWitoutMetadataName} />
       </TestDecorator>
     );
     expect(screen.queryByTestId('assetName')).toHaveTextContent(
@@ -62,10 +60,10 @@ describe('Asset', () => {
     );
   });
 
-  test('Should display empty name', () => {
+  test('Should not display asset name when metadata and ASCII name are not available', () => {
     render(
       <TestDecorator>
-        <Asset asset={assets[2]} />
+        <Asset asset={assetWithoutName} />
       </TestDecorator>
     );
     expect(screen.queryByTestId('assetName')).toBeNull();

--- a/source/renderer/app/components/assets/Asset.spec.tsx
+++ b/source/renderer/app/components/assets/Asset.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import BigNumber from 'bignumber.js';
+import { render, screen, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Asset from './Asset';
+import { TestDecorator } from '../../../../../tests/_utils/TestDecorator';
+
+const assets = [
+  {
+    policyId: 'policyId',
+    assetName: '54657374636f696e',
+    quantity: new BigNumber(1),
+    fingerprint: 'fingerprint',
+    metadata: {
+      name: 'Testcoin',
+      description: 'Test coin',
+    },
+    uniqueId: 'uniqueId',
+    decimals: 1,
+    recommendedDecimals: null,
+  },
+  {
+    policyId: 'policyId',
+    assetName: '436f696e74657374',
+    quantity: new BigNumber(1),
+    fingerprint: 'fingerprint',
+    uniqueId: 'uniqueId',
+    decimals: 1,
+    recommendedDecimals: null,
+  },
+  {
+    policyId: 'policyId',
+    assetName: '',
+    quantity: new BigNumber(1),
+    fingerprint: 'fingerprint',
+    uniqueId: 'uniqueId',
+    decimals: 1,
+    recommendedDecimals: null,
+  },
+];
+
+describe('Asset', () => {
+  afterEach(cleanup);
+
+  test('Should display asset metadata name', () => {
+    render(
+      <TestDecorator>
+        <Asset asset={assets[0]} />
+      </TestDecorator>
+    );
+    expect(screen.queryByTestId('assetName')).toHaveTextContent('Testcoin');
+  });
+
+  test('Should display asset ASCII name', () => {
+    render(
+      <TestDecorator>
+        <Asset asset={assets[1]} />
+      </TestDecorator>
+    );
+    expect(screen.queryByTestId('assetName')).toHaveTextContent(
+      'ASCII: Cointest'
+    );
+  });
+
+  test('Should display empty name', () => {
+    render(
+      <TestDecorator>
+        <Asset asset={assets[2]} />
+      </TestDecorator>
+    );
+    expect(screen.queryByTestId('assetName')).toBeNull();
+  });
+});

--- a/source/renderer/app/components/assets/Asset.tsx
+++ b/source/renderer/app/components/assets/Asset.tsx
@@ -5,7 +5,7 @@ import { PopOver } from 'react-polymorph/lib/components/PopOver';
 import { defineMessages, intlShape } from 'react-intl';
 import { observer } from 'mobx-react';
 import styles from './Asset.scss';
-import { ellipsis } from '../../utils/strings';
+import { ellipsis, hexToString } from '../../utils/strings';
 import AssetContent from './AssetContent';
 import settingsIcon from '../../assets/images/asset-token-settings-ic.inline.svg';
 import warningIcon from '../../assets/images/asset-token-warning-ic.inline.svg';
@@ -173,8 +173,18 @@ class Asset extends Component<Props, State> {
       hasWarning,
       hasError,
     } = this.props;
-    const { fingerprint, metadata, decimals, recommendedDecimals } = asset;
-    const { name } = metadata || {};
+    const {
+      fingerprint,
+      metadata,
+      decimals,
+      recommendedDecimals,
+      assetName,
+    } = asset;
+    const hasName = !!metadata?.name;
+    const name = metadata?.name || `ASCII: ${hexToString(assetName)}`;
+    const displayName = metadataNameChars
+      ? ellipsis(name, metadataNameChars)
+      : name;
     const contentStyles = classnames([
       styles.pill,
       hasError ? styles.error : null,
@@ -196,9 +206,14 @@ class Asset extends Component<Props, State> {
             ? fingerprint
             : ellipsis(fingerprint || '', startCharAmount, endCharAmount)}
         </div>
-        {name && (
-          <div className={styles.metadataName}>
-            {metadataNameChars ? ellipsis(name, metadataNameChars) : name}
+        {displayName && (
+          <div
+            className={classnames(
+              styles.metadataName,
+              !hasName && styles.ascii
+            )}
+          >
+            {displayName}
           </div>
         )}
         {hasWarning && (

--- a/source/renderer/app/components/assets/Asset.tsx
+++ b/source/renderer/app/components/assets/Asset.tsx
@@ -181,7 +181,8 @@ class Asset extends Component<Props, State> {
       assetName,
     } = asset;
     const hasName = !!metadata?.name;
-    const name = metadata?.name || `ASCII: ${hexToString(assetName)}`;
+    const name =
+      metadata?.name || (assetName && `ASCII: ${hexToString(assetName)}`);
     const displayName = metadataNameChars
       ? ellipsis(name, metadataNameChars)
       : name;
@@ -208,6 +209,7 @@ class Asset extends Component<Props, State> {
         </div>
         {displayName && (
           <div
+            data-testid="assetName"
             className={classnames(
               styles.metadataName,
               !hasName && styles.ascii

--- a/source/renderer/app/components/assets/Asset.tsx
+++ b/source/renderer/app/components/assets/Asset.tsx
@@ -180,9 +180,10 @@ class Asset extends Component<Props, State> {
       recommendedDecimals,
       assetName,
     } = asset;
-    const hasName = !!metadata?.name;
+    const hasMetadataName = !!metadata?.name;
     const name =
-      metadata?.name || (assetName && `ASCII: ${hexToString(assetName)}`);
+      metadata?.name || (assetName && `ASCII: ${hexToString(assetName)}`) || '';
+
     const displayName = metadataNameChars
       ? ellipsis(name, metadataNameChars)
       : name;
@@ -212,7 +213,7 @@ class Asset extends Component<Props, State> {
             data-testid="assetName"
             className={classnames(
               styles.metadataName,
-              !hasName && styles.ascii
+              !hasMetadataName && styles.ascii
             )}
           >
             {displayName}

--- a/source/renderer/app/components/wallet/tokens/wallet-token/WalletTokenHeader.scss
+++ b/source/renderer/app/components/wallet/tokens/wallet-token/WalletTokenHeader.scss
@@ -17,6 +17,7 @@
   .favoriteIcon {
     border-radius: 3px;
     cursor: pointer;
+    flex-shrink: 0;
     height: 22px;
     margin-left: 10px;
     opacity: 0.3;
@@ -50,6 +51,7 @@
   .asset {
     margin-left: 10px;
     margin-right: auto;
+    overflow: hidden;
     width: auto;
   }
 

--- a/storybook/stories/wallets/tokens/WalletTokens.stories.tsx
+++ b/storybook/stories/wallets/tokens/WalletTokens.stories.tsx
@@ -36,7 +36,7 @@ const assets = [
   // @ts-ignore ts-migrate(2554) FIXME: Expected 7 arguments, but got 4.
   generateAssetToken(
     '65bc72542b0ca20391caaf66a4d4d7897d281f9c136cd3513136945b',
-    '',
+    '546f6b656e2077697468206c61726765206e616d65',
     'tokenb0ca20391caaf66a4d4d7897d281f9c136cd3513136945b2342',
     400
   ),


### PR DESCRIPTION
<!---
Briefly describe the change.
-->

This PR adds ASCII name on token display when there is no metadata name.

## Todos

<!---
Consider creating a TODO list to help others understand the progress of work in a WIP pull request.
-->

- [ ] TODO

## Screenshots
Before
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/11845759/156780315-9d65c52e-5806-4eb4-97d2-71e2b4113563.png">
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/11845759/156780257-49dae2e5-31b6-47cb-b843-c01162471ee7.png">

After
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/11845759/156781210-9199b1c3-4ace-4bf3-8cf1-7a7d5366b6c6.png">
<img width="1150" alt="image" src="https://user-images.githubusercontent.com/11845759/156781266-cd96f77b-71ed-423e-81a5-e48ef271356f.png">


<!---
Use the GitHub drag&drop feature to upload default-sized Daedalus window screenshots
or animated GIFs of important UI changes in both English and Japanese.
Do not use shadow or any effects. On macOS this can be accomplished the following way:
1. Use the Command+Shift+4 keyboard shortcut.
2. Press the Spacebar.
3. Hold the Option button and click the window you want to capture.
-->

## Testing Checklist



## Test Scenarios

```Gherkin
Scenario 1: ASCII name displayed when token has no metadata name
Given I have a token without metadata name
When I observe the token's metadata name's field
Then this field is populated with ASCII name

Scenario 2: Metadata name displayed when token has metadata name
Given I have a token with metadata name
When I observe the token's metadata name's field
Then this field is populated with metadata name
```

<!---
Open a thread on #daedalus-qa on Slack, mention `@daedalusqa` and `@daedalusteam`, link the thread below
-->

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1646329620217049)
- [ ] Test

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [x] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [x] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [x] All visual regression testing has been reviewed (assign `run Chromatic` label to PR to trigger the run)
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [x] PR link is added to a Jira ticket, ticket moved to In Review
- [x] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [x] PR has a good description that summarizes all changes
- [x] PR contains screenshots (in case of UI changes)
- [x] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [x] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] ~~Text changes are proofread and approved (Jane Wild / Amy Reeve)~~
- [ ] ~~Japanese text changes are proofread and approved (Junko Oda)~~
- [x] Storybook works and no stories are broken (`yarn storybook`)
- [ ] ~~In case of dependency changes `yarn.lock` file is updated~~

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
