### PR TITLE
fix: log level of delegateVotes CWB API call

### DIFF
--- a/source/renderer/app/api/api.ts
+++ b/source/renderer/app/api/api.ts
@@ -2829,7 +2829,7 @@ export default class AdaApi {
 
       return response;
     } catch (error) {
-      logger.debug('AdaApi::delegateVotes error', {
+      logger.error('AdaApi::delegateVotes error', {
         error,
       });
 


### PR DESCRIPTION
Use the error log level for a failure in `delegateVotes` API call.