### PR TITLE
[DDW-1122] Fix `darwin-launcher.go` to replace its process image with `cardano-launcher` (binary), and not swallow `stdout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Chores
 
+- Fix `darwin-launcher.go` to replace its process image with `cardano-launcher` (binary), and not swallow `stdout` ([PR 3023](https://github.com/input-output-hk/daedalus/pull/3023))
 - Updated cardano-node to 1.35.1 ([PR 3012](https://github.com/input-output-hk/daedalus/pull/3012))
 
 ### Features


### PR DESCRIPTION
This PR requires a very basic QA run – the only thing that changes is how Daedalus is started on macOS (both Intel, and M1)

* Without this change, WebDriverIO claims that the Chromium process died – request from @marcin-mazurek and @ManusMcCole 

* And also, now Daedalus stdout/stderr is not being swallowed (and instead, written to the terminal / Console.app) – allowing easier debugging of production installations on macOS

## Todos

n/a

## Screenshots

n/a

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1658933511825369)
- [ ] Test

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [x] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [x] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [x] All visual regression testing has been reviewed (assign `run Chromatic` label to PR to trigger the run)
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [x] PR link is added to a Jira ticket, ticket moved to In Review
- [x] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [x] PR has a good description that summarizes all changes
- [x] PR contains screenshots (in case of UI changes)
- [x] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [x] There are no missing translations (running `yarn manage:translations` produces no changes)
- [x] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [x] Japanese text changes are proofread and approved (Junko Oda)
- [x] Storybook works and no stories are broken (`yarn storybook`)
- [x] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [x] Important parts of the code are properly commented and documented
- [x] Code is properly typed with typescript types
- [x] React components are split-up enough to avoid unnecessary re-renderings
- [x] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark