### PR TITLE
Add OS+architecture tuple to installer file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Added OS-architecture tuple to installer file names to help with releases ([PR 3016](https://github.com/input-output-hk/daedalus/pull/3016))
 - Fixed downloaded installer being left in Downloads after latest update installs ([PR 2941](https://github.com/input-output-hk/daedalus/pull/2941))
 - Fixed incorrect amount of token sent ([PR 2962](https://github.com/input-output-hk/daedalus/pull/2962))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Fixes
 
-- Added OS-architecture tuple to installer file names to help with releases ([PR 3016](https://github.com/input-output-hk/daedalus/pull/3016))
 - Fixed downloaded installer being left in Downloads after latest update installs ([PR 2941](https://github.com/input-output-hk/daedalus/pull/2941))
 - Fixed incorrect amount of token sent ([PR 2962](https://github.com/input-output-hk/daedalus/pull/2962))
 
 ### Chores
 
+- Added OS-architecture tuple to installer file names to help with releases ([PR 3016](https://github.com/input-output-hk/daedalus/pull/3016))
 - Added Vasil-supported cardano-wallet ([PR 3001](https://github.com/input-output-hk/daedalus/pull/3001))
 - Upgraded webpack to version 5 ([PR 2772](https://github.com/input-output-hk/daedalus/pull/2772))
 

--- a/default.nix
+++ b/default.nix
@@ -306,7 +306,7 @@ let
     signed-windows-installer = let
       backend_version = self.daedalus-bridge.wallet-version;
       frontend_version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
-      fullName = "daedalus-${frontend_version}-${cluster}${buildNumSuffix}.exe"; # must match to packageFileName in make-installer
+      fullName = "daedalus-${frontend_version}-${cluster}${buildNumSuffix}-x86_64-windows.exe"; # must match to packageFileName in make-installer
     in pkgs.runCommand "signed-windows-installer-${cluster}" {} ''
       mkdir $out
       cp -v ${self.signFile "${self.unsigned-windows-installer}/${fullName}"} $out/${fullName}
@@ -423,7 +423,7 @@ let
       version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
       backend = "cardano-wallet-${nodeImplementation}";
       suffix = if buildNum == null then "" else "-${toString buildNum}";
-      fn = "daedalus-${version}-${self.linuxClusterBinName}${suffix}.bin";
+      fn = "daedalus-${version}-${self.linuxClusterBinName}${suffix}-x86_64-linux.bin";
     in pkgs.runCommand fn {} ''
       mkdir -p $out
       cp ${self.newBundle} $out/${fn}

--- a/installers/common/Types.hs
+++ b/installers/common/Types.hs
@@ -42,6 +42,7 @@ import           Turtle                              (pwd, cd)
 import           Turtle.Format                       (format, fp)
 import           Data.Aeson                          (FromJSON(..), withObject, eitherDecode, (.:), genericParseJSON, defaultOptions)
 import qualified Data.ByteString.Lazy.Char8       as L8
+import qualified System.Info
 
 data OS
   = Linux64
@@ -113,7 +114,7 @@ packageFileName :: OS -> Cluster -> Version -> Backend -> Text -> Maybe BuildJob
 packageFileName _os cluster ver backend _backendVer build = fromText name <.> ext
   where
     name = T.intercalate "-" parts
-    parts = ["daedalus", fromVer ver, lshowText cluster] ++ build'
+    parts = ["daedalus", fromVer ver, lshowText cluster] ++ build' ++ [archOS]
     _backend' = case backend of
                  Cardano _ -> "cardano-wallet"
     ext = case _os of
@@ -124,6 +125,13 @@ packageFileName _os cluster ver backend _backendVer build = fromText name <.> ex
             Win64   -> "windows"
             Macos64 -> "macos"
             Linux64 -> "linux"
+    archOS = case _os of
+            Win64   -> "x86_64-windows"
+            Macos64 ->
+              if System.Info.arch == "aarch64"
+              then "aarch64-darwin"
+              else "x86_64-darwin"
+            Linux64 -> "x86_64-linux"
     build' = maybe [] (\b -> [fromBuildJob b]) build
 
 instance FromJSON Version where


### PR DESCRIPTION
*Internal PR*

Having the same name for both Intel and Silicon macOS is problematic during release. Also, it’s possible we’ll have `aarch64-linux` in the future.

/cc @danielmain
