### PR TITLE
ci(checks): assert translation artifacts are regenerated, not just runnable

### DIFF
--- a/perSystem/checks.nix
+++ b/perSystem/checks.nix
@@ -34,7 +34,27 @@
       lint = mkJsCheck "daedalus-lint" "yarn lint";
       compile = mkJsCheck "daedalus-compile" "yarn compile";
       stylelint = mkJsCheck "daedalus-stylelint" "yarn stylelint";
-      i18n = mkJsCheck "daedalus-i18n" "yarn i18n:manage";
+      # `yarn i18n:manage` regenerates translation artifacts that are tracked in
+      # the repository. Running it is not enough on its own: the command exits 0
+      # whether or not the regenerated output matches what is committed, so the
+      # tracked artifacts can drift from source indefinitely with CI green.
+      # Snapshot them, regenerate, and require the result to be identical.
+      i18n = mkJsCheck "daedalus-i18n" ''
+        cp -r source/renderer/app/i18n/locales .i18n-locales-before
+        cp translations/messages.json .i18n-messages-before.json
+
+        yarn i18n:manage
+
+        if ! diff -r .i18n-locales-before source/renderer/app/i18n/locales \
+          || ! diff .i18n-messages-before.json translations/messages.json; then
+          echo
+          echo "ERROR: committed translation artifacts are out of date."
+          echo "Run 'yarn i18n:manage' and commit the resulting changes."
+          exit 1
+        fi
+
+        rm -rf .i18n-locales-before .i18n-messages-before.json
+      '';
       storybook = mkJsCheck "daedalus-storybook-build" "yarn storybook:build";
       jest = mkJsCheck "daedalus-jest" "yarn test:jest --maxWorkers=4";
       shellcheck = pkgs.callPackage ../tests/shellcheck.nix {src = inputs.self;};


### PR DESCRIPTION
`checks.i18n` ran `yarn i18n:manage` and asserted only its exit code.

That command regenerates four tracked files — `source/renderer/app/i18n/locales/{defaultMessages,en-US,ja-JP}.json`
and `translations/messages.json` — and exits 0 whether or not the regenerated
output matches what is committed. So the tracked artifacts could drift from
source indefinitely while CI stayed green.

The failure mode is silent rather than loud: a message id missing from a locale
file falls back to the English `defaultMessage`, so stale artifacts ship
untranslated strings to Japanese users without any error.

This snapshots the artifacts, regenerates, and fails with an actionable message
if anything changed.

## Verification

Both directions, because a check that cannot fail is worse than no check:

| Case | Result |
| --- | --- |
| `nix build .#checks.x86_64-linux.i18n` on this branch as-is | **passes** — artifacts are currently in sync |
| Same, with one message id removed from `en-US.json` | **fails**: `ERROR: committed translation artifacts are out of date.` |

## Note

Running the check surfaces 23 pre-existing `[FormatJS CLI] Duplicate message id`
warnings, where the same id is defined more than once with a differing
`description` or `defaultMessage`. Those are untouched here and are worth a
separate look.
