### PR TITLE
fix(chain-storage): resolve relative symlink targets to absolute paths

### DIFF
--- a/source/main/utils/chainStoragePathResolver.realfs.spec.ts
+++ b/source/main/utils/chainStoragePathResolver.realfs.spec.ts
@@ -1,0 +1,107 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { resolveMithrilWorkDir } from './chainStoragePathResolver';
+
+// Real filesystem, no `fs-extra` mock. `chainStoragePathResolver.spec.ts` covers
+// the branch logic against mocks; these cases depend on what the filesystem
+// actually does — in particular that `realpath` fails on a dangling link while
+// `readlink` still returns its raw target.
+
+jest.mock('./logging', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe('resolveMithrilWorkDir against a real filesystem', () => {
+  let tmpRoot: string;
+  let stateDir: string;
+  let chainPath: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'chain-path-resolver-'))
+    );
+    stateDir = path.join(tmpRoot, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+    chainPath = path.join(stateDir, 'chain');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('returns the chain directory itself when it is a plain directory', async () => {
+    fs.mkdirSync(chainPath);
+
+    await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(chainPath);
+  });
+
+  it('resolves a symlink with an absolute target to that target', async () => {
+    const target = path.join(tmpRoot, 'elsewhere');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, chainPath, 'dir');
+
+    await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(target);
+  });
+
+  it('resolves a symlink with a relative target to that target', async () => {
+    const target = path.join(tmpRoot, 'elsewhere');
+    fs.mkdirSync(target);
+    fs.symlinkSync(path.join('..', 'elsewhere'), chainPath, 'dir');
+
+    await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(target);
+  });
+
+  // The regression this file exists for. When `realpath` fails — a dangling
+  // link locally, or a mapped network drive on Windows — the resolver falls back
+  // to `readlink`, which returns the target exactly as it was recorded. For a
+  // relative link that is a relative path, and the result is handed to
+  // MithrilBootstrapService.setWorkDir(), where it would resolve against
+  // process.cwd() rather than the state directory.
+  it('returns an absolute path when a relative symlink target cannot be resolved', async () => {
+    const missingTarget = path.join(tmpRoot, 'target-removed-later');
+    fs.mkdirSync(missingTarget);
+    fs.symlinkSync(path.join('..', 'target-removed-later'), chainPath, 'dir');
+    fs.rmSync(missingTarget, { recursive: true });
+
+    const result = await resolveMithrilWorkDir(stateDir);
+
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toBe(missingTarget);
+  });
+
+  it('returns an absolute path when an absolute symlink target cannot be resolved', async () => {
+    const missingTarget = path.join(tmpRoot, 'absolute-target-removed');
+    fs.mkdirSync(missingTarget);
+    fs.symlinkSync(missingTarget, chainPath, 'dir');
+    fs.rmSync(missingTarget, { recursive: true });
+
+    const result = await resolveMithrilWorkDir(stateDir);
+
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toBe(missingTarget);
+  });
+
+  // A Windows drive-letter target is not absolute by POSIX rules, and `path` is
+  // the POSIX implementation here. Without a win32 check the resolver would
+  // treat 'Z:\...' as relative and resolve it into nonsense, which is precisely
+  // the mapped network drive fallback chainStorageWindowsNetwork.spec.ts guards.
+  it('leaves a Windows drive-letter target intact rather than resolving it', async () => {
+    const windowsTarget = 'Z:\\DaedalusChain\\chain';
+    fs.symlinkSync(windowsTarget, chainPath, 'dir');
+
+    await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(windowsTarget);
+  });
+
+  it('falls back to the chain path itself when the entry point is missing', async () => {
+    const result = await resolveMithrilWorkDir(stateDir);
+
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toBe(chainPath);
+  });
+});

