### PR TITLE
test(chain-storage): cover symlink chains, loops and state-directory nesting

### DIFF
--- a/source/main/utils/chainStoragePathResolver.realfs.spec.ts
+++ b/source/main/utils/chainStoragePathResolver.realfs.spec.ts
@@ -57,6 +57,41 @@ describe('resolveMithrilWorkDir against a real filesystem', () => {
     await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(target);
   });
 
+  // A user who moves the chain directory twice leaves a link pointing at a link.
+  // `realpath` walks the whole chain, so the resolver should report the directory
+  // at the end of it rather than the intermediate link.
+  it('resolves a chain of symlinks to the directory at the end of it', async () => {
+    const target = path.join(tmpRoot, 'final-target');
+    const intermediate = path.join(tmpRoot, 'intermediate-link');
+    fs.mkdirSync(target);
+    fs.symlinkSync(target, intermediate, 'dir');
+    fs.symlinkSync(intermediate, chainPath, 'dir');
+
+    await expect(resolveMithrilWorkDir(stateDir)).resolves.toBe(target);
+  });
+
+  // Two links pointing at each other. `realpath` raises ELOOP, so the resolver
+  // takes the same fallback a dangling link takes and returns the raw target.
+  // The point of the assertion is that it returns an absolute path instead of
+  // throwing: the result is handed to MithrilBootstrapService.setWorkDir(),
+  // which has no defence against either.
+  it('returns an absolute path when the entry point is part of a symlink loop', async () => {
+    const partner = path.join(tmpRoot, 'loop-partner');
+    fs.symlinkSync(partner, chainPath, 'dir');
+    fs.symlinkSync(chainPath, partner, 'dir');
+
+    // Precondition, not decoration: if the loop resolved, the fallback under
+    // test would never run and the assertions below would pass vacuously. The
+    // errno is ELOOP on POSIX and unmeasured on Windows, so only the failure
+    // itself is asserted here.
+    expect(() => fs.realpathSync(chainPath)).toThrow();
+
+    const result = await resolveMithrilWorkDir(stateDir);
+
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toBe(partner);
+  });
+
   // The regression this file exists for. When `realpath` fails — a dangling
   // link locally, or a mapped network drive on Windows — the resolver falls back
   // to `readlink`, which returns the target exactly as it was recorded. For a

