### PR TITLE
Fix `nix-shell` on Darwin

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -116,8 +116,8 @@ let
       ln -svf $(type -P cardano-cli)
       mkdir -p ${BUILDTYPE}/
       ${let
-        # XXX: right now we don’t build Debug/ versions on Linux (TODO: investigate why – @michalrus)
-        sourceBUILDTYPE = if system == "x86_64-linux" then "Release" else BUILDTYPE;
+        # (TODO: investigate why – @michalrus)
+        sourceBUILDTYPE = "Release";
       in ''
         ln -svf $PWD/node_modules/usb/build/${sourceBUILDTYPE}/usb_bindings.node ${BUILDTYPE}/
         ln -svf $PWD/node_modules/node-hid/build/${sourceBUILDTYPE}/HID.node ${BUILDTYPE}/


### PR DESCRIPTION
_Internal._

_No QA required._

@renanvalentin found out `nix-shell` → `yarn dev` no longer works, failing with broken symlinks.

I’m not sure yet why `Release`/`Debug` get switched over…

* [Slack thread](https://input-output-rnd.slack.com/archives/C02DTDJFW2Z/p1654171067947249)