--- a/source/main/utils/chainStoragePathResolver.ts
+++ b/source/main/utils/chainStoragePathResolver.ts
@@ -19,6 +19,24 @@ export const getManagedChainPath = (
     ? path.join(path.resolve(customPath), CHAIN_DIRECTORY_NAME)
     : path.join(stateDir, CHAIN_DIRECTORY_NAME);
 
+/**
+ * Resolves a raw `readlink` result against the directory holding the link.
+ *
+ * `readlink` returns the target as it was recorded, so a relative link yields a
+ * relative path. Every consumer of this module expects an absolute one.
+ *
+ * Absoluteness is tested against both path flavours. A Windows target such as
+ * `Z:\DaedalusChain\chain` is not absolute by POSIX rules, and `path` is the
+ * POSIX implementation whenever this runs on Linux — including in tests that
+ * simulate Windows by overriding `process.platform`. Checking `path.win32` as
+ * well keeps a drive-letter or UNC target intact instead of resolving it into
+ * nonsense. A genuinely relative target is absolute under neither.
+ */
+const resolveLinkTargetPath = (linkPath: string, rawTarget: string): string =>
+  path.isAbsolute(rawTarget) || path.win32.isAbsolute(rawTarget)
+    ? rawTarget
+    : path.resolve(path.dirname(linkPath), rawTarget);
+
 const resolveLinkTarget = async (chainPath: string): Promise<string | null> => {
   try {
     return await fs.realpath(chainPath);
@@ -48,7 +66,13 @@ const resolveManagedChainPathFromEntryPoint = async (
       // realpath failed; fall back to readlink (handles Windows NAS/SMB drives
       // where the junction appears as a symlink but realpath fails with ENOENT):
       try {
-        return await fs.readlink(chainPath);
+        const rawLinkTarget = await fs.readlink(chainPath);
+        // readlink returns the target exactly as recorded, which for a relative
+        // link is a relative path. Callers pass this to setWorkDir() and to the
+        // partial sync cutover, where a relative path would resolve against
+        // process.cwd() rather than the state directory. Resolve it against the
+        // link's own directory, matching captureChainPathState.
+        return resolveLinkTargetPath(chainPath, rawLinkTarget);
       } catch {
         return path.resolve(chainPath);
       }
@@ -59,7 +83,12 @@ const resolveManagedChainPathFromEntryPoint = async (
         const junctionTarget = await fs.readlink(chainPath);
         // realpath can fail with ENOENT on mapped network drives (NAS/SMB)
         // even when the junction itself is valid; fall back to the raw
-        // readlink target, which is always the absolute Windows path:
+        // readlink target, which is always the absolute Windows path.
+        //
+        // Deliberately NOT passed through resolveLinkTargetPath: `path` is the
+        // POSIX implementation in a Linux test process, so path.isAbsolute()
+        // returns false for 'Z:\\...' and the target would be mangled. Junctions
+        // record absolute paths, so there is nothing to resolve here anyway.
         const resolvedJunctionTarget = await resolveLinkTarget(chainPath);
         return resolvedJunctionTarget ?? junctionTarget;
       } catch (error) {


### PR DESCRIPTION
Two resolvers disagreed about the same symlink.

## The defect

When the chain entry point is a symlink whose target `realpath` cannot resolve,
`resolveManagedChainPathFromEntryPoint` falls back to `readlink`, which returns
the target **exactly as recorded**. For a relative link that is a relative path.

`captureChainPathState` in `chainStorageManagerShared.ts` already handles this:

```ts
linkTargetPath = path.isAbsolute(rawLinkTarget)
  ? rawLinkTarget
  : path.resolve(path.dirname(ctx._chainPath), rawLinkTarget);
```

`chainStoragePathResolver.ts` did not. This makes it match.

## Why it matters

`resolveMithrilWorkDir` feeds `MithrilBootstrapService.setWorkDir()` and the
partial sync cutover in `chainStorageCoordinator.ts`. A relative path there
resolves against `process.cwd()`, not the state directory — so Mithril would
work against a location unrelated to the configured chain storage.

## The Windows interaction, which an existing test caught

My first attempt applied `path.isAbsolute` and broke
`chainStorageWindowsNetwork.spec.ts`:

```
Expected: "Z:\DaedalusChain\chain"
Received: "/home/adam/daedalus/C:\Users\test\...\Daedalus Mainnet/Z:\DaedalusChain\chain"
```

`path` is the POSIX implementation whenever this runs on Linux — including in
tests that simulate Windows by overriding `process.platform`, since `path` does
not follow that override. `path.isAbsolute('Z:\\...')` is therefore `false`, and
the target was resolved into nonsense.

Absoluteness is now tested against **both** flavours:

```ts
path.isAbsolute(rawTarget) || path.win32.isAbsolute(rawTarget)
```

A drive-letter or UNC target stays intact; a genuinely relative target is
absolute under neither, so it still gets resolved.

The Windows **junction** branch is deliberately left returning the raw readlink
target. Junctions record absolute paths, so there is nothing to resolve.

## Verification

`chainStoragePathResolver.realfs.spec.ts` is new and uses a real filesystem.
Written before the fix; the two relevant cases failed with `Received:
"../elsewhere"` and `path.isAbsolute(result)` false, and pass after.

| Case | Covers |
| --- | --- |
| plain directory | no link involved |
| absolute symlink | `realpath` succeeds |
| relative symlink | `realpath` succeeds, result must be absolute |
| relative symlink, target removed | `realpath` fails — **the defect** |
| absolute symlink, target removed | fallback stays absolute |
| `Z:\DaedalusChain\chain` target | the win32 interaction above |
| missing entry point | falls back to the chain path |

All 127 chain-storage tests pass, including the mapped-drive regression test.
Full set green: 67 suites, 785 tests, plus lint, compile, stylelint and treefmt.
