### PR TITLE
fix: skip missing asset data

### DIFF
--- a/source/renderer/app/utils/transactionsCsvGenerator.ts
+++ b/source/renderer/app/utils/transactionsCsvGenerator.ts
@@ -187,7 +187,9 @@ const transactionsCsvGenerator = async ({
 
       const valueTokens = filterAssets(assets, type, isInternalAddress)
         .map(({ policyId, assetName, quantity }) => {
-          const { fingerprint, metadata } = getAsset(policyId, assetName);
+          const assetData = getAsset(policyId, assetName);
+          const fingerprint = assetData?.fingerprint || 'unknown fingerprint';
+          const metadata = assetData?.metadata || {};
           const formattedAmount = formattedTokenWalletAmount(
             quantity,
             metadata,


### PR DESCRIPTION
CWB does not expose data for some assets. If we miss metadata and fingerprint, we are going to skip that data and render
`103 (unknown fingerprint)`
instead of 
`103 tHOSKY (asset15qks69wv4vk7clnhp4lq7x0rpk6vs0s6exw0ry)`

<img width="565" alt="image" src="https://github.com/user-attachments/assets/d23563b3-1591-4126-8fc7-15bcf15ed08b">
