### PR TITLE
feat: use pool delegation endpoint for constructing drep tx no matter the wallet type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## vNext
+## 7.0.2
+
+### Fixes
+
+- Changed Cardano Wallet endpoint used to initialize VP delegation transaction ([PR 3262](https://github.com/input-output-hk/daedalus/pull/3262))
 
 ## 7.0.1
 


### PR DESCRIPTION
Workaround for https://github.com/cardano-foundation/cardano-wallet/issues/4872

https://input-output.atlassian.net/browse/LW-11980

The constructTransaction endpoint of CWB seems to fail on vote delegation for some of mnemonic wallets. We can mitigate the problem by using a pool delegation endpoint, as we do for hardware wallets.

The PR targeted to release/7.0.1 temporarily until we have a next release branch.