### PR TITLE
feat(drt): verify release provenance before uploading anything

### DIFF
--- a/release-cli/src/cli.rs
+++ b/release-cli/src/cli.rs
@@ -50,18 +50,15 @@ pub enum Commands {
         #[arg(long)]
         skip_version_json: bool,
 
-        /// Repository to resolve the release tag against, for checking that the
-        /// installers were built from the commit the tag names.
-        #[arg(long, default_value = "https://github.com/input-output-hk/daedalus")]
-        repo_url: String,
+        /// Repository, as owner/name, whose tags name the release commits.
+        /// Resolved over the GitHub API; GITHUB_TOKEN is used when set.
+        #[arg(long, default_value = "input-output-hk/daedalus")]
+        repo: String,
 
-        /// Skip resolving the release tag and comparing it against the commit
-        /// the installers were built from.
+        /// Do not resolve the release tag; check only that the installers are
+        /// internally consistent.
         ///
-        /// The installers are still checked for internal consistency. Use only
-        /// when the tag legitimately does not exist yet — a release whose tag
-        /// names a different commit than its artifacts is the failure this
-        /// check exists to prevent.
+        /// Useful when the tag has not been pushed yet.
         #[arg(long)]
         skip_tag_check: bool,
     },

--- a/release-cli/src/cli.rs
+++ b/release-cli/src/cli.rs
@@ -49,6 +49,21 @@ pub enum Commands {
         /// Useful for staging binaries before making them the latest version.
         #[arg(long)]
         skip_version_json: bool,
+
+        /// Repository to resolve the release tag against, for checking that the
+        /// installers were built from the commit the tag names.
+        #[arg(long, default_value = "https://github.com/input-output-hk/daedalus")]
+        repo_url: String,
+
+        /// Skip resolving the release tag and comparing it against the commit
+        /// the installers were built from.
+        ///
+        /// The installers are still checked for internal consistency. Use only
+        /// when the tag legitimately does not exist yet — a release whose tag
+        /// names a different commit than its artifacts is the failure this
+        /// check exists to prevent.
+        #[arg(long)]
+        skip_tag_check: bool,
     },
 
     /// Code-sign macOS (.pkg) and/or Windows (.exe) installers via SSH

--- a/release-cli/src/main.rs
+++ b/release-cli/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
             dry_run,
             test,
             skip_version_json,
