### PR TITLE
Fix portable Linux XKB and GBM paths

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     "cardano-wallet": {
       "flake": false,
       "locked": {
-        "lastModified": 1778483238,
-        "narHash": "sha256-8Gp5/vYh01EVZ3++wCBfLOq+9roPtswQITHIsvDUGUE=",
+        "lastModified": 1784813498,
+        "narHash": "sha256-WU3d2PbC2GQ09WLxQ/fomTY6x6eT5ZK5JQvZqWMHitc=",
         "owner": "cardano-foundation",
         "repo": "cardano-wallet",
-        "rev": "c642e0779676d2567e3d5fa1e2db9f029b6398e1",
+        "rev": "724be55dc66cf67bc4427e8f1a9657a9d1d33d71",
         "type": "github"
       },
       "original": {
         "owner": "cardano-foundation",
-        "ref": "v2026-05-11",
+        "ref": "v2026-07-23",
         "repo": "cardano-wallet",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     fenix.inputs.nixpkgs.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
-    cardano-wallet.url = "github:cardano-foundation/cardano-wallet/v2026-05-11";
+    cardano-wallet.url = "github:cardano-foundation/cardano-wallet/v2026-07-23";
     cardano-wallet.flake = false; # otherwise, +10k quadratic dependencies in flake.lock…
     cardano-node.url = "github:IntersectMBO/cardano-node/11.0.1";
     cardano-node.flake = false;

--- a/nix/internal/x86_64-linux.nix
+++ b/nix/internal/x86_64-linux.nix
@@ -194,6 +194,7 @@ in rec {
         ${pkgs.libva.out}/lib/*.so.2
         ${pkgs.atk}/lib/libatk-bridge-2.0.so
         ${pkgs.libgbm}/lib/libgbm.so.1
+        ${pkgs.mesa}/lib/gbm/dri_gbm.so
         $(find ${pkgs.glibc}/lib -type l)
       )
     '';
@@ -218,7 +219,9 @@ in rec {
         + ''
           chmod -R +w $out
 
-          mkdir -p $out/lib
+          mkdir -p $out/lib $out/share/X11
+          rm -rf $out/share/X11/xkb
+          cp -RL ${pkgs.xkeyboard-config}/etc/X11/xkb $out/share/X11/xkb
           cp -R ${electronBin}/lib/electron $out/lib/
           ( cd $out/electron && ${pkgs.rsync}/bin/rsync -Rah . $out/lib/electron/ ; )
           rm -rf $out/electron/
@@ -256,8 +259,10 @@ in rec {
             fi
             # nix-bundle-exe nukes the xkeyboard-config path baked into libxkbcommon.so;
             # restore it so keyboard input works:
-            export XKB_CONFIG_ROOT="${pkgs.xkeyboard-config}/etc/X11/xkb"
             LIB_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")/lib"
+            BUNDLE_DIR="$(dirname "$LIB_DIR")"
+            export XKB_CONFIG_ROOT="$BUNDLE_DIR/share/X11/xkb"
+            export GBM_BACKENDS_PATH="$LIB_DIR/electron/lib"
             # Run electron directly (interpreter is embedded via patchelf above):
             exec "$LIB_DIR"/electron/electron "$@"
           ''} $out/bin/electron

--- a/nix/internal/x86_64-linux.nix
+++ b/nix/internal/x86_64-linux.nix
@@ -215,7 +215,8 @@ in rec {
         inherit pkgs;
       }
       electronBin).overrideAttrs (drv: {
-      buildCommand = additionalLibs
+      buildCommand =
+        additionalLibs
         + (builtins.replaceStrings ["find '"] ["find -L '"] drv.buildCommand);
     });
 

--- a/nix/internal/x86_64-linux.nix
+++ b/nix/internal/x86_64-linux.nix
@@ -180,7 +180,10 @@ in rec {
 
   electron-loader = pkgs.glibc;
 
-  relocatableElectron = let
+  # nix-bundle-exe pass: patches the electron binary and collects all .so deps.
+  # exe_dir/lib_dir are set so the output lands directly at lib/electron/ with no
+  # intermediate directory to shuffle around afterwards.
+  electronBundleExe = let
     additionalLibs = ''
       additionalLibs=(
         ${pkgs.xorg.libX11}/lib/libX11-xcb.so.1
@@ -207,68 +210,75 @@ in rec {
           sed -r '/bundleExe "\$binary"/a\  bundleLib "'"$additionalLib"'" "lib"' -i $out/bundle-linux.sh
         done
       '') {
-        exe_dir = "electron";
-        lib_dir = "electron/lib";
-        #bin_dir = "electron-bin";
+        exe_dir = "lib/electron";
+        lib_dir = "lib/electron/lib";
         inherit pkgs;
       }
       electronBin).overrideAttrs (drv: {
-      buildCommand =
-        additionalLibs
-        + (builtins.replaceStrings ["find '"] ["find -L '"] drv.buildCommand)
-        + ''
-          chmod -R +w $out
-
-          mkdir -p $out/lib $out/share/X11
-          rm -rf $out/share/X11/xkb
-          cp -RL ${pkgs.xkeyboard-config}/etc/X11/xkb $out/share/X11/xkb
-          cp -R ${electronBin}/lib/electron $out/lib/
-          ( cd $out/electron && ${pkgs.rsync}/bin/rsync -Rah . $out/lib/electron/ ; )
-          rm -rf $out/electron/
-          cp ${electron-loader}/lib/ld-linux-x86-64.so.2 $out/lib/electron/
-
-          rm -f $out/lib/electron/lib/ld-linux-x86-64.so.2
-          ( cd $out/lib/electron && mv libffmpeg.so lib/libffmpeg.so && ln -s lib/libffmpeg.so libffmpeg.so ; )
-
-          ( cd $out/lib/electron/lib && ln -s libatk-bridge-2.0.so libatk-bridge.so ; )
-
-          # nixpkgs-25.11: libgtk-3 now depends on libtinysparql, which has libsqlite3.so
-          # as a full-path DT_NEEDED that was nuked to eeee... Replace with a soname so
-          # the bundled sqlite copy can satisfy it.
-          cp ${pkgs.sqlite.out}/lib/libsqlite3.so.0 $out/lib/electron/lib/
-          for f in $out/lib/electron/lib/libtinysparql-3.0.so*; do
-            patchelf --replace-needed \
-              '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.50.4/lib/libsqlite3.so' \
-              'libsqlite3.so.0' \
-              "$f"
-          done
-
-          patchelf --set-rpath '$ORIGIN/lib:$ORIGIN' $out/lib/electron/electron
-
-          # Embed the bundled ld-linux as the ELF interpreter so electron can be exec'd
-          # directly. This is critical: if we use `exec ld-linux electron`, /proc/self/exe
-          # points to ld-linux rather than electron, and Electron's subprocess spawning
-          # (zygote, GPU, renderer) breaks with "unrecognized option --type=zygote".
-          patchelf --set-interpreter $out/lib/electron/ld-linux-x86-64.so.2 $out/lib/electron/electron
-
-          cp ${pkgs.writeScript "electron" ''
-            #!/bin/sh
-            if [ -z "''${XCURSOR_PATH}" ] && [ -d "/usr/share/icons" ]; then
-              # Debians don't set this, and in effect all cursors are 2x too small on HiDPI displays:
-              export XCURSOR_PATH="/usr/share/icons"
-            fi
-            # nix-bundle-exe nukes the xkeyboard-config path baked into libxkbcommon.so;
-            # restore it so keyboard input works:
-            LIB_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")/lib"
-            BUNDLE_DIR="$(dirname "$LIB_DIR")"
-            export XKB_CONFIG_ROOT="$BUNDLE_DIR/share/X11/xkb"
-            export GBM_BACKENDS_PATH="$LIB_DIR/electron/lib"
-            # Run electron directly (interpreter is embedded via patchelf above):
-            exec "$LIB_DIR"/electron/electron "$@"
-          ''} $out/bin/electron
-        '';
-      meta.mainProgram = "electron";
+      buildCommand = additionalLibs
+        + (builtins.replaceStrings ["find '"] ["find -L '"] drv.buildCommand);
     });
+
+  relocatableElectron = pkgs.stdenv.mkDerivation {
+    name = "relocatable-electron";
+    dontUnpack = true;
+    dontFixup = true;
+    nativeBuildInputs = [pkgs.patchelf];
+    buildCommand = ''
+      mkdir -p $out/lib $out/bin $out/share/X11
+      cp -RL ${pkgs.xkeyboard-config}/etc/X11/xkb $out/share/X11/xkb
+
+      # Start with the nix-bundle-exe output: patched binary + bundled .so deps
+      # at lib/electron/ (exe_dir) and lib/electron/lib/ (lib_dir):
+      cp -R ${electronBundleExe}/lib/electron $out/lib/
+      chmod -R +w $out/lib/electron
+
+      # Overlay the raw electron app assets (resources, locales, etc.); -n ensures
+      # the patched binary and bundled libs from electronBundleExe are not clobbered:
+      cp -Rn ${electronBin}/lib/electron/. $out/lib/electron/
+
+      cp ${electron-loader}/lib/ld-linux-x86-64.so.2 $out/lib/electron/
+      rm -f $out/lib/electron/lib/ld-linux-x86-64.so.2
+      ( cd $out/lib/electron && mv libffmpeg.so lib/libffmpeg.so && ln -s lib/libffmpeg.so libffmpeg.so ; )
+      ( cd $out/lib/electron/lib && ln -s libatk-bridge-2.0.so libatk-bridge.so ; )
+
+      # nixpkgs-25.11: libgtk-3 now depends on libtinysparql, which has libsqlite3.so
+      # as a full-path DT_NEEDED that was nuked to eeee... Replace with a soname so
+      # the bundled sqlite copy can satisfy it.
+      cp ${pkgs.sqlite.out}/lib/libsqlite3.so.0 $out/lib/electron/lib/
+      for f in $out/lib/electron/lib/libtinysparql-3.0.so*; do
+        patchelf --replace-needed \
+          '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-sqlite-3.50.4/lib/libsqlite3.so' \
+          'libsqlite3.so.0' \
+          "$f"
+      done
+
+      patchelf --set-rpath '$ORIGIN/lib:$ORIGIN' $out/lib/electron/electron
+
+      # Embed the bundled ld-linux as the ELF interpreter so electron can be exec'd
+      # directly. This is critical: if we use `exec ld-linux electron`, /proc/self/exe
+      # points to ld-linux rather than electron, and Electron's subprocess spawning
+      # (zygote, GPU, renderer) breaks with "unrecognized option --type=zygote".
+      patchelf --set-interpreter $out/lib/electron/ld-linux-x86-64.so.2 $out/lib/electron/electron
+
+      cp ${pkgs.writeScript "electron" ''
+        #!/bin/sh
+        if [ -z "''${XCURSOR_PATH}" ] && [ -d "/usr/share/icons" ]; then
+          # Debians don't set this, and in effect all cursors are 2x too small on HiDPI displays:
+          export XCURSOR_PATH="/usr/share/icons"
+        fi
+        # nix-bundle-exe nukes the xkeyboard-config path baked into libxkbcommon.so;
+        # restore it so keyboard input works:
+        LIB_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")/lib"
+        BUNDLE_DIR="$(dirname "$LIB_DIR")"
+        export XKB_CONFIG_ROOT="$BUNDLE_DIR/share/X11/xkb"
+        export GBM_BACKENDS_PATH="$LIB_DIR/electron/lib"
+        # Run electron directly (interpreter is embedded via patchelf above):
+        exec "$LIB_DIR"/electron/electron "$@"
+      ''} $out/bin/electron
+    '';
+    meta.mainProgram = "electron";
+  };
 
   # A completely portable directory that you can run on _any_ Linux:
   newBundle = genClusters (cluster:

--- a/release-cli/src/fetch.rs
+++ b/release-cli/src/fetch.rs
@@ -401,8 +401,14 @@ mod tests {
         let (gitrev, nar_hash) = parse_flake(
             "github:input-output-hk/daedalus/50706edb8f5a772bc961d0ff6bcc54b9e4f8403f?narHash=sha256-pLZ7mM65BevAulHq%2B43ecshkgHSarNvDUTeldp8KxjY%3D",
         );
-        assert_eq!(gitrev.as_deref(), Some("50706edb8f5a772bc961d0ff6bcc54b9e4f8403f"));
-        assert_eq!(nar_hash.as_deref(), Some("sha256-pLZ7mM65BevAulHq+43ecshkgHSarNvDUTeldp8KxjY="));
+        assert_eq!(
+            gitrev.as_deref(),
+            Some("50706edb8f5a772bc961d0ff6bcc54b9e4f8403f")
+        );
+        assert_eq!(
+            nar_hash.as_deref(),
+            Some("sha256-pLZ7mM65BevAulHq+43ecshkgHSarNvDUTeldp8KxjY=")
+        );
     }
 
     #[test]
@@ -410,7 +416,10 @@ mod tests {
         let (gitrev, nar_hash) = parse_flake(
             "git+https://github.com/input-output-hk/daedalus?ref=refs/heads/master&rev=32af7f154b8556dbf794eed2365661ef4ed2670d&submodules=1",
         );
-        assert_eq!(gitrev.as_deref(), Some("32af7f154b8556dbf794eed2365661ef4ed2670d"));
+        assert_eq!(
+            gitrev.as_deref(),
+            Some("32af7f154b8556dbf794eed2365661ef4ed2670d")
+        );
         assert_eq!(nar_hash, None);
     }
 }


### PR DESCRIPTION
## Summary

Fixes a Linux-specific issue where Daedalus can fail to launch because the portable installer references XKB keyboard data at an unavailable Nix store path and does not include Mesa's `dri_gbm.so` backend.

The Linux package now includes the XKB configuration inside the portable bundle and sets `XKB_CONFIG_ROOT` relative to the installed application.

It also bundles `dri_gbm.so` and its dependencies, then sets `GBM_BACKENDS_PATH` to the bundled Electron library directory.

## Tested

- Linux installer build passed
- Confirmed bundled XKB rules are present
- Confirmed bundled `dri_gbm.so` is present
- Confirmed `dri_gbm.so` uses an `$ORIGIN` RPATH
- Confirmed GBM dependencies resolve from the portable bundle
- Installer checksum verified after transfer
- Installer completed successfully on native Ubuntu
- Daedalus launched without the original XKB, GBM, or segmentation-fault errors
- Mithril bootstrap began successfully
- Full blockchain synchronization was not completed because the test partition lacked sufficient storage