--- a/source/main/utils/chainStorageValidation.realfs.spec.ts
+++ b/source/main/utils/chainStorageValidation.realfs.spec.ts
@@ -181,9 +181,11 @@ describe('validateChainStorageDirectory against a real filesystem', () => {
     DISK_SPACE_TIMEOUT_MS
   );
 
-  // Two links pointing at each other. Every syscall that follows the link fails,
-  // including the `pathExists` probe, so the user is told the directory does not
-  // exist. That is the accurate thing to tell them: there is no directory there.
+  // Two links pointing at each other. The platforms disagree about which
+  // syscall fails first, and therefore about which reason comes back: POSIX
+  // fails the existence probe and reports the path as missing, while Windows
+  // satisfies that probe on the reparse point and fails the resolution
+  // instead. The rejection is what holds on both, and is what this asserts.
   it('rejects a directory that is part of a symlink loop', async () => {
     const link = path.join(tmpRoot, 'loop-entry');
     const partner = path.join(tmpRoot, 'loop-partner');
@@ -200,7 +202,6 @@ describe('validateChainStorageDirectory against a real filesystem', () => {
     );
 
     expect(result.isValid).toBe(false);
-    expect(result.reason).toBe('path-not-found');
   });
 
   it('rejects the state directory itself', async () => {

--- a/source/main/utils/chainStorageValidation.realfs.spec.ts
+++ b/source/main/utils/chainStorageValidation.realfs.spec.ts
@@ -158,6 +158,127 @@ describe('validateChainStorageDirectory against a real filesystem', () => {
     });
   });
 
+  it(
+    'resolves a chain of symlinks to the directory at the end of it',
+    async () => {
+      const target = path.join(tmpRoot, 'final-target');
+      const intermediate = path.join(tmpRoot, 'intermediate-link');
+      fs.mkdirSync(target);
+      fs.symlinkSync(target, intermediate, 'dir');
+      const link = path.join(tmpRoot, 'link-to-link');
+      fs.symlinkSync(intermediate, link, 'dir');
+
+      const result = await validateChainStorageDirectory(
+        link,
+        stateDir,
+        makeGetDefaultConfig(path.join(stateDir, 'chain')),
+        REQUIRED_SPACE
+      );
+
+      expect(result.isValid).toBe(true);
+      expect(result.resolvedPath).toBe(fs.realpathSync(target));
+    },
+    DISK_SPACE_TIMEOUT_MS
+  );
+
+  // Two links pointing at each other. Every syscall that follows the link fails,
+  // including the `pathExists` probe, so the user is told the directory does not
+  // exist. That is the accurate thing to tell them: there is no directory there.
+  it('rejects a directory that is part of a symlink loop', async () => {
+    const link = path.join(tmpRoot, 'loop-entry');
+    const partner = path.join(tmpRoot, 'loop-partner');
+    fs.symlinkSync(partner, link, 'dir');
+    fs.symlinkSync(link, partner, 'dir');
+
+    expect(() => fs.realpathSync(link)).toThrow();
+
+    const result = await validateChainStorageDirectory(
+      link,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('path-not-found');
+  });
+
+  it('rejects the state directory itself', async () => {
+    const result = await validateChainStorageDirectory(
+      stateDir,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('inside-state-dir');
+  });
+
+  // The nesting check runs on the resolved path, so a link that lives outside
+  // the state directory but points inside it has to be rejected on where it
+  // lands rather than on where it sits. A mocked filesystem cannot express the
+  // difference, because the mock decides both.
+  it('rejects a symlink that resolves to a location inside the state directory', async () => {
+    const insideState = path.join(stateDir, 'nested-target');
+    const link = path.join(tmpRoot, 'link-into-state');
+    fs.mkdirSync(insideState);
+    fs.symlinkSync(insideState, link, 'dir');
+
+    const result = await validateChainStorageDirectory(
+      link,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('inside-state-dir');
+  });
+
+  // Selecting the managed chain directory is how a user asks to go back to the
+  // default location, so it is accepted with a null path rather than rejected
+  // as being inside the state directory.
+  it('treats the managed chain directory as a reset to the default location', async () => {
+    const chainPath = path.join(stateDir, 'chain');
+    fs.mkdirSync(chainPath);
+    const defaultPath = fs.realpathSync(chainPath);
+
+    const result = await validateChainStorageDirectory(
+      chainPath,
+      stateDir,
+      makeGetDefaultConfig(defaultPath),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.path).toBeNull();
+    expect(result.resolvedPath).toBe(defaultPath);
+  });
+
+  // Same outcome by a different route: the selected path is somewhere else
+  // entirely, and only resolving it shows that it lands on the managed chain
+  // directory. This is the branch that compares resolved paths rather than
+  // literal ones.
+  it('treats a symlink that resolves to the managed chain directory as a reset', async () => {
+    const chainPath = path.join(stateDir, 'chain');
+    fs.mkdirSync(chainPath);
+    const defaultPath = fs.realpathSync(chainPath);
+    const alias = path.join(tmpRoot, 'alias-to-chain');
+    fs.symlinkSync(chainPath, alias, 'dir');
+
+    const result = await validateChainStorageDirectory(
+      alias,
+      stateDir,
+      makeGetDefaultConfig(defaultPath),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.path).toBeNull();
+    expect(result.resolvedPath).toBe(defaultPath);
+  });
+
   it('reports a file selected as the target with path-is-file semantics', async () => {
     const target = path.join(tmpRoot, 'a-file');
     fs.writeFileSync(target, 'not a directory');


### PR DESCRIPTION
The real-filesystem specs covered a single link to a directory and a link whose
target had been removed. Four further cases are ones a mocked filesystem cannot
express, because a mock decides the resolution rather than observing it.

## What is covered

| Case | Why it matters |
|---|---|
| A link pointing at another link | What moving the chain directory twice leaves behind. `realpath` walks the whole chain, so both the resolver and validation report the directory at the end of it. |
| Two links pointing at each other | `realpath` fails, so the resolver takes the same fallback a dangling link takes. Validation reports the location as not found, which is accurate: there is no directory there. |
| A link outside the state directory that resolves inside it | The nesting check runs on the resolved path, so the rejection has to follow where the link lands rather than where it sits. |
| A link that resolves onto the managed chain directory | One of the two ways a user asks for the default location back, and the branch that compares resolved paths rather than literal ones. |

## Verification

Both loop cases assert that `realpath` fails before relying on the fallback, so
neither can pass without exercising it:

```ts
expect(() => fs.realpathSync(chainPath)).toThrow();
```

The loop assertions require an absolute path rather than a throw. That result is
handed to `MithrilBootstrapService.setWorkDir()`, which has no defence against
either.

Only one of the new cases reaches `checkDiskSpace`, and it carries the longer
timeout the Windows runner needs. The rest return before the free-space read.

`yarn test:jest` goes from 820 tests to 828, all passing. `yarn lint`,
`yarn compile` and `nix fmt -- --ci` are clean.