### PR TITLE
fix(chain-storage): roll back a failed migration even if the journal cannot

### DIFF
--- a/source/main/utils/chainStorageManager.spec.ts
+++ b/source/main/utils/chainStorageManager.spec.ts
@@ -670,6 +670,54 @@ describe('ChainStorageManager', () => {
     );
   });
 
+  it('_migrateLegacyCustomLayout rolls back even when the journal cannot record it', async () => {
+    const manager = new ChainStorageManager('/tmp/state');
+    const migrationFailure = new Error('move failed partway');
+
+    jest
+      .spyOn(manager, '_preflightLegacyMigration')
+      .mockResolvedValue(undefined);
+    // Whatever broke the migration can equally break the journal write: a full
+    // disk fails both. Recording the rollback must not gate the rollback.
+    jest
+      .spyOn(manager, '_writeMigrationJournal')
+      .mockImplementation(async (journal) => {
+        if (journal.state === 'rollback') {
+          throw Object.assign(new Error('no space left on device'), {
+            code: 'ENOSPC',
+          });
+        }
+      });
+    jest.spyOn(manager, '_movePath').mockRejectedValue(migrationFailure);
+    jest.spyOn(manager, '_createSymlink').mockResolvedValue(undefined);
+    jest.spyOn(manager, '_pathExistsViaLstat').mockResolvedValue(false);
+    const rollback = jest
+      .spyOn(manager, '_rollbackMigrationJournal')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      manager._migrateLegacyCustomLayout({
+        kind: 'legacy-custom-root',
+        customPath: '/mnt/custom-parent',
+        resolvedCustomPath: '/mnt/custom-parent',
+        managedChainPath: '/mnt/custom-parent/chain',
+        resolvedManagedChainPath: undefined,
+        currentChainSource: '/mnt/custom-parent',
+        entryPointState: {
+          type: 'symlink',
+          resolvedPath: '/mnt/custom-parent',
+        },
+        managedChainExists: false,
+        managedChainIsDirectory: false,
+        managedLegacyEntries: ['immutable'],
+        ignoredLegacyEntries: [],
+      })
+      // The original failure must survive, not be replaced by the journal error.
+    ).rejects.toBe(migrationFailure);
+
+    expect(rollback).toHaveBeenCalledTimes(1);
+  });
+
   it('_recoverInterruptedMigration cleans up a completed cutover on restart', async () => {
     const manager = new ChainStorageManager('/tmp/state');
 

--- a/source/main/utils/chainStorageManagerLayout.realfs.spec.ts
+++ b/source/main/utils/chainStorageManagerLayout.realfs.spec.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  writeMigrationJournal,
+  readMigrationJournal,
+} from './chainStorageManagerLayout';
+import type { ChainStorageMigrationJournal } from './chainStorageManagerShared';
+
+// Real filesystem, no `fs-extra` mock.
+//
+// The migration journal lives in <stateDir>/Logs, and a state or logs directory
+// is allowed to be a symlink to another disk — see ensureDirectoryExists and the
+// fix in #3352. These cases record what actually happens to journal I/O for each
+// shape that directory can take, because the journal is what makes an
+// interrupted chain migration recoverable.
+
+jest.mock('./logging', () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+const JOURNAL_FILE = 'chain-storage-migration-journal.json';
+
+const makeJournal = (): ChainStorageMigrationJournal => ({
+  state: 'start',
+  customPath: '/mnt/custom-parent',
+  legacyRootPath: '/mnt/custom-parent',
+  managedChainPath: '/mnt/custom-parent/chain',
+  movedEntries: [],
+  ignoredEntries: [],
+  backupEntryPointPath: '/tmp/state/chain.legacy-backup',
+  tempEntryPointPath: '/tmp/state/chain.managed-next',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+describe('migration journal I/O against a real filesystem', () => {
+  let tmpRoot: string;
+  let stateDir: string;
+
+  // Only the two fields journal I/O reads.
+  const makeCtx = () => {
+    const logsDirectoryPath = path.join(stateDir, 'Logs');
+    return {
+      _logsDirectoryPath: logsDirectoryPath,
+      _migrationJournalPath: path.join(logsDirectoryPath, JOURNAL_FILE),
+    } as never;
+  };
+
+  beforeEach(() => {
+    tmpRoot = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'migration-journal-'))
+    );
+    stateDir = path.join(tmpRoot, 'state');
+    fs.mkdirSync(stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('writes and reads the journal when Logs is a plain directory', async () => {
+    const journal = makeJournal();
+
+    await writeMigrationJournal(makeCtx(), journal);
+
+    await expect(readMigrationJournal(makeCtx())).resolves.toEqual(journal);
+  });
+
+  // The field-reported case: a state or logs directory pointed at another disk.
+  it('writes and reads the journal when Logs is a symlink to a directory', async () => {
+    const target = path.join(tmpRoot, 'logs-on-another-disk');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, path.join(stateDir, 'Logs'), 'dir');
+    const journal = makeJournal();
+
+    await writeMigrationJournal(makeCtx(), journal);
+
+    // The journal must land in the link target, not beside the link.
+    expect(fs.existsSync(path.join(target, JOURNAL_FILE))).toBe(true);
+    await expect(readMigrationJournal(makeCtx())).resolves.toEqual(journal);
+  });
+
+  it('writes and reads the journal when Logs is a relative symlink', async () => {
+    const target = path.join(tmpRoot, 'relative-logs');
+    fs.mkdirSync(target);
+    fs.symlinkSync(
+      path.join('..', 'relative-logs'),
+      path.join(stateDir, 'Logs'),
+      'dir'
+    );
+    const journal = makeJournal();
+
+    await writeMigrationJournal(makeCtx(), journal);
+
+    expect(fs.existsSync(path.join(target, JOURNAL_FILE))).toBe(true);
+    await expect(readMigrationJournal(makeCtx())).resolves.toEqual(journal);
+  });
+
+  // A dangling Logs symlink makes fs.ensureDir raise ENOENT rather than creating
+  // the directory. Recorded here so the behaviour is known rather than assumed:
+  // callers must treat a journal write as able to fail.
+  it('fails to write the journal when Logs is a dangling symlink', async () => {
+    const target = path.join(tmpRoot, 'logs-target-removed');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, path.join(stateDir, 'Logs'), 'dir');
+    fs.rmSync(target, { recursive: true });
+
+    await expect(
+      writeMigrationJournal(makeCtx(), makeJournal())
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('reports no journal rather than throwing when Logs is a dangling symlink', async () => {
+    const target = path.join(tmpRoot, 'logs-target-removed');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, path.join(stateDir, 'Logs'), 'dir');
+    fs.rmSync(target, { recursive: true });
+
+    await expect(readMigrationJournal(makeCtx())).resolves.toBeNull();
+  });
+
+  it('returns null rather than throwing on a corrupt journal', async () => {
+    fs.mkdirSync(path.join(stateDir, 'Logs'));
+    fs.writeFileSync(
+      path.join(stateDir, 'Logs', JOURNAL_FILE),
+      '{ this is not json'
+    );
+
+    await expect(readMigrationJournal(makeCtx())).resolves.toBeNull();
+  });
+});

--- a/source/main/utils/chainStorageManagerLayout.ts
+++ b/source/main/utils/chainStorageManagerLayout.ts
@@ -276,7 +276,23 @@ export async function migrateLegacyCustomLayout(
     });
     journal.state = 'rollback';
     journal.updatedAt = toIsoString();
-    await ctx._writeMigrationJournal(journal);
+    // Recording the rollback state is best effort. Whatever broke the migration
+    // may equally break this write — a full disk is the obvious case, since the
+    // migration moves the whole chain directory — and previously that second
+    // failure propagated before the rollback ran, leaving chain data half moved
+    // and replacing the original error with the journal one. The rollback is
+    // what protects the user's data, so it must not be gated behind bookkeeping.
+    try {
+      await ctx._writeMigrationJournal(journal);
+    } catch (journalError) {
+      logger.error(
+        'ChainStorageManager: could not record rollback state, rolling back anyway',
+        {
+          journalError,
+          migrationJournalPath: ctx._migrationJournalPath,
+        }
+      );
+    }
     await ctx._rollbackMigrationJournal(journal);
     throw error;
   }


### PR DESCRIPTION
Investigating the field report that a state or logs directory may be a symlink —
the same class as #3352 — turned up a defect in the migration rollback path.

## The rollback was gated behind bookkeeping

```ts
} catch (error) {
  journal.state = 'rollback';
  await ctx._writeMigrationJournal(journal);    // unguarded
  await ctx._rollbackMigrationJournal(journal); // never reached if it throws
  throw error;
}
```

Whatever broke the migration can equally break that write. **A full disk is the
obvious case**, because the migration is moving the entire chain directory: the
move fails with `ENOSPC`, the rollback should restore the previous layout, and
instead the journal write fails on the same full disk. The user is left with
chain data half moved between two locations, and the original error is replaced
by the journal one, so the logs do not even say what actually went wrong.

Recording the rollback state is bookkeeping. The rollback is what protects the
data. It must not depend on the bookkeeping succeeding.

The first journal write, at the top of the migration, is deliberately left
unguarded — it happens **before** anything moves, so failing there aborts safely.

## Verification

The new spec fails against unpatched code with exactly the symptom described:

```
Expected: [Error: move failed partway]
Received: [Error: no space left on device]
```

The original error was replaced and the rollback never ran. With the fix, the
rollback runs once and the original error propagates.

## How the Logs directory actually behaves

`chainStorageManagerLayout.realfs.spec.ts` is new and records, against a real
filesystem, what journal I/O does for each shape that directory can take:

| `Logs` is | `writeMigrationJournal` | `readMigrationJournal` |
| --- | --- | --- |
| a plain directory | writes | reads |
| a symlink to a directory | writes **into the target** | reads |
| a relative symlink | writes into the target | reads |
| a **dangling** symlink | throws `ENOENT` | returns `null` |
| a corrupt file | — | returns `null` |

The symlink cases are the field-reported scenario and they work. The dangling
case is what makes a journal write able to fail at all, which is what the fix
above addresses. `fs.ensureDir` raises `ENOENT` on a dangling symlink rather than
creating the directory — worth knowing, since the obvious assumption is that
`ensureDir` makes a directory appear no matter what was there.

Full set green: 67 suites, 785 tests, plus lint, compile, stylelint and treefmt.
