### PR TITLE
Allow overriding Chromium's device scale factor and Electron flags

### DIFF
--- a/nix/internal/x86_64-linux.nix
+++ b/nix/internal/x86_64-linux.nix
@@ -386,7 +386,11 @@ in rec {
             exit 0
           fi
 
-          exec electron --disable-setuid-sandbox --no-sandbox "$ENTRYPOINT_DIR"/libexec/daedalus-js "$@"
+          # Escape hatch for Linux-only Chromium switches that have no cross-platform
+          # equivalent, e.g. `DAEDALUS_ELECTRON_FLAGS=--ozone-platform=wayland`. Left
+          # unquoted on purpose, so that several flags can be passed at once.
+          # shellcheck disable=SC2086
+          exec electron ''${DAEDALUS_ELECTRON_FLAGS-} --disable-setuid-sandbox --no-sandbox "$ENTRYPOINT_DIR"/libexec/daedalus-js "$@"
         ''} $out/libexec/daedalus-frontend
 
         cp ${pkgs.writeText "update-runner" ''

--- a/source/main/index.ts
+++ b/source/main/index.ts
@@ -81,6 +81,23 @@ if (isBlankScreenFixActive) {
   app.disableHardwareAcceleration();
 }
 
+// Chromium sizes windows in device-independent pixels, so the minimum content
+// size set in `createMainWindow` is multiplied by the device scale factor that
+// Chromium detects (from `Xft.dpi` on X11, or the compositor on Wayland). On a
+// HiDPI display that can make the window too large to fit the screen at all.
+// `DAEDALUS_DEVICE_SCALE_FACTOR` overrides the detected value — note it is
+// absolute, not a multiplier, so e.g. `1.5` on a display Chromium reports as
+// `2.0` scales the UI down. It has to be applied before the app is ready, like
+// `disableHardwareAcceleration` above.
+const deviceScaleFactor = Number(process.env.DAEDALUS_DEVICE_SCALE_FACTOR);
+
+if (deviceScaleFactor > 0 && Number.isFinite(deviceScaleFactor)) {
+  app.commandLine.appendSwitch(
+    'force-device-scale-factor',
+    String(deviceScaleFactor)
+  );
+}
+
 // Increase maximum event listeners to avoid IPC channel stalling
 // (1/2) this line increases the limit for the main process
 EventEmitter.defaultMaxListeners = 100; // Default: 10

--- a/source/main/index.ts
+++ b/source/main/index.ts
@@ -54,6 +54,7 @@ import {
 } from './utils/rtsFlagsSettings';
 import { toggleRTSFlagsModeChannel } from './ipc/toggleRTSFlagsModeChannel';
 import { containsRTSFlags } from './utils/containsRTSFlags';
+import { parseDeviceScaleFactor } from './utils/parseDeviceScaleFactor';
 import { setMithrilBootstrapNodeStateProvider } from './ipc/mithrilBootstrapChannel';
 import { configureMithrilPartialSyncRuntime } from './ipc/mithrilPartialSyncChannel';
 import { getMithrilController } from './mithril/MithrilController';
@@ -83,15 +84,14 @@ if (isBlankScreenFixActive) {
 
 // Chromium sizes windows in device-independent pixels, so the minimum content
 // size set in `createMainWindow` is multiplied by the device scale factor that
-// Chromium detects (from `Xft.dpi` on X11, or the compositor on Wayland). On a
-// HiDPI display that can make the window too large to fit the screen at all.
-// `DAEDALUS_DEVICE_SCALE_FACTOR` overrides the detected value — note it is
-// absolute, not a multiplier, so e.g. `1.5` on a display Chromium reports as
-// `2.0` scales the UI down. It has to be applied before the app is ready, like
+// Chromium detects. On a HiDPI display that can make the window too large to
+// fit the screen at all. This has to be applied before the app is ready, like
 // `disableHardwareAcceleration` above.
-const deviceScaleFactor = Number(process.env.DAEDALUS_DEVICE_SCALE_FACTOR);
+const deviceScaleFactor = parseDeviceScaleFactor(
+  process.env.DAEDALUS_DEVICE_SCALE_FACTOR
+);
 
-if (deviceScaleFactor > 0 && Number.isFinite(deviceScaleFactor)) {
+if (deviceScaleFactor !== null) {
   app.commandLine.appendSwitch(
     'force-device-scale-factor',
     String(deviceScaleFactor)

--- a/source/main/utils/parseDeviceScaleFactor.spec.ts
+++ b/source/main/utils/parseDeviceScaleFactor.spec.ts
@@ -1,0 +1,39 @@
+import { parseDeviceScaleFactor } from './parseDeviceScaleFactor';
+
+describe('parseDeviceScaleFactor', () => {
+  it('accepts a fractional scale factor', () => {
+    expect(parseDeviceScaleFactor('1.5')).toBe(1.5);
+  });
+
+  it('accepts an integer scale factor', () => {
+    expect(parseDeviceScaleFactor('2')).toBe(2);
+  });
+
+  it('accepts a scale factor below 1', () => {
+    expect(parseDeviceScaleFactor('0.75')).toBe(0.75);
+  });
+
+  it('rejects an unset value, leaving the detected scale factor in place', () => {
+    expect(parseDeviceScaleFactor(undefined)).toBeNull();
+  });
+
+  it('rejects an empty value', () => {
+    expect(parseDeviceScaleFactor('')).toBeNull();
+  });
+
+  it('rejects a non-numeric value', () => {
+    expect(parseDeviceScaleFactor('abc')).toBeNull();
+  });
+
+  it('rejects zero, which would make the window unrenderable', () => {
+    expect(parseDeviceScaleFactor('0')).toBeNull();
+  });
+
+  it('rejects a negative value', () => {
+    expect(parseDeviceScaleFactor('-1')).toBeNull();
+  });
+
+  it('rejects a non-finite value', () => {
+    expect(parseDeviceScaleFactor('Infinity')).toBeNull();
+  });
+});

--- a/source/main/utils/parseDeviceScaleFactor.ts
+++ b/source/main/utils/parseDeviceScaleFactor.ts
@@ -1,0 +1,23 @@
+/**
+ *
+ * parseDeviceScaleFactor
+ * ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+ * Validates the value of `DAEDALUS_DEVICE_SCALE_FACTOR`, which overrides the
+ * device scale factor Chromium detects (from `Xft.dpi` on X11, or from the
+ * compositor on Wayland). The value is absolute rather than a multiplier, so
+ * e.g. `1.5` on a display Chromium reports as `2.0` scales the UI down.
+ *
+ * Returns `null` for anything Chromium could not use as a scale factor, so
+ * that a malformed value leaves the detected one untouched instead of
+ * rendering the window at an unusable size.
+ *
+ */
+export const parseDeviceScaleFactor = (raw?: string): number | null => {
+  const scaleFactor = Number(raw);
+
+  if (!Number.isFinite(scaleFactor) || scaleFactor <= 0) {
+    return null;
+  }
+
+  return scaleFactor;
+};


### PR DESCRIPTION
This PR adds two escape hatches for overriding Electron/Chromium startup flags, neither of which is currently reachable by users.

### Problem

Daedalus creates its main window with a minimum content size of 905×564 (`MIN_WINDOW_CONTENT_WIDTH`/`HEIGHT` in `source/main/config.ts`), applied via `setMinimumSize` in `source/main/windows/main.ts`. Those are **device-independent** pixels, so the real window floor is that value multiplied by whatever device scale factor Chromium detects.

On a HiDPI setup this makes the app unusable. Reported on NixOS with `Xft.dpi: 192`, which Chromium reads as a 2.0 scale factor, giving a minimum window width of 905 × 2.0 = **1810 px** that cannot be shrunk — larger than the usable width of many displays.

There is currently no way for a user to work around this:

- `bin/daedalus` (`nix/internal/x86_64-linux.nix`) execs `cardano-launcher` **without forwarding `"$@"`**, so any flags passed on the command line are discarded before Electron is reached. `darwin-launcher.go` does the same with a hardcoded `argv`, and on Windows the shortcuts invoke `cardano-launcher.exe` directly.
- The app never calls `app.commandLine.appendSwitch` or `setZoomFactor`, and there are no zoom entries in the View menu.
- Electron 41 exposes no env-var escape hatch — there is no `ELECTRON_EXTRA_LAUNCH_ARGS` and no `ELECTRON_OZONE_PLATFORM_HINT` (verified against the strings of the pinned `electron-unwrapped-41.3.0` build).

Note that `--force-device-scale-factor` is the correct knob here and `webContents.setZoomFactor` is not: the latter scales page content while the window minimum stays at 905 DIP, whereas the device scale factor changes the DIP→physical mapping and therefore lowers the physical floor. It is also absolute rather than a multiplier — `Display::HasForceDeviceScaleFactor()` bypasses detection entirely — so overriding a detected 2.0 with 1.5 scales the UI *down*, even though the value is above 1.0.

### Changes

**1. `DAEDALUS_DEVICE_SCALE_FACTOR` (all platforms) — `source/main/index.ts`**

Reads the env var and appends `--force-device-scale-factor` before the app is ready, mirroring the existing `isBlankScreenFixActive` → `disableHardwareAcceleration()` block directly above it.

Chosen over an argv flag because argv would require three separate per-platform changes (forward `"$@"` in the Linux script, append `os.Args[1:]` in `darwin-launcher.go`, and add parameters to the NSIS shortcuts), whereas the environment is already propagated through `cardano-launcher` on every platform. It also survives the auto-update relaunch, since `safeExitWithCode` re-execs with the existing environment.

**2. Validation extracted to `source/main/utils/parseDeviceScaleFactor.ts`, with a spec**

Returns `number | null` so the call site's intent is explicit rather than riding on a truthiness check that `0` would silently pass. Invalid values leave the detected scale factor untouched rather than rendering the window at an unusable size: unset, empty, non-numeric, `0`, negative, and non-finite are all rejected. Colocated spec, matching the 15 other `*.spec.ts` files already in `source/main/utils/`.

**3. `DAEDALUS_ELECTRON_FLAGS` (Linux only) — `nix/internal/x86_64-linux.nix`**

`libexec/daedalus-frontend` is the only place Electron is invoked on Linux, and it is the one platform with a shell seam between `cardano-launcher` and Electron. This covers Linux-specific switches that have no cross-platform meaning and so don't belong in the TypeScript — principally `--ozone-platform=wayland`, since Electron 41 defaults to the X11 backend.

Left unquoted deliberately so multiple flags word-split; the `${VAR-}` default form expands to nothing rather than an empty argument when unset.

This generalizes the existing `DAEDALUS_DISABLE_GPU` block in `bin/electron` (`DAEDALUS_ELECTRON_FLAGS=--disable-gpu` reproduces it exactly), but does not touch it — that variable is documented, tested, and has a specific rationale (the nix-bundle-exe `amdgpu.ids` erasure bug). Consolidating the two is a reasonable follow-up, out of scope here.

### Usage

```sh
DAEDALUS_DEVICE_SCALE_FACTOR=1.5 daedalus                    # all platforms
DAEDALUS_ELECTRON_FLAGS=--ozone-platform=wayland daedalus    # Linux only
```
The two are independent and compose.