### PR TITLE
ci(checks): assert the portable bundle is structurally sound

### DIFF
--- a/perSystem/bundle-integrity.nix
+++ b/perSystem/bundle-integrity.nix
@@ -1,0 +1,42 @@
+# The portable bundle declares things about itself — paths its launcher
+# exports, libraries it needs, links it contains — and nothing verified those
+# declarations against the directory actually produced. Both recent release
+# failures were "build succeeds, application does not start", which no other
+# check in this set can see.
+#
+# This lives in its own module rather than in checks.nix because it is the only
+# check tied to a specific system's build products: it inspects the Linux
+# relocatable bundle and needs ELF tooling. flake-parts merges `checks` across
+# perSystem modules, so it joins the same set and becomes merge-blocking the
+# same way.
+{inputs, ...}: {
+  perSystem = {
+    system,
+    lib,
+    pkgs,
+    ...
+  }: {
+    checks = lib.optionalAttrs (system == "x86_64-linux") {
+      # The self-test runs first: it breaks a fixture bundle one way at a time
+      # and requires the checker to reject each break. A checker that has
+      # silently stopped asserting anything then fails here, instead of passing
+      # every bundle put in front of it.
+      bundle-integrity =
+        pkgs.runCommand "daedalus-bundle-integrity" {
+          # glibc.static: the self-test's fixture binary is linked statically so
+          # the fixture bundle is genuinely self-contained and its library
+          # closure does not depend on what the builder happens to provide.
+          nativeBuildInputs = [pkgs.binutils pkgs.stdenv.cc pkgs.glibc.static];
+        } ''
+          # Invoked through bash rather than executed directly: the sandbox has
+          # no /usr/bin/env for the scripts' shebangs to resolve.
+          bash ${inputs.self}/scripts/check-bundle-integrity-selftest.sh \
+            ${inputs.self}/scripts/check-bundle-integrity.sh
+          echo
+          bash ${inputs.self}/scripts/check-bundle-integrity.sh \
+            ${inputs.self.internal.x86_64-linux.relocatableElectron}
+          touch $out
+        '';
+    };
+  };
+}

--- a/perSystem/checks.nix
+++ b/perSystem/checks.nix
@@ -59,33 +59,6 @@
       jest = mkJsCheck "daedalus-jest" "yarn test:jest --maxWorkers=4";
       cucumber-unit = mkJsCheck "daedalus-cucumber-unit" "yarn test:unit";
       shellcheck = pkgs.callPackage ../tests/shellcheck.nix {src = inputs.self;};
-
-      # The portable bundle declares things about itself — paths its launcher
-      # exports, libraries it needs, links it contains — and nothing verified
-      # those declarations against the directory actually produced. Both recent
-      # release failures were "build succeeds, application does not start",
-      # which no other check in this set can see.
-      #
-      # The self-test runs first: it breaks a fixture bundle one way at a time
-      # and requires the checker to reject each break. A checker that has
-      # silently stopped asserting anything then fails here, instead of passing
-      # every bundle put in front of it.
-      bundle-integrity =
-        pkgs.runCommand "daedalus-bundle-integrity" {
-          # glibc.static: the self-test's fixture binary is linked statically so
-          # the fixture bundle is genuinely self-contained and its library
-          # closure does not depend on what the builder happens to provide.
-          nativeBuildInputs = [pkgs.binutils pkgs.stdenv.cc pkgs.glibc.static];
-        } ''
-          # Invoked through bash rather than executed directly: the sandbox has
-          # no /usr/bin/env for the scripts' shebangs to resolve.
-          bash ${inputs.self}/scripts/check-bundle-integrity-selftest.sh \
-            ${inputs.self}/scripts/check-bundle-integrity.sh
-          echo
-          bash ${inputs.self}/scripts/check-bundle-integrity.sh \
-            ${internal.relocatableElectron}
-          touch $out
-        '';
     };
   };
 }

--- a/perSystem/checks.nix
+++ b/perSystem/checks.nix
@@ -59,6 +59,33 @@
       jest = mkJsCheck "daedalus-jest" "yarn test:jest --maxWorkers=4";
       cucumber-unit = mkJsCheck "daedalus-cucumber-unit" "yarn test:unit";
       shellcheck = pkgs.callPackage ../tests/shellcheck.nix {src = inputs.self;};
+
+      # The portable bundle declares things about itself — paths its launcher
+      # exports, libraries it needs, links it contains — and nothing verified
+      # those declarations against the directory actually produced. Both recent
+      # release failures were "build succeeds, application does not start",
+      # which no other check in this set can see.
+      #
+      # The self-test runs first: it breaks a fixture bundle one way at a time
+      # and requires the checker to reject each break. A checker that has
+      # silently stopped asserting anything then fails here, instead of passing
+      # every bundle put in front of it.
+      bundle-integrity =
+        pkgs.runCommand "daedalus-bundle-integrity" {
+          # glibc.static: the self-test's fixture binary is linked statically so
+          # the fixture bundle is genuinely self-contained and its library
+          # closure does not depend on what the builder happens to provide.
+          nativeBuildInputs = [pkgs.binutils pkgs.stdenv.cc pkgs.glibc.static];
+        } ''
+          # Invoked through bash rather than executed directly: the sandbox has
+          # no /usr/bin/env for the scripts' shebangs to resolve.
+          bash ${inputs.self}/scripts/check-bundle-integrity-selftest.sh \
+            ${inputs.self}/scripts/check-bundle-integrity.sh
+          echo
+          bash ${inputs.self}/scripts/check-bundle-integrity.sh \
+            ${internal.relocatableElectron}
+          touch $out
+        '';
     };
   };
 }

--- a/scripts/check-bundle-integrity-selftest.sh
+++ b/scripts/check-bundle-integrity-selftest.sh
@@ -119,7 +119,22 @@ cc -o "$WORK/broken-closure/lib/electron/dynamic" "$WORK/tiny.c"
 expect_fail "rejects an unresolvable DT_NEEDED" \
   "$WORK/broken-closure" "which is not in the bundle"
 
-# 4. The checker must refuse to report success when a tool it depends on is
+# 4. A dangling symlink must not satisfy a DT_NEEDED entry. Indexing broken
+#    links as available libraries would make assertion 3 report a library as
+#    present exactly when it is missing, leaving assertion 2 as the only thing
+#    catching it — two assertions masking each other is worse than one.
+make_fixture "$WORK/dangling-satisfies-needed"
+cc -o "$WORK/dangling-satisfies-needed/lib/electron/dynamic" "$WORK/tiny.c"
+while IFS= read -r needed; do
+  [ -n "$needed" ] || continue
+  ln -s "/nonexistent/$needed" \
+    "$WORK/dangling-satisfies-needed/lib/electron/lib/$needed"
+done < <(readelf -d "$WORK/dangling-satisfies-needed/lib/electron/dynamic" \
+  2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p')
+expect_fail "does not let a dangling symlink satisfy a DT_NEEDED entry" \
+  "$WORK/dangling-satisfies-needed" "which is not in the bundle"
+
+# 5. The checker must refuse to report success when a tool it depends on is
 #    absent, rather than skipping every file it was meant to inspect.
 mkdir -p "$WORK/empty-path"
 if PATH="$WORK/empty-path" "$BASH_ABS" "$CHECKER" "$WORK/good" >"$WORK/out" 2>&1; then

--- a/scripts/check-bundle-integrity-selftest.sh
+++ b/scripts/check-bundle-integrity-selftest.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Self-test for check-bundle-integrity.sh.
+#
+# A checker that only ever runs against a bundle that passes is untested in the
+# direction that matters. This builds a minimal, self-consistent fixture bundle,
+# asserts the checker accepts it, then breaks the fixture one way at a time and
+# asserts the checker rejects each break with the expected reason.
+#
+# The fixture uses a statically linked binary so it has no DT_NEEDED entries of
+# its own and is therefore genuinely complete — no dependency on what happens to
+# be installed on the machine running the test.
+#
+# Usage: check-bundle-integrity-selftest.sh <path-to-check-bundle-integrity.sh>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <path-to-check-bundle-integrity.sh>" >&2
+  exit 2
+fi
+
+CHECKER="$1"
+if [ ! -f "$CHECKER" ]; then
+  echo "ERROR: no such file: $CHECKER" >&2
+  exit 2
+fi
+
+# Invoke through bash rather than executing directly: the checker's
+# `#!/usr/bin/env bash` shebang does not resolve inside the Nix build sandbox,
+# which has no /usr/bin/env.
+BASH_ABS=$(command -v bash)
+
+run_checker() {
+  "$BASH_ABS" "$CHECKER" "$@"
+}
+
+for tool in cc readelf; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "ERROR: required tool '$tool' not found" >&2
+    exit 2
+  }
+done
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+failures=0
+
+expect_pass() {
+  local name="$1" dir="$2"
+  if run_checker "$dir" >"$WORK/out" 2>&1; then
+    echo "ok   $name"
+  else
+    echo "FAIL $name — expected the checker to accept this bundle"
+    sed 's/^/       /' "$WORK/out"
+    failures=$((failures + 1))
+  fi
+}
+
+expect_fail() {
+  local name="$1" dir="$2" pattern="$3"
+  if run_checker "$dir" >"$WORK/out" 2>&1; then
+    echo "FAIL $name — checker accepted a bundle it should have rejected"
+    failures=$((failures + 1))
+  elif grep -q "$pattern" "$WORK/out"; then
+    echo "ok   $name"
+  else
+    echo "FAIL $name — rejected, but not for the expected reason"
+    echo "       wanted: $pattern"
+    sed 's/^/       /' "$WORK/out"
+    failures=$((failures + 1))
+  fi
+}
+
+# A minimal bundle with the same shape as the real one: a launcher that derives
+# LIB_DIR/BUNDLE_DIR from its own location and exports paths into the bundle,
+# plus a statically linked "electron" so the library closure is complete.
+make_fixture() {
+  local dir="$1"
+  rm -rf "$dir"
+  mkdir -p "$dir/bin" "$dir/lib/electron/lib" "$dir/share/X11/xkb"
+  echo 'int main(void) { return 0; }' >"$WORK/tiny.c"
+  cc -static -o "$dir/lib/electron/electron" "$WORK/tiny.c"
+  touch "$dir/share/X11/xkb/rules"
+  cat >"$dir/bin/electron" <<'LAUNCHER'
+#!/bin/sh
+LIB_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")/lib"
+BUNDLE_DIR="$(dirname "$LIB_DIR")"
+export XKB_CONFIG_ROOT="$BUNDLE_DIR/share/X11/xkb"
+export GBM_BACKENDS_PATH="$LIB_DIR/electron/lib"
+exec "$LIB_DIR"/electron/electron "$@"
+LAUNCHER
+  chmod +x "$dir/bin/electron"
+}
+
+echo "Self-testing $CHECKER"
+echo
+
+make_fixture "$WORK/good"
+expect_pass "accepts a well-formed bundle" "$WORK/good"
+
+# 1. A launcher export pointing at something that is not in the bundle.
+make_fixture "$WORK/broken-export"
+rm -rf "$WORK/broken-export/share/X11/xkb"
+expect_fail "rejects an unresolvable launcher export" \
+  "$WORK/broken-export" "XKB_CONFIG_ROOT points at"
+
+# 2. A symlink whose target does not exist — the macOS signing failure.
+make_fixture "$WORK/broken-symlink"
+ln -s "$WORK/broken-symlink/lib/electron/absent.so" \
+  "$WORK/broken-symlink/lib/electron/dangling.so"
+expect_fail "rejects a dangling symlink" \
+  "$WORK/broken-symlink" "dangling symlink"
+
+# 3. A DT_NEEDED entry with nothing in the bundle to satisfy it.
+make_fixture "$WORK/broken-closure"
+cc -o "$WORK/broken-closure/lib/electron/dynamic" "$WORK/tiny.c"
+expect_fail "rejects an unresolvable DT_NEEDED" \
+  "$WORK/broken-closure" "which is not in the bundle"
+
+# 4. The checker must refuse to report success when a tool it depends on is
+#    absent, rather than skipping every file it was meant to inspect.
+mkdir -p "$WORK/empty-path"
+if PATH="$WORK/empty-path" "$BASH_ABS" "$CHECKER" "$WORK/good" >"$WORK/out" 2>&1; then
+  echo "FAIL reports success with no readelf available"
+  failures=$((failures + 1))
+else
+  if grep -q "refusing to report success" "$WORK/out"; then
+    echo "ok   refuses to run without the tools its assertions need"
+  else
+    echo "FAIL failed without the tools, but not with the guard message"
+    sed 's/^/       /' "$WORK/out"
+    failures=$((failures + 1))
+  fi
+fi
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "SELF-TEST FAILED: $failures case(s)"
+  exit 1
+fi
+echo "SELF-TEST PASSED"

--- a/scripts/check-bundle-integrity.sh
+++ b/scripts/check-bundle-integrity.sh
@@ -136,11 +136,15 @@ declare -A have_lib=()
 for elf in "${elf_files[@]}"; do
   have_lib["$(basename "$elf")"]=1
 done
-# Symlinked sonames are real resolution targets too.
+# Symlinked sonames are real resolution targets too — but only when the link
+# resolves. `! -xtype l` excludes dangling ones: indexing those would let a
+# broken link satisfy a DT_NEEDED entry, so this assertion would report a
+# library as present precisely when it is not, and assertion 2 would be the
+# only thing left catching it.
 while IFS= read -r link; do
   [ -n "$link" ] || continue
   have_lib["$(basename "$link")"]=1
-done < <(find "$BUNDLE" -type l)
+done < <(find "$BUNDLE" -type l ! -xtype l)
 
 unresolved=0
 for elf in "${elf_files[@]}"; do

--- a/scripts/check-bundle-integrity.sh
+++ b/scripts/check-bundle-integrity.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+# Static integrity assertions for a built, relocatable bundle.
+#
+# The bundle makes claims about itself — environment variables it exports,
+# libraries it needs, links it contains — and nothing else verifies that those
+# claims hold against the directory actually produced. A build that succeeds
+# while producing a bundle that cannot start is the failure mode this guards.
+#
+# Usage: check-bundle-integrity.sh <bundle-root>
+#
+# Assertions:
+#   1. Every bundle-relative path the launcher exports resolves inside the bundle
+#   2. No symlink in the bundle dangles
+#   3. Every shared library named in DT_NEEDED is present in the bundle
+#
+# Deliberately generic: the launcher is parsed for what it exports rather than
+# checked against a hardcoded list, so a variable added later is covered with no
+# edit here.
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <bundle-root>" >&2
+  exit 2
+fi
+
+BUNDLE="${1%/}"
+
+if [ ! -d "$BUNDLE" ]; then
+  echo "ERROR: not a directory: $BUNDLE" >&2
+  exit 2
+fi
+
+# The assertions below are only meaningful if the tools that make them are
+# present. A missing tool must fail loudly rather than silently pass over every
+# file it was supposed to inspect.
+for tool in readelf find grep sed; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "ERROR: required tool '$tool' not found; refusing to report success" >&2
+    exit 2
+  fi
+done
+
+failures=0
+
+report() {
+  echo "  FAIL: $1"
+  failures=$((failures + 1))
+}
+
+is_elf() {
+  # Cheaper than invoking `file`, and enough to skip scripts and data.
+  [ -f "$1" ] && [ "$(head -c 4 "$1" 2>/dev/null | tr -d '\0')" = $'\x7fELF' ]
+}
+
+# Collect ELF files once; several assertions iterate over them.
+elf_files=()
+while IFS= read -r candidate; do
+  if is_elf "$candidate"; then
+    elf_files+=("$candidate")
+  fi
+done < <(find "$BUNDLE" -type f)
+
+echo "Bundle: $BUNDLE"
+echo "ELF objects: ${#elf_files[@]}"
+echo
+
+# ---------------------------------------------------------------------------
+# 1. Launcher environment paths
+#
+# The launcher computes LIB_DIR and BUNDLE_DIR from its own location, then
+# exports variables pointing into the bundle. Parse those exports out of the
+# built launcher and assert each target exists. Values rooted anywhere else
+# (XCURSOR_PATH points at /usr/share/icons and is -d guarded) are correctly
+# not matched.
+# ---------------------------------------------------------------------------
+echo "1. Launcher environment paths"
+launcher="$BUNDLE/bin/electron"
+if [ ! -f "$launcher" ]; then
+  report "no launcher at $launcher"
+else
+  # shellcheck disable=SC2016  # $BUNDLE_DIR/$LIB_DIR are literals to match in
+  # the launcher's own text, not variables to expand here.
+  exports=$(grep -oE 'export [A-Z_]+="\$(BUNDLE_DIR|LIB_DIR)[^"]*"' "$launcher" || true)
+  if [ -z "$exports" ]; then
+    report "launcher exports no bundle-relative paths; the parse is out of date"
+  else
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      var=${line#export }
+      var=${var%%=*}
+      value=${line#*=\"}
+      value=${value%\"}
+      # LIB_DIR is <bundle>/lib; BUNDLE_DIR is its parent, i.e. the bundle root.
+      resolved=${value//\$LIB_DIR/$BUNDLE/lib}
+      resolved=${resolved//\$BUNDLE_DIR/$BUNDLE}
+      if [ -e "$resolved" ]; then
+        echo "  ok: $var -> ${resolved#"$BUNDLE"/}"
+      else
+        report "$var points at ${resolved#"$BUNDLE"/}, which does not exist"
+      fi
+    done <<<"$exports"
+  fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 2. Dangling symlinks
+#
+# A broken link inside the bundle is a shipped defect: the macOS signing pass
+# rejects one, and on Linux it surfaces as a missing file at runtime.
+# ---------------------------------------------------------------------------
+echo "2. Dangling symlinks"
+dangling=$(find "$BUNDLE" -xtype l || true)
+if [ -n "$dangling" ]; then
+  while IFS= read -r link; do
+    report "dangling symlink: ${link#"$BUNDLE"/} -> $(readlink "$link")"
+  done <<<"$dangling"
+else
+  echo "  ok: none"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# 3. Shared library closure
+#
+# Every DT_NEEDED entry must correspond to a file inside the bundle. A library
+# that resolves only because the build machine happens to have it installed is
+# the defect that is invisible to all of our own testing — every machine we own
+# has a populated Nix store, and a user's does not.
+# ---------------------------------------------------------------------------
+echo "3. Shared library closure"
+# Index every shared object in the bundle by basename.
+declare -A have_lib=()
+for elf in "${elf_files[@]}"; do
+  have_lib["$(basename "$elf")"]=1
+done
+# Symlinked sonames are real resolution targets too.
+while IFS= read -r link; do
+  [ -n "$link" ] || continue
+  have_lib["$(basename "$link")"]=1
+done < <(find "$BUNDLE" -type l)
+
+unresolved=0
+for elf in "${elf_files[@]}"; do
+  while IFS= read -r needed; do
+    [ -n "$needed" ] || continue
+    if [ -z "${have_lib[$needed]:-}" ]; then
+      report "${elf#"$BUNDLE"/} needs $needed, which is not in the bundle"
+      unresolved=$((unresolved + 1))
+    fi
+  done < <(readelf -d "$elf" 2>/dev/null | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p')
+done
+if [ "$unresolved" -eq 0 ]; then
+  echo "  ok: every DT_NEEDED resolves inside the bundle"
+fi
+echo
+
+if [ "$failures" -gt 0 ]; then
+  echo "FAILED: $failures problem(s) found"
+  exit 1
+fi
+
+echo "PASSED"


### PR DESCRIPTION
The bundle declares things about itself — the paths its launcher exports, the shared libraries its objects need, the links it contains — and nothing verified those declarations against the directory actually produced. A build can succeed while producing a bundle that cannot start, and no existing check can see that.

## What it asserts

Three properties of a built bundle:

1. **Launcher environment paths resolve.** Every bundle-relative path the launcher exports must exist inside the bundle. The variables are parsed out of the *built* launcher rather than hardcoded, so one added later is covered with no edit here. Values rooted elsewhere are correctly not matched — `XCURSOR_PATH` points at `/usr/share/icons` and is `-d` guarded.
2. **No dangling symlinks.** A broken link is a shipped defect: the macOS signing pass rejects one, and on Linux it surfaces as a missing file at runtime.
3. **The shared library closure is complete.** Every `DT_NEEDED` entry must name a file present in the bundle. A library that resolves only because the build machine happens to have it installed fails only on a machine with no populated Nix store.

## Why there is a self-test

A checker that only ever runs against a bundle that passes is untested in the direction that matters. The self-test builds a minimal fixture bundle, breaks it one way at a time, and requires the checker to reject each break *for the expected reason*:

- a launcher export pointing at something absent
- a dangling symlink
- an unresolvable `DT_NEEDED`
- and the checker refusing to report success when a tool it depends on is missing, rather than skipping every file it was meant to inspect

That last case is the one worth having. An absent `readelf` turns every assertion into a silent no-op, and the check then reports a clean pass over a set it never inspected — worse than no check at all, because it is trusted.

The fixture links statically, so its library closure is genuinely complete rather than dependent on what the builder provides.

## Verification

```
$ nix build .#checks.x86_64-linux.bundle-integrity
SELF-TEST PASSED
Bundle: /nix/store/...-relocatable-electron
ELF objects: 189
1. Launcher environment paths
  ok: XKB_CONFIG_ROOT -> share/X11/xkb
  ok: GBM_BACKENDS_PATH -> lib/electron/lib
2. Dangling symlinks
  ok: none
3. Shared library closure
  ok: every DT_NEEDED resolves inside the bundle
PASSED
```

`shellcheck` and `treefmt` re-run and pass — both see the new files.

Adding the derivation to `checks.<system>` makes it merge-blocking automatically via the `required` aggregate in `flake.nix`, so there is no workflow or matrix to maintain.

## Where the check lives

It is defined in `perSystem/bundle-integrity.nix` rather than in `perSystem/checks.nix`. It is the only check tied to one system's build products — it inspects the Linux relocatable bundle and needs ELF tooling — so keeping it in the shared file meant every other change to the check set collided with it.

flake-parts merges `checks` across perSystem modules, so it lands in the same set, shows up in `nix eval .#checks.x86_64-linux`, and is collected into the required aggregate exactly as before. This branch does not touch `checks.nix` at all.
