### PR TITLE
[DDW-1224] Remove `process.env.BUILD_COUNTER` from `environment.version`

### DIFF
--- a/installers/common/Types.hs
+++ b/installers/common/Types.hs
@@ -139,7 +139,7 @@ packageFileName uglyName _os cluster ver backend buildJob buildCounter = fromTex
               else "x86_64-darwin"
             Linux64 -> "x86_64-linux"
     buildJob' = maybe [] (\b -> [fromBuildJob b]) buildJob
-    buildCounter' = "." <> maybe "0" fromBuildJob buildCounter
+    buildCounter' = "-" <> maybe "0" fromBuildJob buildCounter
 
 instance FromJSON Version where
   parseJSON = withObject "Package" $ \o -> Version <$> o .: "version"

--- a/nix/any-darwin.nix
+++ b/nix/any-darwin.nix
@@ -17,7 +17,7 @@ let
 
   archSuffix = if pkgs.system == "aarch64-darwin" then "arm64" else "x64";
   packageVersion = originalPackageJson.version;
-  installerName = "daedalus-${packageVersion}.${toString sourceLib.buildCounter}-${cluster}-${sourceLib.buildRevShort}-${pkgs.system}";
+  installerName = "daedalus-${packageVersion}-${toString sourceLib.buildCounter}-${cluster}-${sourceLib.buildRevShort}-${pkgs.system}";
 
 in rec {
 

--- a/nix/x86_64-linux.nix
+++ b/nix/x86_64-linux.nix
@@ -300,7 +300,7 @@ in rec {
 
     wrappedBundle = let
       version = (builtins.fromJSON (builtins.readFile ../package.json)).version;
-      fn = "daedalus-${version}.${toString sourceLib.buildCounter}-${linuxClusterBinName}-${sourceLib.buildRevShort}-x86_64-linux.bin";
+      fn = "daedalus-${version}-${toString sourceLib.buildCounter}-${linuxClusterBinName}-${sourceLib.buildRevShort}-x86_64-linux.bin";
     in pkgs.runCommand fn {} ''
       mkdir -p $out
       cp ${newBundle} $out/${fn}

--- a/source/main/environment.ts
+++ b/source/main/environment.ts
@@ -23,7 +23,7 @@ import {
   checkIsLinux,
 } from '../common/utils/environmentCheckers';
 
-const version = `${packageJson.version}.${process.env.BUILD_COUNTER || '0'}`;
+const version = `${packageJson.version}`;
 // Daedalus requires minimum 16 gigabytes of RAM, but some devices having 16 GB
 // actually have a slightly smaller RAM size (eg. 15.99 GB), therefore we used 15 GB threshold
 //


### PR DESCRIPTION
Internal PR, I think it's so trivial that it doesn’t require QA

It's important because of analytics – we were getting incorrect entries – the same version but with a different build counter being reported separately