### PR TITLE
[DDW-1180] Trigger Darwin builds manually

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,25 +1,37 @@
 env:
   ARTIFACT_BUCKET: s3://ci-output-sink
 steps:
+
+  - input: ':recycle: Trigger ‘x86_64-darwin’'
+    key: 'trigger-x86_64-darwin'
+
+  - input: ':recycle: Trigger ‘aarch64-darwin’'
+    key: 'trigger-aarch64-darwin'
+
   - label: 'daedalus-x86_64-darwin'
     command: 'scripts/with-nix-2.5.sh scripts/build-installer-unix.sh --build-id $BUILDKITE_BUILD_NUMBER'
+    depends_on: 'trigger-x86_64-darwin'
     env:
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
     agents:
       queue: daedalus
       system: x86_64-darwin
+
   - label: 'daedalus-aarch64-darwin'
     command: 'scripts/with-nix-2.5.sh scripts/build-installer-unix.sh --build-id $BUILDKITE_BUILD_NUMBER'
+    depends_on: 'trigger-aarch64-darwin'
     env:
       NIX_SSL_CERT_FILE: /nix/var/nix/profiles/default/etc/ssl/certs/ca-bundle.crt
       UPLOAD_DIR_OVERRIDE: UNSAFE-internal-build
     agents:
       queue: daedalus
       system: aarch64-darwin
+
   - label: 'daedalus-x86_64-linux-nix'
     command: 'scripts/with-nix-2.5.sh scripts/build-installer-nix.sh $BUILDKITE_BUILD_NUMBER'
     agents:
       system: x86_64-linux
+
   - label: 'daedalus-x86_64-windows-nix'
     command: 'scripts/with-nix-2.5.sh scripts/build-cross-windows.sh $BUILDKITE_BUILD_NUMBER'
     agents:


### PR DESCRIPTION
This PR adds a temporary requirement to trigger macOS workers in Buildkite manually. Wait times recently have been too long, when building each commit.

## Todos

*n/a*

## Screenshots

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/4366292/210404748-d32aff69-1784-4b8d-89a1-118a1642db77.png">

## Testing Checklist

- [Slack QA thread](https://input-output-rnd.slack.com/archives/GGKFXSKC6/p1672765837442719)
- [ ] Test

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [x] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [x] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [ ] All visual regression testing has been reviewed (assign `run Chromatic` label to PR to trigger the run)
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [x] PR link is added to a Jira ticket, ticket moved to In Review
- [x] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [x] PR has a good description that summarizes all changes
- [x] PR contains screenshots (in case of UI changes)
- [ ] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [x] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [x] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
