### PR TITLE
chore: update `cardano-node` to 10.2.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,22 +6,14 @@ steps:
 
   # XXX: `</dev/null turns off any interactive questions from Nix (e.g. accept-flake-config)
 
-  - input: ':recycle: Trigger ‘x86_64-darwin’'
-    key: 'trigger-x86_64-darwin'
-
-  - input: ':recycle: Trigger ‘aarch64-darwin’'
-    key: 'trigger-aarch64-darwin'
-
   - label: 'daedalus-x86_64-darwin'
     command: 'nix </dev/null run --no-accept-flake-config -L .#packages.x86_64-darwin.buildkitePipeline'
-    depends_on: 'trigger-x86_64-darwin'
     agents:
       queue: lace
       system: x86_64-darwin
 
   - label: 'daedalus-aarch64-darwin'
     command: 'nix </dev/null run --no-accept-flake-config -L .#packages.aarch64-darwin.buildkitePipeline'
-    depends_on: 'trigger-aarch64-darwin'
     env:
       # XXX: avoid Böhm GC segfaults in Nix on aarch64-darwin:
       GC_DONT_GC: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Update `cardano-node` to 10.1.4, and `cardano-wallet` to v2025-01-09 ([PR 3270](https://github.com/input-output-hk/daedalus/pull/3270))
 
+- Update `cardano-node` to 10.2.0 ([PR 3274](https://github.com/input-output-hk/daedalus/pull/3274))
+
 ## 7.0.2
 
 ### Fixes

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "cardano-node-override": {
       "flake": false,
       "locked": {
-        "lastModified": 1736202991,
-        "narHash": "sha256-Oys38YkpSpB48/H2NseP9kTWXm92a7kjAZtdnorcIEY=",
+        "lastModified": 1738098813,
+        "narHash": "sha256-tdcqwA1OqgoiSZpYm6Yqaizou9I36Utmg2oy6s5OQ3A=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1f63dbf2ab39e0b32bf6901dc203866d3e37de08",
+        "rev": "c4d675beb9ae5bc86499dfa4287e550cd759f2c1",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.1.4",
+        "ref": "10.2.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -20,17 +20,17 @@
     "cardano-playground": {
       "flake": false,
       "locked": {
-        "lastModified": 1736275496,
-        "narHash": "sha256-4Mk9Ts8ztZGhTuO0P1ukz2TsMenLpWiOWTc7gUdhUOI=",
+        "lastModified": 1736967417,
+        "narHash": "sha256-ORjEkhUGwRuxj3TiRDyplddsY9p27qg5Ah3lo9U8duw=",
         "owner": "input-output-hk",
         "repo": "cardano-playground",
-        "rev": "d3322dce0ab1c00386adc93899aabe9252342b54",
+        "rev": "39ea4db0daa11d6334a55353f685e185765a619b",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "cardano-playground",
-        "rev": "d3322dce0ab1c00386adc93899aabe9252342b54",
+        "rev": "39ea4db0daa11d6334a55353f685e185765a619b",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,9 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-22.11-darwin";
     cardano-wallet-unpatched.url = "github:cardano-foundation/cardano-wallet/v2025-01-09";
     cardano-wallet-unpatched.flake = false; # otherwise, +10k quadratic dependencies in flake.lock…
-    cardano-node-override.url = "github:IntersectMBO/cardano-node/10.1.4";
+    cardano-node-override.url = "github:IntersectMBO/cardano-node/10.2.0";
     cardano-node-override.flake = false;
-    cardano-playground.url = "github:input-output-hk/cardano-playground/d3322dce0ab1c00386adc93899aabe9252342b54";
+    cardano-playground.url = "github:input-output-hk/cardano-playground/39ea4db0daa11d6334a55353f685e185765a619b";
     cardano-playground.flake = false; # otherwise, +9k dependencies in flake.lock…
     cardano-shell.url = "github:input-output-hk/cardano-shell/0d1d5f036c73d18e641412d2c58d4acda592d493";
     cardano-shell.flake = false;


### PR DESCRIPTION
Pre-release test PR.

Via <https://github.com/IntersectMBO/cardano-node/releases/tag/10.2.0>.

## Screenshots

_n/a_

## Testing Checklist

_n/a_

---

## Review Checklist

### Basics

- [x] PR assigned to the PR author(s)
- [ ] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [ ] If there are UI changes, Alexander Rukin assigned as an additional reviewer
- [x] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [ ] PR link is added to a Jira ticket, ticket moved to In Review
- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [ ] PR has a good description that summarizes all changes
- [ ] PR contains screenshots (in case of UI changes)
- [x] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
- [ ] Japanese text changes are proofread and approved (Junko Oda)
- [ ] Storybook works and no stories are broken (`yarn storybook`)
- [ ] In case of dependency changes `yarn.lock` file is updated

### Code Quality

- [ ] Important parts of the code are properly commented and documented
- [ ] Code is properly typed with typescript types
- [ ] React components are split-up enough to avoid unnecessary re-renderings
- [ ] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
