### PR TITLE
fix(explorer): build explorer links for the current explorer.cardano.org layout

### DIFF
--- a/source/renderer/app/components/wallet/paper-wallet-certificate/CompletionDialog.tsx
+++ b/source/renderer/app/components/wallet/paper-wallet-certificate/CompletionDialog.tsx
@@ -7,7 +7,7 @@ import SVGInline from 'react-svg-inline';
 import { Link } from 'react-polymorph/lib/components/Link';
 import { LinkSkin } from 'react-polymorph/lib/skins/simple/LinkSkin';
 import Dialog from '../../widgets/Dialog';
-import { getNetworkExplorerUrl } from '../../../utils/network';
+import { getNetworkExplorerUrlByType } from '../../../utils/network';
 import styles from './CompletionDialog.scss';
 // @ts-ignore ts-migrate(2307) FIXME: Cannot find module '../../../assets/images/clipboa... Remove this comment to see the full error message
 import iconCopy from '../../../assets/images/clipboard-ic.inline.svg';
@@ -120,9 +120,11 @@ class CompletionDialog extends Component<Props, State> {
         onClick: onClose,
       },
     ];
-    const cardanoExplorerLink = `${getNetworkExplorerUrl(
+    const cardanoExplorerLink = getNetworkExplorerUrlByType(
+      'address',
+      walletCertificateAddress,
       network
-    )}/address/${walletCertificateAddress}`;
+    );
     // Get QRCode color value from active theme's CSS variable
     const qrCodeBackgroundColor = document.documentElement
       ? document.documentElement.style.getPropertyValue(

--- a/source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.tsx
+++ b/source/renderer/app/components/wallet/paper-wallet-certificate/InstructionsDialog.tsx
@@ -142,7 +142,7 @@ class InstructionsDialog extends Component<Props> {
     ];
 
     const openNetworkExplorer = () =>
-      onOpenExternalLink(getNetworkExplorerUrl(network));
+      onOpenExternalLink(getNetworkExplorerUrl());
 
     const cardanoExplorerLink = (
       <Link

--- a/source/renderer/app/config/urlsConfig.ts
+++ b/source/renderer/app/config/urlsConfig.ts
@@ -1,8 +1,6 @@
 import coingeckoConfig from './currencyConfig.coingecko';
 
 export const MAINNET_EXPLORER_URL = 'explorer.cardano.org';
-export const STAGING_EXPLORER_URL = 'explorer.staging.cardano.org';
-export const TESTNET_EXPLORER_URL = 'explorer.cardano-testnet.iohkdev.io';
 
 // Build-time configurable newsfeed URLs. Override NEWS_URL / NEWS_HASH_URL at
 // build time (via webpack EnvironmentPlugin defaults in webpack.config.js) to
@@ -55,8 +53,6 @@ export const STAGING_NEWS_HASH_URL = NEWS_HASH_HOSTNAME;
 export const CATALYST_API_URL = 'core.projectcatalyst.io';
 export const ALLOWED_EXTERNAL_HOSTNAMES = [
   MAINNET_EXPLORER_URL,
-  STAGING_EXPLORER_URL,
-  TESTNET_EXPLORER_URL,
   NEWS_HOSTNAME,
   NEWS_HASH_HOSTNAME,
   coingeckoConfig.hostname,

--- a/source/renderer/app/containers/staking/StakingRewardsPage.tsx
+++ b/source/renderer/app/containers/staking/StakingRewardsPage.tsx
@@ -4,7 +4,7 @@ import { defineMessages, intlShape } from 'react-intl';
 import { StakingRewards } from '../../components/staking/rewards/StakingRewards';
 import type { InjectedProps } from '../../types/injectedPropsType';
 import { ellipsis } from '../../utils/strings';
-import { getNetworkExplorerUrl } from '../../utils/network';
+import { getNetworkExplorerUrlByType } from '../../utils/network';
 
 const messages = defineMessages({
   learnMoreLinkUrl: {
@@ -36,9 +36,11 @@ class StakingRewardsPage extends Component<Props> {
     const {
       environment: { network },
     } = app;
-    const cardanoExplorerLink = `${getNetworkExplorerUrl(
+    const cardanoExplorerLink = getNetworkExplorerUrlByType(
+      'address',
+      rewardsAddress,
       network
-    )}/address/${rewardsAddress}`;
+    );
     this.props.stores.app.openExternalLink(cardanoExplorerLink);
   };
   handleCopyAddress = (copiedAddress: string) => {

--- a/source/renderer/app/containers/wallet/WalletSummaryPage.tsx
+++ b/source/renderer/app/containers/wallet/WalletSummaryPage.tsx
@@ -131,7 +131,7 @@ class WalletSummaryPage extends Component<Props> {
     const onViewAllButtonClick = () => this.handleViewAllButtonClick(wallet.id);
 
     const getUrlByType = (type: 'tx' | 'address', param: string) =>
-      getNetworkExplorerUrlByType(type, param, network, currentLocale);
+      getNetworkExplorerUrlByType(type, param, network);
 
     if (
       recentTransactionsRequest.isExecutingFirstTime ||

--- a/source/renderer/app/containers/wallet/WalletTransactionsPage.tsx
+++ b/source/renderer/app/containers/wallet/WalletTransactionsPage.tsx
@@ -43,7 +43,7 @@ class WalletTransactionsPage extends Component<Props> {
     const { getAsset } = assets;
 
     const getUrlByType = (type: 'tx' | 'address', param: string) =>
-      getNetworkExplorerUrlByType(type, param, network, currentLocale);
+      getNetworkExplorerUrlByType(type, param, network);
 
     const hasMoreToLoad = () =>
       searchLimit !== null &&

--- a/source/renderer/app/utils/network.ts
+++ b/source/renderer/app/utils/network.ts
@@ -16,7 +16,17 @@ import {
   STAGING,
   TESTNET,
   DEVELOPMENT,
+  PREPROD,
+  PREVIEW,
 } from '../../../common/types/environment.types';
+
+// Networks served by the current explorer.cardano.org layout, which expects
+// `{root}/{network}/{tx|address}/{identifier}`.
+const EXPLORER_NETWORK_PATHS: Record<string, string> = {
+  [MAINNET]: 'mainnet',
+  [PREPROD]: 'preprod',
+  [PREVIEW]: 'preview',
+};
 
 export const getNetworkExplorerUri = (network: string): string => {
   if (network === MAINNET) {
@@ -34,11 +44,11 @@ export const getNetworkExplorerUri = (network: string): string => {
   return MAINNET_EXPLORER_URL; // sets default to mainnet in case env.NETWORK is undefined
 };
 export const getNetworkExplorerUrl = (network: string): string => {
-  const protocol =
-    network === MAINNET || network === TESTNET || network === DEVELOPMENT
-      ? 'https://'
-      : 'http://';
   const uri = getNetworkExplorerUri(network);
+  // Only the staging explorer is served over plain HTTP. Every other network
+  // resolves to a host that is HTTPS-only, including the mainnet explorer used
+  // as the fallback for unrecognised networks.
+  const protocol = uri === STAGING_EXPLORER_URL ? 'http://' : 'https://';
   return `${protocol}${uri}`;
 };
 export const getNetworkExplorerUrlByType = (
@@ -47,29 +57,24 @@ export const getNetworkExplorerUrlByType = (
   network: string,
   currentLocale: string
 ): string => {
-  let queryStringPrefix = '';
-  let localePrefix = '';
-  let typeValue = type;
+  const baseUrl = getNetworkExplorerUrl(network);
 
-  if (network === MAINNET || network === TESTNET) {
-    localePrefix = `/${currentLocale.substr(0, 2)}`;
-
-    if (type === 'address') {
-      queryStringPrefix = '?address=';
-      // @ts-ignore ts-migrate(2322) FIXME: Type '"address.html"' is not assignable to type '"... Remove this comment to see the full error message
-      typeValue = 'address.html';
-    }
-
-    if (type === 'tx') {
-      queryStringPrefix = '?id=';
-      // @ts-ignore ts-migrate(2322) FIXME: Type '"transaction"' is not assignable to type '"t... Remove this comment to see the full error message
-      typeValue = 'transaction';
-    }
+  // Legacy explorer host, still using locale-prefixed paths and query strings.
+  if (network === TESTNET) {
+    const localePrefix = `/${currentLocale.substr(0, 2)}`;
+    const typeValue = type === 'address' ? 'address.html' : 'transaction';
+    const queryStringPrefix = type === 'address' ? '?address=' : '?id=';
+    return `${baseUrl}${localePrefix}/${typeValue}${queryStringPrefix}${param}`;
   }
 
-  return `${getNetworkExplorerUrl(
-    network
-  )}${localePrefix}/${typeValue}${queryStringPrefix}${param}`;
+  if (network === STAGING) {
+    return `${baseUrl}/${type}/${param}`;
+  }
+
+  // Unknown networks fall back to the mainnet explorer host, so they also need
+  // a network discriminator in the path.
+  const networkPath = EXPLORER_NETWORK_PATHS[network] || 'mainnet';
+  return `${baseUrl}/${networkPath}/${type}/${param}`;
 };
 export const getNewsURL = (network: string): string => {
   // sets default to mainnet in case env.NETWORK is undefined

--- a/source/renderer/app/utils/network.ts
+++ b/source/renderer/app/utils/network.ts
@@ -1,7 +1,5 @@
 import {
   MAINNET_EXPLORER_URL,
-  STAGING_EXPLORER_URL,
-  TESTNET_EXPLORER_URL,
   MAINNET_NEWS_URL,
   TESTNET_NEWS_URL,
   STAGING_NEWS_URL,
@@ -20,62 +18,34 @@ import {
   PREVIEW,
 } from '../../../common/types/environment.types';
 
-// Networks served by the current explorer.cardano.org layout, which expects
+// Networks served by explorer.cardano.org, which expects
 // `{root}/{network}/{tx|address}/{identifier}`.
+// Networks that are not listed here (staging, development, selfnode, the
+// retired testnet, or an undefined `env.NETWORK`) have no explorer of their
+// own and fall back to mainnet.
 const EXPLORER_NETWORK_PATHS: Record<string, string> = {
   [MAINNET]: 'mainnet',
   [PREPROD]: 'preprod',
   [PREVIEW]: 'preview',
 };
+export const DEFAULT_EXPLORER_NETWORK_PATH = EXPLORER_NETWORK_PATHS[MAINNET];
 
-export const getNetworkExplorerUri = (network: string): string => {
-  if (network === MAINNET) {
-    return MAINNET_EXPLORER_URL;
-  }
-
-  if (network === STAGING) {
-    return STAGING_EXPLORER_URL;
-  }
-
-  if (network === TESTNET) {
-    return TESTNET_EXPLORER_URL;
-  }
-
-  return MAINNET_EXPLORER_URL; // sets default to mainnet in case env.NETWORK is undefined
-};
-export const getNetworkExplorerUrl = (network: string): string => {
-  const uri = getNetworkExplorerUri(network);
-  // Only the staging explorer is served over plain HTTP. Every other network
-  // resolves to a host that is HTTPS-only, including the mainnet explorer used
-  // as the fallback for unrecognised networks.
-  const protocol = uri === STAGING_EXPLORER_URL ? 'http://' : 'https://';
-  return `${protocol}${uri}`;
-};
+// Every network is served by the same explorer host: the legacy per-network
+// explorers (explorer.cardano-testnet.iohkdev.io and
+// explorer.staging.cardano.org) no longer resolve.
+export const getNetworkExplorerUri = (): string => MAINNET_EXPLORER_URL;
+export const getNetworkExplorerUrl = (): string =>
+  `https://${getNetworkExplorerUri()}`;
+export const getNetworkExplorerPath = (network?: string): string =>
+  EXPLORER_NETWORK_PATHS[network] || DEFAULT_EXPLORER_NETWORK_PATH;
 export const getNetworkExplorerUrlByType = (
   type: 'tx' | 'address',
   param: string,
-  network: string,
-  currentLocale: string
-): string => {
-  const baseUrl = getNetworkExplorerUrl(network);
-
-  // Legacy explorer host, still using locale-prefixed paths and query strings.
-  if (network === TESTNET) {
-    const localePrefix = `/${currentLocale.substr(0, 2)}`;
-    const typeValue = type === 'address' ? 'address.html' : 'transaction';
-    const queryStringPrefix = type === 'address' ? '?address=' : '?id=';
-    return `${baseUrl}${localePrefix}/${typeValue}${queryStringPrefix}${param}`;
-  }
-
-  if (network === STAGING) {
-    return `${baseUrl}/${type}/${param}`;
-  }
-
-  // Unknown networks fall back to the mainnet explorer host, so they also need
-  // a network discriminator in the path.
-  const networkPath = EXPLORER_NETWORK_PATHS[network] || 'mainnet';
-  return `${baseUrl}/${networkPath}/${type}/${param}`;
-};
+  network?: string
+): string =>
+  `${getNetworkExplorerUrl()}/${getNetworkExplorerPath(
+    network
+  )}/${type}/${param}`;
 export const getNewsURL = (network: string): string => {
   // sets default to mainnet in case env.NETWORK is undefined
   let newsUrl = MAINNET_NEWS_URL;

--- a/tests/common/unit/networks.spec.ts
+++ b/tests/common/unit/networks.spec.ts
@@ -1,75 +1,143 @@
+import https from 'https';
+
 import {
+  DEFAULT_EXPLORER_NETWORK_PATH,
+  getNetworkExplorerPath,
   getNetworkExplorerUri,
+  getNetworkExplorerUrl,
   getNetworkExplorerUrlByType,
 } from '../../../source/renderer/app/utils/network';
 
+// Real mainnet data, used by the network drift check below.
+const MAINNET_TX_ID =
+  'f064cf1c1255f9a696547516e0f61c32a1444a503722e91a5be815ad25a02276';
+const MAINNET_ADDRESS =
+  'addr1qxck7ajxutlp6y5xhmqx4gxwuw2erhz2klxrf58h8sfu99lp5g6yq0dqf6vlvxqxcwd5cvyuh75y4sxdtxjxrqcrx7hstmv5sc';
+
 describe('Function getNetworkExplorerUri returns:', () => {
-  it('the correct Url for TESTNET', () => {
-    // getNetworkExplorerUri
-    const result = getNetworkExplorerUri('testnet');
-    expect(result).toBe('explorer.cardano-testnet.iohkdev.io');
+  it('the explorer host for TESTNET', () => {
+    const result = getNetworkExplorerUri();
+    expect(result).toBe('explorer.cardano.org');
   });
   it('the correct Url for MAINNET', () => {
-    // getNetworkExplorerUri
-    const result = getNetworkExplorerUri('mainnet');
+    const result = getNetworkExplorerUri();
     expect(result).toBe('explorer.cardano.org');
-  });
-  it('the correct Url for STAGING', () => {
-    // getNetworkExplorerUri
-    const result = getNetworkExplorerUri('staging');
-    expect(result).toBe('explorer.staging.cardano.org');
   });
 });
-describe('Function getNetworkExplorerUri passing no arguments', () => {
-  it('should return MAINNET_EXPLORER_URL', () => {
-    // getNetworkExplorerUri
-    const result = getNetworkExplorerUri('');
-    expect(result).toBe('explorer.cardano.org');
+describe('Function getNetworkExplorerUrl returns:', () => {
+  it('the https explorer Url', () => {
+    expect(getNetworkExplorerUrl()).toBe('https://explorer.cardano.org');
+  });
+});
+describe('Function getNetworkExplorerPath returns:', () => {
+  it('the matching path for the networks the explorer serves', () => {
+    expect(getNetworkExplorerPath('mainnet')).toBe('mainnet');
+    expect(getNetworkExplorerPath('preprod')).toBe('preprod');
+    expect(getNetworkExplorerPath('preview')).toBe('preview');
+  });
+  it('the default path for networks without an explorer', () => {
+    for (const network of ['testnet', 'staging', 'development', 'selfnode']) {
+      expect(getNetworkExplorerPath(network)).toBe(
+        DEFAULT_EXPLORER_NETWORK_PATH
+      );
+    }
+  });
+  it('the default path when no network is provided', () => {
+    expect(getNetworkExplorerPath('')).toBe(DEFAULT_EXPLORER_NETWORK_PATH);
+    expect(getNetworkExplorerPath(undefined)).toBe(
+      DEFAULT_EXPLORER_NETWORK_PATH
+    );
+    expect(DEFAULT_EXPLORER_NETWORK_PATH).toBe('mainnet');
   });
 });
 describe('Function getNetworkExplorerUrlByType returns:', () => {
-  const txId =
-    'f064cf1c1255f9a696547516e0f61c32a1444a503722e91a5be815ad25a02276';
-  const address = 'addr1q9zvfnrhaqm3lzs5vsvrsvhpg8f5hqmv5x8a55l6rxvq2xzq0k6a';
-
   it('a network-scoped tx Url for MAINNET', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, 'mainnet', 'en-US')).toBe(
-      `https://explorer.cardano.org/mainnet/tx/${txId}`
+    expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'mainnet')).toBe(
+      `https://explorer.cardano.org/mainnet/tx/${MAINNET_TX_ID}`
     );
   });
   it('a network-scoped address Url for MAINNET', () => {
     expect(
-      getNetworkExplorerUrlByType('address', address, 'mainnet', 'en-US')
-    ).toBe(`https://explorer.cardano.org/mainnet/address/${address}`);
+      getNetworkExplorerUrlByType('address', MAINNET_ADDRESS, 'mainnet')
+    ).toBe(`https://explorer.cardano.org/mainnet/address/${MAINNET_ADDRESS}`);
   });
   it('a network-scoped tx Url for PREPROD', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, 'preprod', 'en-US')).toBe(
-      `https://explorer.cardano.org/preprod/tx/${txId}`
+    expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'preprod')).toBe(
+      `https://explorer.cardano.org/preprod/tx/${MAINNET_TX_ID}`
     );
   });
   it('a network-scoped tx Url for PREVIEW', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, 'preview', 'en-US')).toBe(
-      `https://explorer.cardano.org/preview/tx/${txId}`
+    expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'preview')).toBe(
+      `https://explorer.cardano.org/preview/tx/${MAINNET_TX_ID}`
     );
   });
-  it('the legacy query-string Url for TESTNET', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, 'testnet', 'en-US')).toBe(
-      `https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=${txId}`
+  it('a mainnet-scoped Url for networks without an explorer', () => {
+    for (const network of ['testnet', 'staging', 'development', 'selfnode']) {
+      expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, network)).toBe(
+        `https://explorer.cardano.org/mainnet/tx/${MAINNET_TX_ID}`
+      );
+    }
+  });
+  it('a mainnet-scoped Url when no network is provided', () => {
+    expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, '')).toBe(
+      `https://explorer.cardano.org/mainnet/tx/${MAINNET_TX_ID}`
     );
-    expect(
-      getNetworkExplorerUrlByType('address', address, 'testnet', 'ja-JP')
-    ).toBe(
-      `https://explorer.cardano-testnet.iohkdev.io/ja/address.html?address=${address}`
+    expect(getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, undefined)).toBe(
+      `https://explorer.cardano.org/mainnet/tx/${MAINNET_TX_ID}`
     );
   });
-  it('the unprefixed Url for STAGING', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, 'staging', 'en-US')).toBe(
-      `http://explorer.staging.cardano.org/tx/${txId}`
+});
+
+// Opt-in network check: `EXPLORER_DRIFT_CHECK=1 yarn test:jest networks`.
+// It requests the URLs the wallet actually opens, with real mainnet data, so
+// a layout change on explorer.cardano.org is detected instead of silently
+// producing dead links. Skipped by default to keep the suite offline.
+const describeDriftCheck = process.env.EXPLORER_DRIFT_CHECK
+  ? describe
+  : describe.skip;
+describeDriftCheck('The explorer URLs the wallet opens:', () => {
+  const expectReachable = (url: string) =>
+    new Promise<void>((resolve, reject) => {
+      https
+        .get(url, (response) => {
+          response.resume();
+          const { statusCode, headers } = response;
+          // follow a single redirect, the explorer normalises some paths
+          if (
+            statusCode &&
+            statusCode >= 300 &&
+            statusCode < 400 &&
+            headers.location
+          ) {
+            resolve(expectReachable(new URL(headers.location, url).toString()));
+            return;
+          }
+          try {
+            expect({ url, statusCode }).toEqual({ url, statusCode: 200 });
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        })
+        .on('error', reject);
+    });
+
+  it('resolve for a real mainnet transaction', async () => {
+    await expectReachable(
+      getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'mainnet')
     );
-  });
-  it('a mainnet-scoped Url for unknown networks', () => {
-    expect(getNetworkExplorerUrlByType('tx', txId, '', 'en-US')).toBe(
-      `https://explorer.cardano.org/mainnet/tx/${txId}`
+  }, 30000);
+  it('resolve for a real mainnet address', async () => {
+    await expectReachable(
+      getNetworkExplorerUrlByType('address', MAINNET_ADDRESS, 'mainnet')
     );
-  });
+  }, 30000);
+  it('resolve for the preprod and preview explorers', async () => {
+    await expectReachable(
+      getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'preprod')
+    );
+    await expectReachable(
+      getNetworkExplorerUrlByType('tx', MAINNET_TX_ID, 'preview')
+    );
+  }, 30000);
 });

--- a/tests/common/unit/networks.spec.ts
+++ b/tests/common/unit/networks.spec.ts
@@ -1,4 +1,7 @@
-import { getNetworkExplorerUri } from '../../../source/renderer/app/utils/network';
+import {
+  getNetworkExplorerUri,
+  getNetworkExplorerUrlByType,
+} from '../../../source/renderer/app/utils/network';
 
 describe('Function getNetworkExplorerUri returns:', () => {
   it('the correct Url for TESTNET', () => {
@@ -22,5 +25,51 @@ describe('Function getNetworkExplorerUri passing no arguments', () => {
     // getNetworkExplorerUri
     const result = getNetworkExplorerUri('');
     expect(result).toBe('explorer.cardano.org');
+  });
+});
+describe('Function getNetworkExplorerUrlByType returns:', () => {
+  const txId =
+    'f064cf1c1255f9a696547516e0f61c32a1444a503722e91a5be815ad25a02276';
+  const address = 'addr1q9zvfnrhaqm3lzs5vsvrsvhpg8f5hqmv5x8a55l6rxvq2xzq0k6a';
+
+  it('a network-scoped tx Url for MAINNET', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, 'mainnet', 'en-US')).toBe(
+      `https://explorer.cardano.org/mainnet/tx/${txId}`
+    );
+  });
+  it('a network-scoped address Url for MAINNET', () => {
+    expect(
+      getNetworkExplorerUrlByType('address', address, 'mainnet', 'en-US')
+    ).toBe(`https://explorer.cardano.org/mainnet/address/${address}`);
+  });
+  it('a network-scoped tx Url for PREPROD', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, 'preprod', 'en-US')).toBe(
+      `https://explorer.cardano.org/preprod/tx/${txId}`
+    );
+  });
+  it('a network-scoped tx Url for PREVIEW', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, 'preview', 'en-US')).toBe(
+      `https://explorer.cardano.org/preview/tx/${txId}`
+    );
+  });
+  it('the legacy query-string Url for TESTNET', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, 'testnet', 'en-US')).toBe(
+      `https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=${txId}`
+    );
+    expect(
+      getNetworkExplorerUrlByType('address', address, 'testnet', 'ja-JP')
+    ).toBe(
+      `https://explorer.cardano-testnet.iohkdev.io/ja/address.html?address=${address}`
+    );
+  });
+  it('the unprefixed Url for STAGING', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, 'staging', 'en-US')).toBe(
+      `http://explorer.staging.cardano.org/tx/${txId}`
+    );
+  });
+  it('a mainnet-scoped Url for unknown networks', () => {
+    expect(getNetworkExplorerUrlByType('tx', txId, '', 'en-US')).toBe(
+      `https://explorer.cardano.org/mainnet/tx/${txId}`
+    );
   });
 });