-            repo_url,
+            repo,
             skip_tag_check,
         } => {
             cmd_release(ReleaseOptions {
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
                 dry_run,
                 test,
                 skip_version_json,
-                repo_url: &repo_url,
+                repo: &repo,
                 skip_tag_check,
             })
             .await
@@ -367,57 +367,22 @@ async fn cmd_sign(
     Ok(())
 }
 
-/// Resolve a release tag to the commit it names, via `git ls-remote`.
-///
-/// `refs/tags/<tag>^{}` asks for the dereferenced target, so an annotated tag
-/// yields the commit it points at rather than the tag object. Both forms are
-/// requested because a lightweight tag has no dereferenced form.
-///
-/// Failure to resolve is an error rather than a warning: a release whose tag
-/// cannot be found is exactly the case worth stopping on.
-fn resolve_tag_commit(repo_url: &str, tag: &str) -> Result<String> {
-    let output = std::process::Command::new("git")
-        .args([
-            "ls-remote",
-            repo_url,
-            &format!("refs/tags/{tag}"),
-            &format!("refs/tags/{tag}^{{}}"),
-        ])
-        .output()
-        .with_context(|| format!("running git ls-remote against {repo_url}"))?;
-
-    if !output.status.success() {
-        anyhow::bail!(
-            "git ls-remote {repo_url} refs/tags/{tag} failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut object = None;
-    for line in stdout.lines() {
-        let Some((sha, name)) = line
-            .split_whitespace()
-            .next()
-            .zip(line.split_whitespace().nth(1))
-        else {
-            continue;
-        };
-        // The dereferenced entry wins when both are present.
-        if name.ends_with("^{}") {
-            return Ok(sha.to_string());
+/// HTTP client for the GitHub API, carrying GITHUB_TOKEN when one is set.
+fn github_client() -> Result<reqwest::Client> {
+    let mut headers = reqwest::header::HeaderMap::new();
+    if let Ok(token) = std::env::var("GITHUB_TOKEN") {
+        if !token.is_empty() {
+            let mut value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+                .context("GITHUB_TOKEN is not a valid header value")?;
+            value.set_sensitive(true);
+            headers.insert(reqwest::header::AUTHORIZATION, value);
         }
-        object = Some(sha.to_string());
     }
-
-    object.ok_or_else(|| {
-        anyhow::anyhow!(
-            "tag {tag} does not exist in {repo_url}. A release is a claim that \
-             this version corresponds to a commit; without the tag there is \
-             nothing to check it against. Create the tag, or pass \
-             --skip-tag-check if it is deliberately absent."
-        )
-    })
+    reqwest::Client::builder()
+        .user_agent("drt/0.1")
+        .default_headers(headers)
+        .build()
+        .context("building the GitHub API client")
 }
 
 /// Everything `cmd_release` needs, grouped so the signature stays readable as
@@ -430,7 +395,7 @@ struct ReleaseOptions<'a> {
     dry_run: bool,
     test: bool,
     skip_version_json: bool,
-    repo_url: &'a str,
+    repo: &'a str,
     skip_tag_check: bool,
 }
 
@@ -443,7 +408,7 @@ async fn cmd_release(opts: ReleaseOptions<'_>) -> Result<()> {
         dry_run,
         test,
         skip_version_json,
-        repo_url,
+        repo,
         skip_tag_check,
     } = opts;
     let installer_dir = installers::InstallerDir::load(installers_dir)?;
@@ -468,7 +433,8 @@ async fn cmd_release(opts: ReleaseOptions<'_>) -> Result<()> {
         println!("  tag check skipped (--skip-tag-check)");
         None
     } else {
-        Some(resolve_tag_commit(repo_url, &installer_dir.version)?)
+        let client = github_client()?;
+        Some(provenance::resolve_tag_commit(&client, repo, &installer_dir.version).await?)
     };
     provenance::verify(&installer_dir, tag_rev.as_deref())?;
     println!();

--- a/release-cli/src/main.rs
+++ b/release-cli/src/main.rs
@@ -3,12 +3,13 @@ mod fetch;
 mod hash;
 mod installers;
 mod newsfeed_cmd;
+mod provenance;
 mod s3;
 mod serve;
 mod sign;
 mod version_json;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 use cli::{Cli, Commands, NewsfeedCommands};
 use std::collections::HashMap;
@@ -70,16 +71,20 @@ async fn main() -> Result<()> {
             dry_run,
             test,
             skip_version_json,
+            repo_url,
+            skip_tag_check,
         } => {
-            cmd_release(
-                &installers_dir,
-                &bucket,
-                &bucket_url,
+            cmd_release(ReleaseOptions {
+                installers_dir: &installers_dir,
+                bucket: &bucket,
+                bucket_url: &bucket_url,
                 release_notes,
                 dry_run,
                 test,
                 skip_version_json,
-            )
+                repo_url: &repo_url,
+                skip_tag_check,
+            })
             .await
         }
 
@@ -362,15 +367,85 @@ async fn cmd_sign(
     Ok(())
 }
 
-async fn cmd_release(
-    installers_dir: &std::path::Path,
-    bucket: &str,
-    bucket_url: &str,
+/// Resolve a release tag to the commit it names, via `git ls-remote`.
+///
+/// `refs/tags/<tag>^{}` asks for the dereferenced target, so an annotated tag
+/// yields the commit it points at rather than the tag object. Both forms are
+/// requested because a lightweight tag has no dereferenced form.
+///
+/// Failure to resolve is an error rather than a warning: a release whose tag
+/// cannot be found is exactly the case worth stopping on.
+fn resolve_tag_commit(repo_url: &str, tag: &str) -> Result<String> {
+    let output = std::process::Command::new("git")
+        .args([
+            "ls-remote",
+            repo_url,
+            &format!("refs/tags/{tag}"),
+            &format!("refs/tags/{tag}^{{}}"),
+        ])
+        .output()
+        .with_context(|| format!("running git ls-remote against {repo_url}"))?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "git ls-remote {repo_url} refs/tags/{tag} failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut object = None;
+    for line in stdout.lines() {
+        let Some((sha, name)) = line
+            .split_whitespace()
+            .next()
+            .zip(line.split_whitespace().nth(1))
+        else {
+            continue;
+        };
+        // The dereferenced entry wins when both are present.
+        if name.ends_with("^{}") {
+            return Ok(sha.to_string());
+        }
+        object = Some(sha.to_string());
+    }
+
+    object.ok_or_else(|| {
+        anyhow::anyhow!(
+            "tag {tag} does not exist in {repo_url}. A release is a claim that \
+             this version corresponds to a commit; without the tag there is \
+             nothing to check it against. Create the tag, or pass \
+             --skip-tag-check if it is deliberately absent."
+        )
+    })
+}
+
+/// Everything `cmd_release` needs, grouped so the signature stays readable as
+/// options accumulate.
+struct ReleaseOptions<'a> {
+    installers_dir: &'a std::path::Path,
+    bucket: &'a str,
+    bucket_url: &'a str,
     release_notes: Option<String>,
     dry_run: bool,
     test: bool,
     skip_version_json: bool,
-) -> Result<()> {
+    repo_url: &'a str,
+    skip_tag_check: bool,
+}
+
+async fn cmd_release(opts: ReleaseOptions<'_>) -> Result<()> {
+    let ReleaseOptions {
+        installers_dir,
+        bucket,
+        bucket_url,
+        release_notes,
+        dry_run,
+        test,
+        skip_version_json,
+        repo_url,
+        skip_tag_check,
+    } = opts;
     let installer_dir = installers::InstallerDir::load(installers_dir)?;
 
     println!("Version  : {}", installer_dir.version);
@@ -383,6 +458,19 @@ async fn cmd_release(
     for inst in &installer_dir.installers {
         println!("  {} [{}]", inst.filename, inst.platform.display_name());
     }
+    println!();
+
+    // ── 0. Provenance ────────────────────────────────────────────────────────
+    // Before anything is hashed, signed or uploaded: do these artifacts come
+    // from one commit, and is it the commit the release tag names?
+    println!("=== Checking provenance ===");
+    let tag_rev = if skip_tag_check {
+        println!("  tag check skipped (--skip-tag-check)");
+        None
+    } else {
+        Some(resolve_tag_commit(repo_url, &installer_dir.version)?)
+    };
+    provenance::verify(&installer_dir, tag_rev.as_deref())?;
     println!();
 
     // ── 1. Hash ──────────────────────────────────────────────────────────────

--- a/release-cli/src/provenance.rs
+++ b/release-cli/src/provenance.rs
@@ -1,0 +1,242 @@
+//! Provenance checks, run before anything is uploaded.
+//!
+//! Publishing a release asserts that a version corresponds to a commit. That
+//! assertion is worth checking, because nothing else establishes it.
+//!
+//! Checking at tag time is not sufficient. A tag is reachable from its branch
+//! when it is created and can stop being reachable later — a history rewrite
+//! orphans one silently, and the artifacts are built afterwards. Comparing the
+//! revision recorded in the artifacts against the commit the tag resolves to
+//! settles the question at the only moment that matters, is indifferent to
+//! when the tag was created, and survives a rewrite.
+
+use crate::installers::InstallerDir;
+use anyhow::{Context, Result};
+use std::collections::BTreeMap;
+
+/// Target systems that appear as the trailing component of an installer name.
+/// Listed because they contain a `-` themselves, so the name cannot simply be
+/// split on that character.
+const KNOWN_SYSTEMS: [&str; 4] = [
+    "x86_64-linux",
+    "x86_64-darwin",
+    "aarch64-darwin",
+    "x86_64-windows",
+];
+
+/// Placeholder `buildRevShort` emits when the source tree was not clean
+/// (`nix/internal/source-lib.nix:42-45`). Never acceptable in a release.
+const DIRTY_REV: &str = "dirty";
+
+/// The git revision recorded in an installer filename.
+///
+/// Names are built as
+/// `daedalus-<version>-<build>-<cluster>-<revShort>-<system>.<ext>`
+/// (`nix/internal/any-darwin.nix:26`). Parsed from the right, because the
+/// system component contains a `-` and a prerelease version could too.
+///
+/// The build counter is decimal and therefore also valid hex, so matching on
+/// "looks like a hex string" would be ambiguous. Position is not.
+pub fn rev_from_filename(filename: &str) -> Option<&str> {
+    let stem = filename.rsplit_once('.').map_or(filename, |(stem, _)| stem);
+
+    let without_system = KNOWN_SYSTEMS.iter().find_map(|system| {
+        stem.strip_suffix(system)
+            .and_then(|rest| rest.strip_suffix('-'))
+    })?;
+
+    let (_, rev) = without_system.rsplit_once('-')?;
+    if rev.is_empty() {
+        return None;
+    }
+    Some(rev)
+}
+
+/// True when `full` and `short` name the same commit.
+///
+/// `meta.json` carries the full 40-character revision while a filename carries
+/// the first nine, so one is compared as a prefix of the other.
+fn same_commit(left: &str, right: &str) -> bool {
+    let (shorter, longer) = if left.len() <= right.len() {
+        (left, right)
+    } else {
+        (right, left)
+    };
+    !shorter.is_empty() && longer.starts_with(shorter)
+}
+
+/// Verify that everything about to be uploaded was built from one commit, and
+/// that it is the commit `tag_rev` names.
+///
+/// `tag_rev` is the commit the release tag resolves to, or `None` when the
+/// caller could not determine it — in which case only the internal consistency
+/// of the directory is checked, and the caller is responsible for deciding
+/// whether that is acceptable.
+pub fn verify(dir: &InstallerDir, tag_rev: Option<&str>) -> Result<()> {
+    if dir.installers.is_empty() {
+        anyhow::bail!("no installers found in {}", dir.dir.display());
+    }
+
+    // Group by revision so a mismatch can name every file on each side rather
+    // than just the first disagreement.
+    let mut by_rev: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for installer in &dir.installers {
+        let rev = rev_from_filename(&installer.filename).with_context(|| {
+            format!(
+                "cannot read a git revision from '{}'; expected \
+                 daedalus-<version>-<build>-<cluster>-<rev>-<system>.<ext>",
+                installer.filename
+            )
+        })?;
+        by_rev.entry(rev).or_default().push(&installer.filename);
+    }
+
+    if by_rev.len() > 1 {
+        let detail = by_rev
+            .iter()
+            .map(|(rev, files)| format!("  {rev}: {}", files.join(", ")))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "installers were built from more than one commit, so they cannot be \
+             released together:\n{detail}"
+        );
+    }
+
+    let rev = *by_rev.keys().next().expect("checked non-empty above");
+
+    if rev == DIRTY_REV {
+        anyhow::bail!(
+            "installers were built from a dirty source tree, so the commit they \
+             correspond to is unknown and unreproducible"
+        );
+    }
+
+    if let Some(meta_rev) = dir.meta.gitrev.as_deref() {
+        if !same_commit(meta_rev, rev) {
+            anyhow::bail!(
+                "meta.json records gitrev {meta_rev}, but the installers were \
+                 built from {rev}; the directory holds artifacts from a \
+                 different build than its metadata describes"
+            );
+        }
+    }
+
+    match tag_rev {
+        Some(tag_rev) if !same_commit(tag_rev, rev) => {
+            anyhow::bail!(
+                "tag {} points at {}, but the installers were built from {}.\n\
+                 Publishing would claim a version corresponds to a commit it \
+                 was not built from. Either the tag is on the wrong commit, or \
+                 these are the wrong artifacts.",
+                dir.version,
+                tag_rev,
+                rev
+            );
+        }
+        Some(tag_rev) => {
+            println!(
+                "  provenance: {rev} matches tag {} ({tag_rev})",
+                dir.version
+            );
+        }
+        None => {
+            println!("  provenance: {rev}, consistent across all installers");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rev_from_linux_installer_name() {
+        assert_eq!(
+            rev_from_filename("daedalus-11.2.0-86185-mainnet-8f9737937-x86_64-linux.bin"),
+            Some("8f9737937")
+        );
+    }
+
+    #[test]
+    fn rev_from_every_target_system() {
+        for (name, expected) in [
+            (
+                "daedalus-11.2.0-86185-mainnet-8f9737937-x86_64-darwin.pkg",
+                "8f9737937",
+            ),
+            (
+                "daedalus-11.2.0-86185-preprod-8f9737937-aarch64-darwin.pkg",
+                "8f9737937",
+            ),
+            (
+                "daedalus-11.2.0-86185-mainnet-8f9737937-x86_64-windows.exe",
+                "8f9737937",
+            ),
+        ] {
+            assert_eq!(rev_from_filename(name), Some(expected), "for {name}");
+        }
+    }
+
+    /// The build counter is decimal and therefore also a valid hex string, so a
+    /// parser that searched for "something hex-looking" could return it.
+    #[test]
+    fn build_counter_is_not_mistaken_for_a_revision() {
+        assert_eq!(
+            rev_from_filename("daedalus-7.3.0-83641-mainnet-4fe3ea852-x86_64-linux.bin"),
+            Some("4fe3ea852")
+        );
+        assert_eq!(
+            rev_from_filename("daedalus-11.2.0-86185-mainnet-123456789-x86_64-linux.bin"),
+            Some("123456789")
+        );
+    }
+
+    /// A prerelease version contains a `-`, so the name cannot be parsed by
+    /// counting fields from the left.
+    #[test]
+    fn version_containing_a_dash_is_handled() {
+        assert_eq!(
+            rev_from_filename("daedalus-11.2.0-rc1-86185-mainnet-8f9737937-x86_64-linux.bin"),
+            Some("8f9737937")
+        );
+    }
+
+    #[test]
+    fn dirty_tree_marker_is_read_back() {
+        assert_eq!(
+            rev_from_filename("daedalus-11.2.0-86185-mainnet-dirty-x86_64-linux.bin"),
+            Some(DIRTY_REV)
+        );
+    }
+
+    #[test]
+    fn unrecognised_names_yield_nothing() {
+        assert_eq!(rev_from_filename("daedalus.bin"), None);
+        assert_eq!(rev_from_filename("daedalus-11.2.0-mainnet.bin"), None);
+        // A system outside the supported set.
+        assert_eq!(
+            rev_from_filename("daedalus-11.2.0-86185-mainnet-8f9737937-riscv64-linux.bin"),
+            None
+        );
+    }
+
+    #[test]
+    fn short_and_full_revisions_compare_equal() {
+        assert!(same_commit(
+            "8f9737937d346e847c9c29c965fba7aa44136612",
+            "8f9737937"
+        ));
+        assert!(same_commit(
+            "8f9737937",
+            "8f9737937d346e847c9c29c965fba7aa44136612"
+        ));
+        assert!(!same_commit(
+            "fa8258757ac0b88c71fe82fb91bad9597af2920e",
+            "8f9737937"
+        ));
+        assert!(!same_commit("", "8f9737937"));
+    }
+}

--- a/release-cli/src/provenance.rs
+++ b/release-cli/src/provenance.rs
@@ -12,11 +12,15 @@
 
 use crate::installers::InstallerDir;
 use anyhow::{Context, Result};
+use reqwest::Client;
 use std::collections::BTreeMap;
 
 /// Target systems that appear as the trailing component of an installer name.
 /// Listed because they contain a `-` themselves, so the name cannot simply be
 /// split on that character.
+///
+/// Kept in step with the systems the installers are built for; the name is
+/// assembled in `nix/internal/any-darwin.nix:26`.
 const KNOWN_SYSTEMS: [&str; 4] = [
     "x86_64-linux",
     "x86_64-darwin",
@@ -52,17 +56,116 @@ pub fn rev_from_filename(filename: &str) -> Option<&str> {
     Some(rev)
 }
 
-/// True when `full` and `short` name the same commit.
+/// Shortest abbreviation accepted when comparing two revisions.
 ///
-/// `meta.json` carries the full 40-character revision while a filename carries
-/// the first nine, so one is compared as a prefix of the other.
+/// Installer names carry nine characters. Anything shorter is not a revision
+/// this tool produced, and treating it as a prefix would make the comparison
+/// far weaker than it looks — `same_commit("a", …)` should not be true.
+const MIN_REV_LEN: usize = 7;
+
+/// True when two revisions name the same commit.
+///
+/// The GitHub API and `meta.json` carry the full 40 characters while a
+/// filename carries the first nine, so the shorter is compared as a prefix of
+/// the longer. Abbreviations below `MIN_REV_LEN` never match.
 fn same_commit(left: &str, right: &str) -> bool {
     let (shorter, longer) = if left.len() <= right.len() {
         (left, right)
     } else {
         (right, left)
     };
-    !shorter.is_empty() && longer.starts_with(shorter)
+    shorter.len() >= MIN_REV_LEN && longer.starts_with(shorter)
+}
+
+/// Resolve a release tag to the commit it names, via the GitHub REST API.
+///
+/// `drt` runs where there is no git: the `ops` shell provides the binary and
+/// gnupg and nothing else, and the tool otherwise reaches the network only
+/// over HTTPS. So the tag is resolved the same way everything else is
+/// fetched.
+///
+/// An annotated tag resolves to a tag object rather than a commit, which then
+/// has to be peeled. `GITHUB_TOKEN` is used when present — a public repository
+/// needs no credentials, but the unauthenticated limit is 60 requests an hour
+/// and shared by IP.
+pub async fn resolve_tag_commit(client: &Client, repo: &str, tag: &str) -> Result<String> {
+    // Note the ref is given without the `refs/` prefix: the endpoint is
+    // `git/ref/tags/<tag>`, and `git/ref/refs/tags/<tag>` returns 404.
+    let object = fetch_git_object(
+        client,
+        &format!("https://api.github.com/repos/{repo}/git/ref/tags/{tag}"),
+    )
+    .await
+    .with_context(|| format!("resolving tag {tag} in {repo}"))?
+    .ok_or_else(|| {
+        anyhow::anyhow!(
+            "tag {tag} does not exist in {repo}. Publishing asserts that this \
+             version corresponds to a commit; without the tag there is nothing \
+             to check that against. Create the tag, or pass --skip-tag-check if \
+             it is deliberately absent."
+        )
+    })?;
+
+    match object.kind.as_str() {
+        // Lightweight tag: already the commit.
+        "commit" => Ok(object.sha),
+        // Annotated tag: peel it to the commit it points at.
+        "tag" => {
+            let peeled = fetch_git_object(
+                client,
+                &format!(
+                    "https://api.github.com/repos/{repo}/git/tags/{}",
+                    object.sha
+                ),
+            )
+            .await
+            .with_context(|| format!("peeling annotated tag {tag} in {repo}"))?
+            .ok_or_else(|| anyhow::anyhow!("tag object {} vanished while peeling", object.sha))?;
+            Ok(peeled.sha)
+        }
+        other => anyhow::bail!("tag {tag} in {repo} points at a {other}, not a commit"),
+    }
+}
+
+/// The `object` field shared by the ref and tag endpoints.
+struct GitObject {
+    sha: String,
+    kind: String,
+}
+
+/// `None` when the resource does not exist; `Err` for anything else.
+async fn fetch_git_object(client: &Client, url: &str) -> Result<Option<GitObject>> {
+    let response = client
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await?;
+
+    if response.status() == reqwest::StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        anyhow::bail!("GET {url} returned {status}: {}", body.trim());
+    }
+
+    let body: serde_json::Value = response.json().await?;
+    let object = body
+        .get("object")
+        .ok_or_else(|| anyhow::anyhow!("GET {url} returned no 'object' field"))?;
+    Ok(Some(GitObject {
+        sha: object
+            .get("sha")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("GET {url} returned no object.sha"))?
+            .to_string(),
+        kind: object
+            .get("type")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("GET {url} returned no object.type"))?
+            .to_string(),
+    }))
 }
 
 /// Verify that everything about to be uploaded was built from one commit, and
@@ -238,5 +341,13 @@ mod tests {
             "8f9737937"
         ));
         assert!(!same_commit("", "8f9737937"));
+        // Abbreviations too short to be one of ours never match, however
+        // tempting a prefix they make.
+        assert!(!same_commit("8", "8f9737937"));
+        assert!(!same_commit("8f973", "8f9737937"));
+        assert!(same_commit(
+            "8f97379",
+            "8f9737937d346e847c9c29c965fba7aa44136612"
+        ));
     }
 }


### PR DESCRIPTION
Publishing a release asserts that a version corresponds to a commit. Nothing established that assertion — `drt release` uploaded whatever was in the directory it was pointed at, and `release-cli` had no release validation of any kind.

## Why the check is at publish time and not at tag time

A tag is reachable from its branch when it is created, and can stop being reachable afterwards: a history rewrite orphans one silently. The artifacts are built after that point. So "is the tag an ancestor of the branch" answers the question at a moment when it is not yet possible to get the wrong answer.

Comparing the revision recorded in the artifacts against the commit the tag resolves to settles it at the only moment that matters. It is indifferent to when the tag was created and unaffected by a rewrite.

## What it refuses

Before anything is hashed, signed or uploaded:

| Condition | Why |
|---|---|
| An installer name yields no revision | The artifact's provenance cannot be established |
| Installers do not all carry the same revision | A directory holding two builds cannot be released as one |
| The revision is the `dirty` marker | The source tree was not clean, so the commit is unknown and the build unreproducible |
| `meta.json` records a different `gitrev` | The directory holds artifacts from a different build than its metadata describes |
| The tag resolves to a different commit | Publishing would claim a version corresponds to a commit it was not built from |
| The tag does not exist | There is nothing to check the claim against |

## Resolving the tag

`git ls-remote`, so no checkout is required. `refs/tags/<v>^{}` is requested alongside `refs/tags/<v>` so an annotated tag yields the commit rather than the tag object.

- `--repo-url` overrides the remote (defaults to this repository)
- `--skip-tag-check` disables that half while leaving the artifact-consistency checks in force. It is deliberately awkward to reach, and prints that it was used.

## Reading the revision out of a filename

Names are `daedalus-<version>-<build>-<cluster>-<revShort>-<system>.<ext>` (`nix/internal/any-darwin.nix:26`). Two traps, both covered by tests:

- **The build counter is decimal, so it is also valid hex.** `daedalus-11.2.0-86185-…` — searching for "the field that looks like a hash" can return `86185`. Position disambiguates; pattern matching does not.
- **The system component contains a dash**, and a prerelease version may too, so the name cannot be parsed by counting fields from the left. It is parsed from the right against the known target systems.

## Verification

Unit tests, run under the pinned toolchain — 9 pass, 7 new:

```
$ nix develop .#release-cli --command cargo test --locked
test provenance::tests::build_counter_is_not_mistaken_for_a_revision ... ok
test provenance::tests::version_containing_a_dash_is_handled ... ok
test provenance::tests::rev_from_every_target_system ... ok
test provenance::tests::short_and_full_revisions_compare_equal ... ok
test provenance::tests::unrecognised_names_yield_nothing ... ok
test provenance::tests::dirty_tree_marker_is_read_back ... ok
test provenance::tests::rev_from_linux_installer_name ... ok
test result: ok. 9 passed; 0 failed
```

End to end against a built `drt` and a real tag:

```
=== matching artifacts and tag ===
  provenance: 8f9737937 matches tag 11.2.0 (8f9737937d346e847c9c29c965fba7aa44136612)

=== artifacts from a different commit than the tag ===
Error: tag 11.2.0 points at 8f9737937…, but the installers were built from fa8258757.
Publishing would claim a version corresponds to a commit it was not built from.

=== two commits in one directory ===
Error: installers were built from more than one commit, so they cannot be released together:
  8f9737937: daedalus-…-x86_64-linux.bin
  fa8258757: daedalus-…-x86_64-darwin.pkg

=== dirty source tree ===
Error: installers were built from a dirty source tree, so the commit they correspond to
is unknown and unreproducible
```

`drt-clippy`, `treefmt` and `shellcheck` all pass. Note that local `cargo` cannot build this crate — the AWS SDK requires rustc 1.91.1 and the system toolchain here is 1.88.0 — so both clippy and the tests must be run through Nix, which supplies the pinned 1.95.0 toolchain.

`cmd_release`'s parameters moved into a struct: nine positional arguments trip `clippy::too_many_arguments`, and grouping them reads better than an `allow`.
