### PR TITLE
fix(main): follow symlinks in ensureDirectoryExists

### DIFF
--- a/source/main/utils/ensureDirectoryExists.spec.ts
+++ b/source/main/utils/ensureDirectoryExists.spec.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import ensureDirectoryExists from './ensureDirectoryExists';
+
+jest.mock('./logging', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+describe('ensureDirectoryExists', () => {
+  let tmpRoot: string;
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ensure-dir-'));
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      // Throwing keeps the test process alive while still proving exit was called.
+      .mockImplementation(((code?: number) => {
+        throw new Error(`process.exit(${code})`);
+      }) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('accepts an existing directory', () => {
+    const dir = path.join(tmpRoot, 'existing');
+    fs.mkdirSync(dir);
+
+    expect(() => ensureDirectoryExists(dir)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('creates the directory when it is missing', () => {
+    const dir = path.join(tmpRoot, 'nested', 'missing');
+
+    expect(() => ensureDirectoryExists(dir)).not.toThrow();
+    expect(fs.statSync(dir).isDirectory()).toBe(true);
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  // A state or logs directory may be symlinked to another disk; lstat would
+  // report the link itself and wrongly exit the whole app.
+  it('accepts a symlink pointing at a directory', () => {
+    const target = path.join(tmpRoot, 'target');
+    const link = path.join(tmpRoot, 'link');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, link, 'dir');
+
+    expect(() => ensureDirectoryExists(link)).not.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('exits when the path exists but is a file', () => {
+    const file = path.join(tmpRoot, 'a-file');
+    fs.writeFileSync(file, 'not a directory');
+
+    expect(() => ensureDirectoryExists(file)).toThrow('process.exit(1)');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/source/main/utils/ensureDirectoryExists.ts
+++ b/source/main/utils/ensureDirectoryExists.ts
@@ -1,21 +1,32 @@
 import mkdirp from 'mkdirp';
 import fs from 'fs';
+import { logger } from './logging';
 
 export default (filepath: string) => {
   let stats;
 
+  // statSync, not lstatSync: a state or logs directory is allowed to be a
+  // symlink to a directory elsewhere (e.g. another disk), and lstat would
+  // report the link itself, failing the isDirectory() check below.
   try {
-    stats = fs.lstatSync(filepath);
+    stats = fs.statSync(filepath);
   } catch (e) {
     try {
       mkdirp.sync(filepath);
-      stats = fs.lstatSync(filepath);
+      stats = fs.statSync(filepath);
     } catch (error) {
+      logger.error('ensureDirectoryExists: could not create directory', {
+        filepath,
+        error,
+      });
       process.exit(1);
     }
   }
 
   if (!stats || !stats.isDirectory()) {
+    logger.error('ensureDirectoryExists: path is not a directory', {
+      filepath,
+    });
     process.exit(1);
   }
 };


### PR DESCRIPTION
`ensureDirectoryExists` used `fs.lstatSync`, which does not resolve symlinks, so a state or logs directory symlinked elsewhere (e.g. onto another disk) failed the `isDirectory()` check and the app called `process.exit(1)`.

Since `spawnMithrilChild` calls `ensureDirectoryExists(workDir)` before every Mithril child spawn, this killed Daedalus roughly half a second into startup, with no log line and no dialog. `setupLogging` and `MithrilBootstrapService` reach the same code path.

Use `fs.statSync` so an intermediate or final symlink to a directory is accepted, and log before either exit so this can no longer fail silently.

### How it was found

Reproduced on Linux with `~/.local/share/Daedalus/mainnet` symlinked to another disk. The launcher only reported `Wallet exited with exitcode: ExitFailure 1`; running the installed build under an instrumented wrapper gave the real stack:

```
process.exit(1)
  at ensureDirectoryExists (main/index.js:144438)
  at spawnMithrilChild     (main/index.js:145422)
  at runCommand            (main/index.js:145505)
### lstatSync NOT-A-DIR: /home/weebl/.local/share/Daedalus/mainnet
```

Patching only that call in the installed 11.1.0 build made the app start and stay up.

## Todos

- [x] Reproduce the startup crash and isolate the root cause
- [x] Make `ensureDirectoryExists` follow symlinks
- [x] Log before both `process.exit(1)` paths so the failure is never silent
- [x] Add unit coverage for the symlink-to-directory case
- [ ] Run `yarn compile` and `yarn test:jest` (not yet run locally — no `node_modules` in the working checkout)
- [ ] Add CHANGELOG entry under _Fixes_

## Screenshots

n/a — no UI changes.

## Testing Checklist

<!---
Open a thread on #daedalus-qa on Slack, mention `@daedalusqa` and `@daedalusteam`, link the thread below
-->

- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
- [ ] Symlink `~/.local/share/Daedalus/<network>` to a directory on another disk, then launch Daedalus. Before this change it exits with code 1 about half a second into startup, with no error shown; after it should start normally.
- [ ] Launch with a normal (non-symlinked) state directory to confirm no regression.
- [ ] Confirm a genuinely invalid path (a regular file where a directory is expected) still exits, and now logs `ensureDirectoryExists: path is not a directory`.

---

## Review Checklist

### Basics

- [ ] PR assigned to the PR author(s)
- [ ] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
- [x] If there are UI changes, Alexander Rukin assigned as an additional reviewer — n/a, no UI changes
- [ ] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
- [ ] PR link is added to a Jira ticket, ticket moved to In Review
- [x] PR is updated to the most recent version of the target branch (and there are no conflicts)
- [x] PR has a good description that summarizes all changes
- [x] PR contains screenshots (in case of UI changes) — n/a, no UI changes
- [ ] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
- [x] There are no missing translations (running `yarn manage:translations` produces no changes) — n/a, no user-facing strings added
- [x] Text changes are proofread and approved (Jane Wild / Amy Reeve) — n/a, no user-facing text
- [x] Japanese text changes are proofread and approved (Junko Oda) — n/a, no user-facing text
- [x] Storybook works and no stories are broken (`yarn storybook`) — n/a, no components changed
- [x] In case of dependency changes `yarn.lock` file is updated — n/a, no dependency changes

### Code Quality

- [x] Important parts of the code are properly commented and documented
- [x] Code is properly typed with typescript types
- [x] React components are split-up enough to avoid unnecessary re-renderings — n/a, no React changes
- [x] Any code that only works in main process is neatly separated from components

### Testing

- [ ] New feature/change is covered by acceptance tests — a unit spec (`ensureDirectoryExists.spec.ts`) is added covering existing dir, missing dir, symlink-to-dir and file-not-dir; it has not been executed yet locally
- [ ] New feature/change is manually tested and approved by QA team
- [ ] All existing acceptance tests are still up-to-date
- [ ] New feature/change is covered by Daedalus Testing scenario
- [ ] All existing Daedalus Testing scenarios are still up-to-date

### After Review

- [ ] Update Slack QA thread by marking it with a green checkmark