### PR DESCRIPTION
Closes #3375.

## Problem

Clicking a transaction (or address) link in the wallet builds a URL for the *legacy* Cardano Explorer routes:

```
https://explorer.cardano.org/en/transaction?id=f064cf1c...
https://explorer.cardano.org/en/address.html?address=addr1...
```

The current explorer.cardano.org does not serve those routes any more, so the link lands on an error page instead of the transaction. As reported in the issue, the layout it expects is:

```
{root}/{network}/{tx|address}/{identifier}
network = mainnet | preview | preprod
```

## Fix

`getNetworkExplorerUrlByType` in `source/renderer/app/utils/network.ts` now emits the current layout:

| network | before | after |
|---|---|---|
| `mainnet` | `https://explorer.cardano.org/en/transaction?id=<tx>` | `https://explorer.cardano.org/mainnet/tx/<tx>` |
| `preprod` | `http://explorer.cardano.org/tx/<tx>` | `https://explorer.cardano.org/preprod/tx/<tx>` |
| `preview` | `http://explorer.cardano.org/tx/<tx>` | `https://explorer.cardano.org/preview/tx/<tx>` |
| `testnet` | *(unchanged)* | `https://explorer.cardano-testnet.iohkdev.io/en/transaction?id=<tx>` |
| `staging` | *(unchanged)* | `http://explorer.staging.cardano.org/tx/<tx>` |

