### PR TITLE
fix: vote delegation form

### DIFF
--- a/source/renderer/app/api/wallets/types.ts
+++ b/source/renderer/app/api/wallets/types.ts
@@ -77,7 +77,11 @@ export type SyncStateStatus =
   | 'syncing'
   | 'not_responding';
 export type Discovery = 'random' | 'sequential';
-export type DelegationStatus = 'delegating' | 'not_delegating';
+export type DelegationStatus =
+  | 'delegating'
+  | 'not_delegating'
+  | 'voting'
+  | 'voting_and_delegating';
 export type WalletSyncStateProgress = {
   quantity: number;
   unit: 'percentage';

--- a/source/renderer/app/domains/Wallet.ts
+++ b/source/renderer/app/domains/Wallet.ts
@@ -33,9 +33,13 @@ export const WalletSyncStateStatuses: {
 export const WalletDelegationStatuses: {
   DELEGATING: DelegationStatus;
   NOT_DELEGATING: DelegationStatus;
+  VOTING: DelegationStatus;
+  VOTING_AND_DELEGATING: DelegationStatus;
 } = {
   DELEGATING: 'delegating',
   NOT_DELEGATING: 'not_delegating',
+  VOTING: 'voting',
+  VOTING_AND_DELEGATING: 'voting_and_delegating',
 };
 export type HwDeviceStatus =
   | 'connecting'
@@ -234,10 +238,12 @@ export default class Wallet {
 
   @computed
   get isDelegating(): boolean {
-    return this.lastDelegationStakePoolStatus
-      ? this.lastDelegationStakePoolStatus ===
-          WalletDelegationStatuses.DELEGATING
-      : this.delegationStakePoolStatus === WalletDelegationStatuses.DELEGATING;
+    const statusToCheck = (this.lastDelegationStakePoolStatus ||
+      this.delegationStakePoolStatus) as DelegationStatus;
+    return [
+      WalletDelegationStatuses.DELEGATING,
+      WalletDelegationStatuses.VOTING_AND_DELEGATING,
+    ].includes(statusToCheck);
   }
 
   @computed

--- a/source/renderer/app/utils/dataSerialization.ts
+++ b/source/renderer/app/utils/dataSerialization.ts
@@ -3,6 +3,7 @@ import blakejs from 'blakejs';
 import { encode } from 'borc';
 import { utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { base58_decode } from '@cardano-foundation/ledgerjs-hw-app-cardano/dist/utils/address';
+import { Cardano } from '@cardano-sdk/core';
 import { AddressStyles } from '../domains/WalletAddress';
 import {
   derivationPathToLedgerPath,
@@ -182,11 +183,12 @@ const parseVoteDelegation = (vote: string): [number] | [number, Buffer] => {
   if (vote === 'abstain') return [2];
   if (vote === 'no_confidence') return [3];
 
-  const voteHash = Buffer.from(
-    utils.buf_to_hex(utils.bech32_decodeAddress(vote)),
-    'hex'
-  );
-  return [vote.includes('_script') ? 1 : 0, voteHash];
+  const { type, hash } = Cardano.DRepID.toCredential(Cardano.DRepID(vote));
+
+  return [
+    type === Cardano.CredentialType.ScriptHash ? 1 : 0,
+    Buffer.from(hash, 'hex'),
+  ];
 };
 
 export function toTxCertificate(cert: {

--- a/source/renderer/app/utils/shelleyLedger.ts
+++ b/source/renderer/app/utils/shelleyLedger.ts
@@ -13,6 +13,7 @@ import {
   base58_decode,
   str_to_path,
 } from '@cardano-foundation/ledgerjs-hw-app-cardano/dist/utils/address';
+import { Cardano } from '@cardano-sdk/core';
 import {
   CATALYST_VOTING_REGISTRATION_TYPE,
   CERTIFICATE_TYPE,
@@ -67,18 +68,18 @@ const parseVoteDelegation = (
     };
   }
 
-  const votHash = utils.buf_to_hex(utils.bech32_decodeAddress(cert.vote));
+  const { type, hash } = Cardano.DRepID.toCredential(Cardano.DRepID(cert.vote));
 
-  if (cert.vote.includes('_script')) {
+  if (type === Cardano.CredentialType.ScriptHash) {
     return {
       type: DRepParamsType.SCRIPT_HASH,
-      scriptHashHex: votHash,
+      scriptHashHex: hash,
     };
   }
 
   return {
     type: DRepParamsType.KEY_HASH,
-    keyHashHex: votHash,
+    keyHashHex: hash,
   };
 };
 

--- a/source/renderer/app/utils/shelleyTrezor.ts
+++ b/source/renderer/app/utils/shelleyTrezor.ts
@@ -2,17 +2,18 @@ import { utils } from '@cardano-foundation/ledgerjs-hw-app-cardano';
 import { Messages } from '@trezor/transport';
 import { CardanoDRep, PROTO } from '@trezor/connect';
 import { map } from 'lodash';
+import { Cardano } from '@cardano-sdk/core';
 import {
-  derivationPathToString,
   CERTIFICATE_TYPE,
+  derivationPathToString,
   groupTokensByPolicyId,
 } from './hardwareWalletUtils';
 import type {
+  CoinSelectionAssetsType,
+  CoinSelectionCertificate,
   CoinSelectionInput,
   CoinSelectionOutput,
-  CoinSelectionCertificate,
   CoinSelectionWithdrawal,
-  CoinSelectionAssetsType,
 } from '../api/transactions/types';
 
 export const TrezorTransactionSigningMode = {
@@ -67,18 +68,18 @@ const parseVoteDelegation = (cert: CoinSelectionCertificate): CardanoDRep => {
     };
   }
 
-  const voteHash = utils.bech32_decodeAddress(cert.vote).toString('hex');
+  const { type, hash } = Cardano.DRepID.toCredential(Cardano.DRepID(cert.vote));
 
-  if (cert.vote.includes('_script')) {
+  if (type === Cardano.CredentialType.ScriptHash) {
     return {
       type: PROTO.CardanoDRepType.SCRIPT_HASH,
-      scriptHash: voteHash,
+      scriptHash: hash,
     };
   }
 
   return {
     type: PROTO.CardanoDRepType.KEY_HASH,
-    keyHash: voteHash,
+    keyHash: hash,
   };
 };
 


### PR DESCRIPTION
<!---
Briefly describe the change.
-->

This PR
 - fixes the vote delegation form for wallets which had both: vote and pool delegation. With the recent Cardano Wallet update the form was not working properly for those wallets
 - enables HW based wallets to use cip129 drep format