### PR TITLE
Really cache the devshell setup in `$out` (and Hydra)

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -10,7 +10,11 @@ let
   shellEnvs = {
     linux = import ./shell.nix { system = "x86_64-linux"; autoStartBackend = true; };
     darwin = import ./shell.nix { system = "x86_64-darwin"; autoStartBackend = true; };
-    darwin-arm = import ./shell.nix { system = "aarch64-darwin"; autoStartBackend = true; };
+    #darwin-arm = import ./shell.nix { system = "aarch64-darwin"; autoStartBackend = true; };    # TODO: re-enable when we have `aarch64-darwin` in Hydra
+  };
+  buildShell = { # Only used by (impure) Darwin installer build script
+    darwin = shellEnvs.darwin.buildShell;
+    #darwin-arm = shellEnvs.darwin-arm.buildShell;    # TODO: re-enable when we have `aarch64-darwin` in Hydra
   };
   suffix = if buildNum == null then "" else "-${toString buildNum}";
   version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
@@ -20,7 +24,7 @@ let
       x86_64-linux = import ./. { target = "x86_64-linux"; };
       x86_64-windows = import ./. { target = "x86_64-windows"; };
       x86_64-darwin = import ./. { target = "x86_64-darwin"; };
-      aarch64-darwin = import ./. { target = "aarch64-darwin"; };
+      #aarch64-darwin = import ./. { target = "aarch64-darwin"; };    # TODO: re-enable when we have `aarch64-darwin` in Hydra
     };
   in
     table.${system};
@@ -52,6 +56,7 @@ let
   sources = import ./nix/sources.nix;
 in {
   inherit shellEnvs;
+  inherit buildShell;
   inherit ((daedalusPkgs {}).pkgs) mono;
   wine = (daedalusPkgs {}).wine;
   wine64 = (daedalusPkgs {}).wine64;

--- a/shell.nix
+++ b/shell.nix
@@ -28,6 +28,7 @@ let
   fixYarnLock = pkgs.stdenv.mkDerivation {
     name = "fix-yarn-lock";
     buildInputs = [ daedalusPkgs.nodejs daedalusPkgs.yarn pkgs.git ];
+    phases = [ "buildPhase" ]; buildPhase = "export > $out"; # actually cache the shell setup in $out (Hydra etc.)
     shellHook = ''
       git diff > pre-yarn.diff
       yarn --frozen-lockfile
@@ -70,9 +71,10 @@ let
     ) ++ (pkgs.lib.optionals (nodeImplementation == "cardano") [
       debug.node
     ]);
-  buildShell = pkgs.stdenv.mkDerivation {
+  buildShell = pkgs.stdenv.mkDerivation { # Only used by (impure) Darwin installer build script
     name = "daedalus-build";
     buildInputs = daedalusShellBuildInputs;
+    phases = [ "buildPhase" ]; buildPhase = "export > $out"; # actually cache the shell setup in $out (Hydra etc.)
   };
   debug.node = pkgs.writeShellScriptBin "debug-node" (with daedalusPkgs.launcherConfigs.launcherConfig; ''
     cardano-node run --topology ${nodeConfig.network.topologyFile} --config ${nodeConfig.network.configFile} --database-path ${stateDir}/chain --port 3001 --socket-path ${stateDir}/cardano-node.socket
@@ -80,7 +82,7 @@ let
   daedalusShell = pkgs.stdenv.mkDerivation (rec {
     buildInputs = daedalusShellBuildInputs;
     name = "daedalus";
-    buildCommand = "touch $out";
+    phases = [ "buildPhase" ]; buildPhase = "export > $out"; # actually cache the shell setup in $out (Hydra etc.)
     LAUNCHER_CONFIG = launcherConfig';
     DAEDALUS_CONFIG = "${daedalusPkgs.daedalus.cfg}/etc/";
     DAEDALUS_INSTALL_DIRECTORY = "./";
@@ -186,6 +188,7 @@ let
     buildInputs = let
       inherit (localLib.iohkNix) niv;
     in if nivOnly then [ niv ] else [ niv daedalusPkgs.cardano-node-cluster.start daedalusPkgs.cardano-node-cluster.stop ];
+    phases = [ "buildPhase" ]; buildPhase = "export > $out"; # actually cache the shell setup in $out (Hydra etc.)
     shellHook = ''
       export CARDANO_NODE_SOCKET_PATH=$(pwd)/state-cluster/bft1.socket
       echo "DevOps Tools" \


### PR DESCRIPTION
*Internal PR*

It often happens that developers have to rebuild the world when entering `nix-shell`.

It turns out we don’t cache the devshell environment in https://hydra.iohk.io/ 

This PR fixes that: instead of just `touch`ing `$out`, we need to `export` the environment into it.

Cf. e.g. https://github.com/NixOS/nixpkgs/blob/51ae0c2a8cdfc729fe0ed68f630d12d5e3f6594d/pkgs/build-support/mkshell/default.nix#L53