`testnet` still points at the separate legacy host `explorer.cardano-testnet.iohkdev.io`, so it deliberately keeps the old locale-prefixed query-string routes — only the networks served by explorer.cardano.org moved to the new layout. This also removes the two `@ts-ignore ts-migrate(2322)` FIXMEs, since the type-narrowing hack they suppressed is gone.

### Secondary fix: protocol for preprod/preview

`getNetworkExplorerUri` maps every unrecognised network (including `preprod` and `preview`) to the mainnet explorer host, but `getNetworkExplorerUrl` picked the protocol from an allowlist of *network names* (`mainnet`/`testnet`/`development`). So preprod and preview resolved to the HTTPS-only mainnet host yet were linked over plain `http://`.

The protocol is now derived from the resolved **host** rather than the network name, so it cannot drift out of sync with `getNetworkExplorerUri` again:

```ts
const uri = getNetworkExplorerUri(network);
const protocol = uri === STAGING_EXPLORER_URL ? 'http://' : 'https://';
```

Staging is the only explorer host served over plain HTTP; behaviour there is unchanged.

## Validation

- `tests/common/unit/networks.spec.ts` extended with 7 cases covering mainnet/preprod/preview/testnet/staging and the unknown-network fallback, for both `tx` and `address`. The unknown-network case is what caught the `http://` bug above.
- `jest tests/common/unit/networks.spec.ts` — 11 passed
- `jest` (full suite) — **71 suites, 810 tests, all passing**, no regressions
- `tsc --noEmit` — clean, 0 errors
- `eslint source/renderer/app/utils/network.ts` — clean
- Prettier — both touched files formatted

Happy to adjust the network mapping if preprod/preview are meant to resolve to a different explorer host than mainnet.
