### PR TITLE
fix: catch errors and inform user of the need to register voting rights [LW-11518]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Update `cardano-node` to 10.1.1 via `cardano-wallet` [`ba7d3340968`](https://github.com/cardano-foundation/cardano-wallet/commit/ba7d33409680f4e75ef260add8744dcf71f40a77) ([PR 3229](https://github.com/input-output-hk/daedalus/pull/3229))
 
+### Fixes
+
+- Handle createTransaction error when Conway era wallet has staking rewards but has not participated in governance yet ([PR 3237](https://github.com/input-output-hk/daedalus/pull/3237)
+
 ## 6.0.2
 
 ### Fixes

--- a/source/renderer/app/api/api.ts
+++ b/source/renderer/app/api/api.ts
@@ -1016,6 +1016,9 @@ export default class AdaApi {
         .set('wrongEncryptionPassphrase')
         .where('code', 'bad_request')
         .inc('message', 'passphrase is too short')
+        .set('conwayWalletNotDelegatedToDRep')
+        .where('code', 'created_invalid_transaction')
+        .inc('message', 'ConwayWdrlNotDelegatedToDRep')
         .set('transactionIsTooBig', true, {
           linkLabel: 'tooBigTransactionErrorLinkLabel',
           linkURL: 'tooBigTransactionErrorLinkURL',

--- a/source/renderer/app/api/errors.ts
+++ b/source/renderer/app/api/errors.ts
@@ -121,6 +121,12 @@ export const messages = defineMessages({
     description:
       '"Balance after transaction would not leave enough ada in the wallet to support tokens remaining in wallet',
   },
+  conwayWalletNotDelegatedToDRep: {
+    id: 'api.errors.conwayWalletNotDelegatedToDRep',
+    defaultMessage: '!!!conwayWalletNotDelegatedToDRep',
+    description:
+      'Error message shown when conway era wallet has staking rewards but has not participated in governance yet.',
+  },
 });
 
 type Balances = {

--- a/source/renderer/app/containers/wallet/dialogs/send-confirmation/SendConfirmation.view.tsx
+++ b/source/renderer/app/containers/wallet/dialogs/send-confirmation/SendConfirmation.view.tsx
@@ -89,7 +89,8 @@ function View({
         !isPasswordValid({
           isHardwareWallet,
           isValid: passphraseField.isValid,
-        }),
+        }) ||
+        !!error,
     },
   ];
 

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -95,6 +95,11 @@
         "defaultMessage": "!!!Insufficient funds to support tokens. You need at least an additional {adaAmount} ADA in your wallet to process this transaction.",
         "description": "\"Balance after transaction would not leave enough ada in the wallet to support tokens remaining in wallet",
         "id": "api.errors.NotEnoughFundsForTransactionFeesErrorWithTokens"
+      },
+      {
+        "defaultMessage": "!!!conwayWalletNotDelegatedToDRep",
+        "description": "Error message shown when conway era wallet has staking rewards but has not participated in governance yet.",
+        "id": "api.errors.conwayWalletNotDelegatedToDRep"
       }
     ],
     "path": "source/renderer/app/api/errors.ts"

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -34,6 +34,7 @@
   "api.errors.WalletAlreadyImportedError": "Wallet you are trying to import already exists.",
   "api.errors.WalletAlreadyRestoredError": "Wallet you are trying to restore already exists.",
   "api.errors.WalletFileImportError": "Wallet could not be imported, please make sure you are providing a correct file.",
+  "api.errors.conwayWalletNotDelegatedToDRep": "Daedalus cannot process this transaction because of blocked staking rewards. To unblock your rewards go to the <a href=\"/#/voting/governance\">Cardano voting power delegation tab</a> and delegate your voting power",
   "api.errors.inputsDepleted": "Your wallet contains only reward funds.<br />Please send at least 1 ADA to your wallet so that you can spend the funds.",
   "api.errors.invalidAddress": "Please enter a valid address.",
   "api.errors.invalidSmashServer": "This URL is not a valid SMASH server",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -34,6 +34,7 @@
   "api.errors.WalletAlreadyImportedError": "インポートしようとしているウォレットは既に存在します。",
   "api.errors.WalletAlreadyRestoredError": "復元しようとしているウォレットは既に存在します。",
   "api.errors.WalletFileImportError": "ウォレットをインポートできませんでした。有効なファイルを指定していることを確認してください。",
+  "api.errors.conwayWalletNotDelegatedToDRep": "ステーキング報酬がブロックされているため、このトランザクションを処理できません。報酬のブロックを解除するには、<a href=\"/#/voting/governance\">Cardano投票権の委任タブ</a>に移動し、投票権を委任してください。",
   "api.errors.inputsDepleted": "このウォレットには報酬として得られた資金しか入っていません。<br />資金を使用するには1ADA以上をウォレットに入金してください。",
   "api.errors.invalidAddress": "有効なアドレスを入力してください。",
   "api.errors.invalidSmashServer": "このURLは有効なSMASHサーバーではありません",

--- a/source/renderer/app/stores/WalletsStore.ts
+++ b/source/renderer/app/stores/WalletsStore.ts
@@ -837,7 +837,12 @@ export default class WalletsStore extends Store {
         : null;
     const wallet = this.active;
     if (!wallet) throw new Error('Active wallet required before sending.');
-    // @ts-ignore ts-migrate(1320) FIXME: Type of 'await' operand must either be a valid pro... Remove this comment to see the full error message
+
+    /**
+     * Do not try to catch the request error here, its intended to throw
+     * a localized error created in app/api/api.ts
+     */
+    // @ts-ignore
     await this.sendMoneyRequest.execute({
       address: receiver,
       amount: parseInt(amount, 10),
@@ -847,6 +852,7 @@ export default class WalletsStore extends Store {
       assets: formattedAssets,
       hasAssetsRemainingAfterTransaction,
     });
+    // The following code will not be executed if the request above fails
     this.analytics.sendEvent(
       EventCategories.WALLETS,
       'Transaction made',

--- a/storybook/stories/wallets/send/WalletSend.stories.tsx
+++ b/storybook/stories/wallets/send/WalletSend.stories.tsx
@@ -15,11 +15,13 @@ import { NUMBER_OPTIONS } from '../../../../source/renderer/app/config/profileCo
 import Wallet, {
   HwDeviceStatuses,
 } from '../../../../source/renderer/app/domains/Wallet';
+import { messages } from '../../../../source/renderer/app/api/errors';
 // Screens
 import WalletSendForm from '../../../../source/renderer/app/components/wallet/WalletSendForm';
 import type { WalletTokens } from '../../../../source/renderer/app/api/assets/types';
 import { WalletSendConfirmationDialogView } from '../../../../source/renderer/app/containers/wallet/dialogs/send-confirmation/SendConfirmation.view';
 import { noopAnalyticsTracker as analyticsTracker } from '../../../../source/renderer/app/analytics';
+import LocalizableError from '../../../../source/renderer/app/i18n/LocalizableError';
 
 const allAssets = [
   generateAssetToken(
@@ -470,7 +472,11 @@ storiesOf('Wallets / Send', module)
           isSubmitting={boolean('isSubmitting', false)}
           isHardwareWallet={boolean('isHardwareWallet', false)}
           formattedTotalAmount="21.000000"
-          error={null}
+          error={
+            new LocalizableError({
+              ...messages.conwayWalletNotDelegatedToDRep,
+            })
+          }
           onCancel={action('onCancel')}
           onSubmitCb={action('onSubmitCb')}
           onTermsCheckboxClick={action('onTermsCheckboxClick')}

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -95,6 +95,11 @@
         "defaultMessage": "!!!Insufficient funds to support tokens. You need at least an additional {adaAmount} ADA in your wallet to process this transaction.",
         "description": "\"Balance after transaction would not leave enough ada in the wallet to support tokens remaining in wallet",
         "id": "api.errors.NotEnoughFundsForTransactionFeesErrorWithTokens"
+      },
+      {
+        "defaultMessage": "!!!conwayWalletNotDelegatedToDRep",
+        "description": "Error message shown when conway era wallet has staking rewards but has not participated in governance yet.",
+        "id": "api.errors.conwayWalletNotDelegatedToDRep"
       }
     ],
     "path": "source/renderer/app/api/errors.ts"


### PR DESCRIPTION
Properly handle the case when a Conway era wallet that has staking rewards but did not participate in governance (register voting rights) yet can't send transactions due to blocked staking rewards.

**Please note:** This PR is based on https://github.com/input-output-hk/daedalus/pull/3229 to work with the latest cardano-node and cardano-wallet which needs to be merged first.

## Screenshots

![image](https://github.com/user-attachments/assets/2b4054d3-b1ff-4c2e-8ef2-a58ab348fc8d)

![image](https://github.com/user-attachments/assets/94419245-de16-4e72-a098-43ef18276b04)

![image](https://github.com/user-attachments/assets/7bc206a9-6113-478e-89df-e1d598077854)

## Todos

- [x] Catch the error from the node and show some message in the send tx confirm dialog
- [x] Disable the send button in the confirmation dialog if this error happened
- [x] Link to the governance tab from the error link
