### PR TITLE
Clean `~/.config/nix/nix.conf` on Buildkite workers (conflicts cause 10 hour builds)

### DIFF
--- a/scripts/with-nix-2.5.sh
+++ b/scripts/with-nix-2.5.sh
@@ -6,19 +6,29 @@ if [ $# -eq 0 ] ; then
   exit 1
 fi
 
-echo "~~~ Obtaining ‘pkgs.nixUnstable’"
+userNixConfig="$HOME/.config/nix/nix.conf"
+if [ -e "$userNixConfig" ] ; then
+  echo "~~~ Warning: cleaning user’s Nix config: $userNixConfig"
+  echo "Sometimes, a conflicting nix.conf appears in ~/.config/nix, which"
+  echo "results in builds not using our global substituters (binary caches)."
+  echo
+  mv -v "$userNixConfig" "$userNixConfig.$(date -Iseconds)"
+fi
 
-myDir=$(dirname "$0")
-nixUnstable=$(nix-build "$myDir"/../default.nix -A pkgs.nixUnstable)
-
-PATH="$nixUnstable/bin:$PATH"
+echo "~~~ Obtaining ‘nixFlakes’"
 
 # *Maybe* prevent segfaults on `aarch64-darwin` in `GC_*` code:
 export GC_DONT_GC=1 # <https://chromium.googlesource.com/chromiumos/third_party/gcc/+/f4131b9cddd80547d860a6424ee1644167a330d6/gcc/gcc-4.6.0/boehm-gc/doc/README.environment#151>
 
 export NIX_CONFIG='
   experimental-features = nix-command flakes
+  accept-flake-config = true
 '
+
+# 9e96b1562d67a90ca2f7cfb919f1e86b76a65a2c is `nixos-22.05` on 2022-07-06
+nixFlakes=$(nix-build --no-out-link 'https://github.com/NixOS/nixpkgs/archive/9e96b1562d67a90ca2f7cfb919f1e86b76a65a2c.tar.gz' -A nixFlakes)
+
+PATH="$nixFlakes/bin:$PATH"
 
 nix --version
 echo


### PR DESCRIPTION
*Internal PR*

* Discussion with DevOps: https://input-output-rnd.slack.com/archives/GJMEW8FV3/p1662984545676609

* Sample build that took ~10 hours: https://buildkite.com/input-output-hk/daedalus/builds/22154

The culprit is misconfiguration in `~/.config/nix/nix.conf`, which conflicts with the global `/etc/nix/nix.conf`, and in result only https://cache.nixos.org/ is used, cause rebuilds of GCC, GHC, and the world in general.