### PR TITLE
Update `cardano-node` to 1.35.1 via `cardano-wallet` PR `.patch`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Chores
 
+- Updated cardano-node to 1.35.1 ([PR 3012](https://github.com/input-output-hk/daedalus/pull/3012))
 - Added Vasil-supported cardano-wallet ([PR 3001](https://github.com/input-output-hk/daedalus/pull/3001))
 - Upgraded webpack to version 5 ([PR 2772](https://github.com/input-output-hk/daedalus/pull/2772))
 

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,10 @@ let
       chmod -R +w $out
       cd $out
       patch -p1 -i ${./nix/cardano-wallet--enable-aarch64-darwin.patch}
+      patch -p1 -i ${pkgs.fetchurl {
+        url = "https://github.com/input-output-hk/cardano-wallet/pull/3382.patch";
+        sha256 = "1ii12g2zikv4197c7bsh4v5dc1jzygn1jap8xvnr7mvh3a09pdgn";
+      }}
     '';
   };
   haskellNix = import sources."haskell.nix" {};

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,14 @@
 {
     "cardano-node": {
-        "branch": "tags/1.35.0",
+        "branch": "tags/1.35.1",
         "description": null,
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "9f1d7dc163ee66410d912e48509d6a2300cfa68a",
-        "sha256": "06arx9hv7dn3qxfy83f0b6018rxbsvh841nvfyg5w6qclm1hddj7",
+        "rev": "c75451f0ffd7a60b5ad6c4263891e6c8acac105a",
+        "sha256": "1z0zv1i58ikmbqg878f9z573jkwp4lzhmmswshm6c96rq6lprzh8",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/cardano-node/archive/9f1d7dc163ee66410d912e48509d6a2300cfa68a.tar.gz",
+        "url": "https://github.com/input-output-hk/cardano-node/archive/c75451f0ffd7a60b5ad6c4263891e6c8acac105a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "cardano-shell": {

--- a/source/main/environment.ts
+++ b/source/main/environment.ts
@@ -46,7 +46,7 @@ const isSelfnode = checkIsSelfnode(NETWORK);
 const isDevelopment = checkIsDevelopment(NETWORK);
 const keepLocalClusterRunning = process.env.KEEP_LOCAL_CLUSTER_RUNNING;
 const API_VERSION = process.env.API_VERSION || 'dev';
-const NODE_VERSION = '1.35.0'; // TODO: pick up this value from process.env
+const NODE_VERSION = '1.35.1'; // TODO: pick up this value from process.env
 
 const mainProcessID = get(process, 'ppid', '-');
 const rendererProcessID = process.pid;


### PR DESCRIPTION
… which also includes `cardano-ledger` update.

Internal PR, this time targeting `develop`.

Cherry picked from release 4.12.0 – PR https://github.com/input-output-hk/daedalus/pull/3013