### PR TITLE
[DDW-1130] Fix blank screen when opening ITN rewards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fixed blank screen when opening ITN rewards ([PR 3030](https://github.com/input-output-hk/daedalus/pull/3030))
 - Ensured non-recommended decimal place setting alert is correctly shown ([PR 3007](https://github.com/input-output-hk/daedalus/pull/3007))
 - Disabled the possibility to choose a syncing wallet for ITN rewards and delegation ([PR 3015](https://github.com/input-output-hk/daedalus/pull/3015))
 

--- a/source/renderer/app/components/staking/redeem-itn-rewards/Step1ConfigurationDialog.tsx
+++ b/source/renderer/app/components/staking/redeem-itn-rewards/Step1ConfigurationDialog.tsx
@@ -358,7 +358,7 @@ class Step1ConfigurationDialog extends Component<Props, State> {
           <div className={styles.recoveryPhrase}>
             <MnemonicInput
               {...mnemonicInputProps}
-              label={intl.formatMessage(messages.recoveryPhraseInputLabel)}
+              label={intl.formatMessage(messages.recoveryPhraseInputHint)}
               availableWords={suggestedMnemonics}
               wordCount={ITN_WALLET_RECOVERY_PHRASE_WORD_COUNT}
               error={recoveryPhraseField.error}

--- a/source/renderer/app/components/widgets/DialogFullSizeOverride.scss
+++ b/source/renderer/app/components/widgets/DialogFullSizeOverride.scss
@@ -22,7 +22,8 @@
     .SimpleInput_input:not(.SimpleInput_disabled),
     .SimpleInput_input:focus:not(.SimpleInput_disabled),
     .SimpleInput_input:hover:not(.SimpleInput_disabled),
-    .SimpleLink_root {
+    .SimpleLink_root,
+    .MnemonicInput_content {
       background-color: transparent !important;
     }
 
@@ -94,7 +95,10 @@
     .SimpleInput_input,
     .SimpleInput_input::placeholder,
     .SimpleInput_input:focus,
-    .SimpleInput_input:hover {
+    .SimpleInput_input:hover,
+    .MnemonicInput_headerSlot,
+    .MnemonicAutocompleteLayout_inputLabel,
+    .MnemonicAutocompleteLayout_root {
       color: var(--theme-dialog-fullsize-text-color);
     }
 
@@ -112,7 +116,8 @@
       .SimpleInput_input:not(.SimpleInput_disabled),
     .SimpleInput_input:focus:not(.SimpleInput_errored),
     .SimpleInput_input:hover:not(.SimpleInput_errored),
-    .SimpleOptions_option:after {
+    .SimpleOptions_option:after,
+    .MnemonicAutocompleteLayout_input {
       background-color: transparent !important;
       border-color: var(--theme-dialog-fullsize-text-color) !important;
     }


### PR DESCRIPTION
This PR fixes translations for MnemonicInput and CSS styles at ITN rewards dialog.

## Screenshots

![image](https://user-images.githubusercontent.com/17825044/187446579-dfd0b7bf-179e-4e8c-8b4f-f4de36523c28.png)
![image](https://user-images.githubusercontent.com/17825044/187446648-d95d8bae-2999-47eb-a3bc-9e0141dd7882.png)

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1661865559664719)
- [ ] Test

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [x] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [x] All visual regression testing has been reviewed (assign `run Chromatic` label to PR to trigger the run)
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [x] PR link is added to a Jira ticket, ticket moved to In Review
- [x] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [x] PR has a good description that summarizes all changes
- [x] PR contains screenshots (in case of UI changes)
- [x] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [x] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
