### PR TITLE
Merge main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
-## vNext
+## 5.4.0
 
 ### Fixes
 
+- Fixed logs download ([PR 3197](https://github.com/input-output-hk/daedalus/pull/3197))
+- Fixed hardware wallets transaction logic ([PR 3195](https://github.com/input-output-hk/daedalus/pull/3195))
 - Make Windows installer check if previous Daedalus is running ([PR 3141](https://github.com/input-output-hk/daedalus/pull/3141))
 - Fixed out-of-memory errors on https://ci.iog.io ([PR 3145](https://github.com/input-output-hk/daedalus/pull/3145))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## vNext
+
 ## 5.4.0
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daedalus",
   "productName": "Daedalus",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Cryptocurrency Wallet",
   "main": "./dist/main/index.js",
   "scripts": {


### PR DESCRIPTION
This post-release maintenance PR merges `main` back into `develop`.