### PR TITLE
fix(chain-storage): report a read-only directory as not-writable

### DIFF
--- a/source/main/utils/chainStorageValidation.realfs.spec.ts
+++ b/source/main/utils/chainStorageValidation.realfs.spec.ts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateChainStorageDirectory } from './chainStorageValidation';
+
+// This spec deliberately does NOT mock `fs-extra`. `chainStorageValidation.spec.ts`
+// covers the branch logic against a mocked filesystem; the cases here are ones a
+// mock cannot express, because they depend on how the real filesystem behaves:
+// permission bits, symlink resolution, and the errno a syscall actually raises.
+//
+// Jest's module registry is per test file, so mocking `fs-extra` there and using
+// the real module here does not conflict.
+
+// `../config` refuses to load outside the Nix shell, and `./logging` writes to
+// the Electron app data directory. Both are mocked; neither is the filesystem
+// behaviour under test. `check-disk-space` is left real, so the free-space read
+// happens against the actual temp volume.
+jest.mock('../config', () => ({
+  DISK_SPACE_REQUIRED: 1024,
+}));
+
+jest.mock('./logging', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const REQUIRED_SPACE = 1024;
+
+const makeGetDefaultConfig = (defaultPath: string) =>
+  jest.fn().mockResolvedValue({
+    defaultPath,
+    availableSpaceBytes: Number.MAX_SAFE_INTEGER,
+    requiredSpaceBytes: REQUIRED_SPACE,
+  });
+
+/**
+ * Asserts that `dir` genuinely denies writes before a test depends on it.
+ *
+ * A process with privileges that bypass the mode bits — root, or CAP_DAC_OVERRIDE
+ * in a container — can still write to a 0555 directory. Without this the
+ * read-only test would pass vacuously in exactly the environments where it was
+ * not actually exercised. Failing loudly is better than a silent false pass.
+ */
+const expectWritesDenied = (dir: string) => {
+  expect(() => fs.accessSync(dir, fs.constants.W_OK)).toThrow();
+};
+
+describe('validateChainStorageDirectory against a real filesystem', () => {
+  let tmpRoot: string;
+  let stateDir: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'chain-storage-validation-')
+    );
+    stateDir = path.join(tmpRoot, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Restore write permission first, or the recursive removal fails on the
+    // directories this spec deliberately made read-only.
+    for (const entry of fs.readdirSync(tmpRoot)) {
+      const full = path.join(tmpRoot, entry);
+      try {
+        fs.chmodSync(full, 0o700);
+      } catch {
+        // Not all entries are directories we changed; ignore.
+      }
+    }
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('reports a read-only directory as not-writable rather than unknown', async () => {
+    const target = path.join(tmpRoot, 'read-only');
+    fs.mkdirSync(target);
+    fs.chmodSync(target, 0o555);
+    expectWritesDenied(target);
+
+    const result = await validateChainStorageDirectory(
+      target,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('not-writable');
+  });
+
+  it('resolves a symlinked target directory to its real path', async () => {
+    const target = path.join(tmpRoot, 'real-target');
+    const link = path.join(tmpRoot, 'link-to-target');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, link, 'dir');
+
+    const result = await validateChainStorageDirectory(
+      link,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.resolvedPath).toBe(fs.realpathSync(target));
+  });
+
+  it('reports a dangling symlink as path-not-found', async () => {
+    const missingTarget = path.join(tmpRoot, 'target-that-was-deleted');
+    const link = path.join(tmpRoot, 'dangling');
+    fs.mkdirSync(missingTarget);
+    fs.symlinkSync(missingTarget, link, 'dir');
+    fs.rmSync(missingTarget, { recursive: true });
+
+    const result = await validateChainStorageDirectory(
+      link,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('path-not-found');
+  });
+
+  it('reports a file selected as the target with path-is-file semantics', async () => {
+    const target = path.join(tmpRoot, 'a-file');
+    fs.writeFileSync(target, 'not a directory');
+
+    const result = await validateChainStorageDirectory(
+      target,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+  });
+
+  it('accepts a directory whose path contains spaces and non-ASCII characters', async () => {
+    const target = path.join(tmpRoot, 'Ünïcödé 目録 dir');
+    fs.mkdirSync(target);
+
+    const result = await validateChainStorageDirectory(
+      target,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.reason).toBeUndefined();
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/source/main/utils/chainStorageValidation.ts
+++ b/source/main/utils/chainStorageValidation.ts
@@ -178,7 +178,24 @@ export async function validateChainStorageDirectory(
       };
     }
 
-    await fs.access(resolvedValidationPath, fs.constants.W_OK);
+    try {
+      await fs.access(resolvedValidationPath, fs.constants.W_OK);
+    } catch (accessError) {
+      // Without this, EACCES falls through to the generic catch below and the
+      // user is told only "Unable to validate selected directory", when the
+      // actual problem — and the one the renderer already has copy for — is
+      // that the location cannot be written to.
+      const code = (accessError as NodeJS.ErrnoException)?.code;
+      if (code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+        return {
+          ...defaultValidation,
+          resolvedPath: resolvedValidationPath,
+          reason: 'not-writable',
+          message: 'Selected directory is not writable.',
+        };
+      }
+      throw accessError;
+    }
 
     const managedChainPath = isDirectChainSelection
       ? resolvedPath


### PR DESCRIPTION
Selecting a read-only directory for chain storage tells the user only
"Unable to validate selected directory", which does not say what is wrong or
what to do about it.

## The defect

`fs.access(resolvedValidationPath, W_OK)` raises `EACCES`, which fell through to
the generic `catch` and returned `reason: 'unknown'`. The `'not-writable'` reason
was only ever produced for a path that **is not a directory**, so
`chainStorageUtils.ts:41` — which already has `validationNotWritable` copy — was
unreachable for the case it was written for.

`EACCES`, `EPERM` and `EROFS` are now caught at the access call and mapped to
`'not-writable'`. Anything else is rethrown, so genuinely unexpected failures
still surface as `'unknown'` rather than being mislabelled.

## A real-filesystem spec

`chainStorageValidation.spec.ts` mocks `fs-extra` wholesale. That is the right
tool for branch logic, but it cannot express this defect: the bug is *which errno
the real syscall raises*, and a mock only ever returns what the author already
believed.

`chainStorageValidation.realfs.spec.ts` is new and does not mock `fs-extra`. It
uses real temp directories, real permission bits and real symlinks. The existing
mocked spec is untouched and still passes — Jest's module registry is per test
file, so the two coexist.

| Case | Covers |
| --- | --- |
| read-only directory | `EACCES` from `fs.access(W_OK)` — the defect above |
| symlinked target | `realpath` resolution to the real path |
| dangling symlink | link exists, target deleted |
| file selected as target | not-a-directory |
| spaces and non-ASCII in the path | `Ünïcödé 目録 dir` |

The read-only test **asserts its own precondition** — that the `0555` mode really
denies writes — because a process with privileges that bypass mode bits, such as
root or `CAP_DAC_OVERRIDE` in a container, would otherwise pass it vacuously. It
fails loudly in that situation rather than reporting a false green.

## Verification

The spec was written first and run against unpatched code, where it failed with
`Expected: "not-writable"` / `Received: "unknown"`. It passes with the fix.

`lint`, `compile`, `stylelint`, `treefmt` and `jest` all pass — 67 suites, 783
tests.

## Context

This is the first of the real-filesystem cases. It follows the pattern
established by `ensureDirectoryExists.spec.ts` in #3352, which fixed a closely
related defect: a state or logs directory that is a symlink. Both are the same
class — code reasoning about the filesystem from assumptions no test ever
checked against a real one.
