### PR TITLE
fix: handle blocked staking rewards error for hardware wallets [LW-11931]

### DIFF
--- a/source/renderer/app/api/api.ts
+++ b/source/renderer/app/api/api.ts
@@ -1318,7 +1318,13 @@ export default class AdaApi {
       logger.error('AdaApi::createExternalTransaction error', {
         error,
       });
-      throw new ApiError(error).result();
+
+      const apiError = new ApiError(error)
+        .set('conwayWalletNotDelegatedToDRep')
+        .where('code', 'created_invalid_transaction')
+        .inc('message', 'ConwayWdrlNotDelegatedToDRep');
+
+      throw apiError.result();
     }
   };
   inspectAddress = async (request: {


### PR DESCRIPTION
Handle blocked staking rewards api error when sending funds, for hardware wallets https://input-output.atlassian.net/browse/LW-11931