### PR TITLE
Fix Windows mapped-drive chain target fallback

### DIFF
--- a/source/main/utils/chainStoragePathResolver.ts
+++ b/source/main/utils/chainStoragePathResolver.ts
@@ -43,22 +43,32 @@ const resolveManagedChainPathFromEntryPoint = async (
     const chainStats = await fs.lstat(chainPath);
 
     if (chainStats.isSymbolicLink()) {
+      const rawLinkTarget = await fs.readlink(chainPath);
+      const linkTargetPath = path.isAbsolute(rawLinkTarget)
+        ? rawLinkTarget
+        : path.resolve(path.dirname(chainPath), rawLinkTarget);
+
       const resolvedLinkTarget = await resolveLinkTarget(chainPath);
       if (resolvedLinkTarget) {
         return resolvedLinkTarget;
       }
 
-      return path.resolve(chainPath);
+      return linkTargetPath;
     }
 
     if (process.platform === 'win32' && chainStats.isDirectory()) {
       try {
-        await fs.readlink(chainPath);
+        const rawLinkTarget = await fs.readlink(chainPath);
+        const linkTargetPath = path.isAbsolute(rawLinkTarget)
+          ? rawLinkTarget
+          : path.resolve(path.dirname(chainPath), rawLinkTarget);
 
         const resolvedJunctionTarget = await resolveLinkTarget(chainPath);
         if (resolvedJunctionTarget) {
           return resolvedJunctionTarget;
         }
+
+        return linkTargetPath;
       } catch (error) {
         const code = (error as NodeJS.ErrnoException)?.code;
         if (

--- a/source/main/utils/chainStorageWindowsNetwork.spec.ts
+++ b/source/main/utils/chainStorageWindowsNetwork.spec.ts
@@ -1,0 +1,42 @@
+import fs from 'fs-extra';
+import { resolveMithrilWorkDir } from './chainStoragePathResolver';
+
+jest.mock('fs-extra', () => ({
+  lstat: jest.fn(),
+  readlink: jest.fn(),
+  realpath: jest.fn(),
+  pathExists: jest.fn(),
+}));
+
+jest.mock('./logging', () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('Windows mapped-drive chain storage', () => {
+  beforeEach(() => jest.resetAllMocks());
+
+  it('preserves the Z: junction target when realpath temporarily fails', async () => {
+    (fs.lstat as jest.Mock).mockResolvedValue({
+      isSymbolicLink: () => true,
+      isDirectory: () => false,
+    });
+
+    (fs.readlink as jest.Mock).mockResolvedValue('Z:\\DaedalusChain\\chain');
+
+    ((fs.realpath as unknown) as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('mapped drive temporarily unavailable'), {
+        code: 'ENOENT',
+      })
+    );
+
+    const result = await resolveMithrilWorkDir(
+      'C:\\Users\\test\\AppData\\Roaming\\Daedalus Mainnet'
+    );
+
+    expect(result).toBe('Z:\\DaedalusChain\\chain');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a Win specific issue where Daedalus can lose track of a chain directory located on a mapped NAS/network drive.

Chain junction points to a path such as `Z:\DaedalusChain\chain`, `fs.readlink` still returns the correct target, but `fs.realpath` can fail with `ENOENT`. In that case, Daedalus was falling back to the local `<stateDir>\chain` path instead of keeping the configured mapped drive location.

Resolver now reads the junction target first, uses the resolved path when available, and falls back to the original junction target when `realpath` fails.

Added a regression test for this case.

### Tested

- TypeScript compilation passed
- Main-process build passed
- Existing Windows junction test passed
- New mapped-drive regression test passed
- Reproduced and verified using a local SMB share mapped as `Z:`
- Confirmed the development build launched and shut down normally