### PR TITLE
[LW-10649] Unset `LD_LIBRARY_PATH` on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## vNext
 
+### Chores
+
+- Unset `LD_LIBRARY_PATH` on Linux ([PR 3219](https://github.com/input-output-hk/daedalus/pull/3219))
+
 ## 6.0.0
 
 ### Chores

--- a/nix/internal/x86_64-linux.nix
+++ b/nix/internal/x86_64-linux.nix
@@ -291,6 +291,12 @@ in rec {
 
       cp ${pkgs.writeText "daedalus" ''
         #!/bin/sh
+
+        if [ -n "$LD_LIBRARY_PATH" ]; then
+          echo >&2 'Warning: ‘LD_LIBRARY_PATH’ is set, it’s been known to cause problems in the past, unsetting it.'
+          unset LD_LIBRARY_PATH
+        fi
+
         set -ex
 
         ENTRYPOINT_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")"


### PR DESCRIPTION
Otherwise, it sometimes causes problems, e.g. with OpenGL, as [found](https://input-output-rnd.slack.com/archives/C7PJ29FME/p1724180523046699?thread_ts=1724177213.102339&cid=C7PJ29FME) by @johnalotoski.

## Todos

_n/a_

## Screenshots

_n/a_

## Testing Checklist

- [ ] Test that the Linux installer still works.

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [ ] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [ ] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [ ] PR link is added to a Jira ticket, ticket moved to In Review
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR contains screenshots (in case of UI changes)
- [x] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
