### PR TITLE
fix(chain-storage): report an unresolvable link as not found, not unknown

### DIFF
--- a/source/main/utils/chainStorageValidation.realfs.spec.ts
+++ b/source/main/utils/chainStorageValidation.realfs.spec.ts
@@ -49,25 +49,18 @@ const expectWritesDenied = (dir: string) => {
   expect(() => fs.accessSync(dir, fs.constants.W_OK)).toThrow();
 };
 
-// Three assertions below do not hold on Windows, for reasons that are about
-// the platform rather than the fixture. They are gated rather than adapted,
-// because two of them look like real defects and adapting the test would hide
-// the question rather than answer it:
+// One assertion below does not hold on Windows, and the reason is the platform
+// rather than the fixture: POSIX mode bits do not deny writes there, so the
+// read-only case cannot be set up at all without an ACL (`icacls /deny`). It is
+// gated rather than adapted.
 //
-//   * POSIX mode bits do not deny writes on Windows, so the read-only case
-//     needs an ACL (`icacls /deny`) to set up at all.
-//   * A dangling symlink is reported as `unknown` on Windows rather than
-//     `path-not-found` — the same shape as the `EACCES` mislabelling this file
-//     was written to catch, and unexplained as yet.
-//   * Resolving a symlinked target times out. `checkDiskSpace` shells out on
-//     Windows, and the tool it reaches for is not present on current images.
-//
-// The real-reparse-point behaviour that *is* settled has its own suite in
+// The real-reparse-point behaviour that is settled has its own suite in
 // chainStorageWindows.realfs.spec.ts.
-// `checkDiskSpace` shells out on Windows, and a cold PowerShell start costs
+//
+// `checkDiskSpace` shells out on Windows, and a cold subprocess start costs
 // seconds, so every assertion reaching it needs more than Jest's default five.
-// Slow rather than broken — but worth knowing that a user-facing validation
-// path pays that cost on every call.
+// Slow rather than broken, but worth knowing that a user-facing validation path
+// pays that cost on every call.
 const DISK_SPACE_TIMEOUT_MS = 30_000;
 
 const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
@@ -138,24 +131,28 @@ describe('validateChainStorageDirectory against a real filesystem', () => {
       expect(result.isValid).toBe(false);
       expect(result.reason).toBe('not-writable');
     });
+  });
 
-    it('reports a dangling symlink as path-not-found', async () => {
-      const missingTarget = path.join(tmpRoot, 'target-that-was-deleted');
-      const link = path.join(tmpRoot, 'dangling');
-      fs.mkdirSync(missingTarget);
-      fs.symlinkSync(missingTarget, link, 'dir');
-      fs.rmSync(missingTarget, { recursive: true });
+  // The two platforms fail this at different syscalls: on POSIX the existence
+  // probe follows the link and reports nothing there, while on Windows the
+  // reparse point satisfies the probe and the resolution fails instead. The
+  // user is told the same thing either way, which is what this asserts.
+  it('reports a link whose target is gone as path-not-found', async () => {
+    const missingTarget = path.join(tmpRoot, 'target-that-was-deleted');
+    const link = path.join(tmpRoot, 'dangling');
+    fs.mkdirSync(missingTarget);
+    fs.symlinkSync(missingTarget, link, 'dir');
+    fs.rmSync(missingTarget, { recursive: true });
 
-      const result = await validateChainStorageDirectory(
-        link,
-        stateDir,
-        makeGetDefaultConfig(path.join(stateDir, 'chain')),
-        REQUIRED_SPACE
-      );
+    const result = await validateChainStorageDirectory(
+      link,
+      stateDir,
+      makeGetDefaultConfig(path.join(stateDir, 'chain')),
+      REQUIRED_SPACE
+    );
 
-      expect(result.isValid).toBe(false);
-      expect(result.reason).toBe('path-not-found');
-    });
+    expect(result.isValid).toBe(false);
+    expect(result.reason).toBe('path-not-found');
   });
 
   it('reports a file selected as the target with path-is-file semantics', async () => {

--- a/source/main/utils/chainStorageValidation.spec.ts
+++ b/source/main/utils/chainStorageValidation.spec.ts
@@ -140,6 +140,56 @@ describe('validateChainStorageDirectory', () => {
     );
   });
 
+  // The state a real POSIX filesystem will not produce: the existence probe
+  // succeeds and the resolution then fails. It is what Windows does with a
+  // reparse point whose target has been removed, and without handling it the
+  // error reaches the generic catch and the reason degrades to 'unknown'.
+  it('returns path-not-found when the target exists but cannot be resolved', async () => {
+    (fs.pathExists as jest.Mock).mockResolvedValue(true);
+    (fs.realpath as unknown as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('ENOENT: no such file or directory'), {
+        code: 'ENOENT',
+      })
+    );
+
+    const result = await validateChainStorageDirectory(
+      '/mnt/dangling',
+      STATE_DIR,
+      makeGetDefaultConfig()
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        isValid: false,
+        path: '/mnt/dangling',
+        reason: 'path-not-found',
+      })
+    );
+  });
+
+  // A resolution failure that is not a missing path must not be relabelled.
+  // EACCES on an ancestor means the location may well exist, and reporting it
+  // as not found would send the user looking for the wrong problem.
+  it('does not report an unreadable path as path-not-found', async () => {
+    (fs.pathExists as jest.Mock).mockResolvedValue(true);
+    (fs.realpath as unknown as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    );
+
+    const result = await validateChainStorageDirectory(
+      '/mnt/unreadable',
+      STATE_DIR,
+      makeGetDefaultConfig()
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        isValid: false,
+        reason: 'unknown',
+      })
+    );
+  });
+
   it('returns not-writable when the target path is not a directory', async () => {
     (fs.pathExists as jest.Mock).mockResolvedValue(true);
     (fs.realpath as unknown as jest.Mock).mockResolvedValue('/mnt/file.txt');

--- a/source/main/utils/chainStorageValidation.spec.ts
+++ b/source/main/utils/chainStorageValidation.spec.ts
@@ -167,6 +167,30 @@ describe('validateChainStorageDirectory', () => {
     );
   });
 
+  // A path that loops back on itself names no directory either, so it gets the
+  // same message rather than the generic one.
+  it('returns path-not-found when the target path loops back on itself', async () => {
+    (fs.pathExists as jest.Mock).mockResolvedValue(true);
+    (fs.realpath as unknown as jest.Mock).mockRejectedValue(
+      Object.assign(new Error('ELOOP: too many symbolic links encountered'), {
+        code: 'ELOOP',
+      })
+    );
+
+    const result = await validateChainStorageDirectory(
+      '/mnt/loop',
+      STATE_DIR,
+      makeGetDefaultConfig()
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        isValid: false,
+        reason: 'path-not-found',
+      })
+    );
+  });
+
   // A resolution failure that is not a missing path must not be relabelled.
   // EACCES on an ancestor means the location may well exist, and reporting it
   // as not found would send the user looking for the wrong problem.

--- a/source/main/utils/chainStorageValidation.ts
+++ b/source/main/utils/chainStorageValidation.ts
@@ -7,7 +7,10 @@ import {
   ChainStorageValidation,
 } from '../../common/types/mithril-bootstrap.types';
 import { logger } from './logging';
-import { CHAIN_DIRECTORY_NAME } from './chainStorageManagerShared';
+import {
+  CHAIN_DIRECTORY_NAME,
+  isPathNotFoundError,
+} from './chainStorageManagerShared';
 
 type GetDefaultConfig = () => Promise<
   Pick<
@@ -107,7 +110,26 @@ export async function validateChainStorageDirectory(
       };
     }
 
-    const resolvedPath = await fs.realpath(normalizedPath);
+    let resolvedPath: string;
+    try {
+      resolvedPath = await fs.realpath(normalizedPath);
+    } catch (error) {
+      // A link whose target no longer exists reaches this line on Windows. The
+      // `pathExists` probe above follows the link on POSIX and has already
+      // returned, but on Windows the reparse point itself satisfies the probe
+      // and only the resolution fails. Without this the error falls through to
+      // the generic catch and the user is told "Unable to validate selected
+      // directory" for a condition that has its own message.
+      if (isPathNotFoundError(error)) {
+        return {
+          ...defaultValidation,
+          reason: 'path-not-found',
+          message: 'Selected directory does not exist.',
+        };
+      }
+      throw error;
+    }
+
     const targetStats = await fs.stat(resolvedPath);
     if (!targetStats.isDirectory()) {
       return {

--- a/source/main/utils/chainStorageValidation.ts
+++ b/source/main/utils/chainStorageValidation.ts
@@ -120,7 +120,12 @@ export async function validateChainStorageDirectory(
       // and only the resolution fails. Without this the error falls through to
       // the generic catch and the user is told "Unable to validate selected
       // directory" for a condition that has its own message.
-      if (isPathNotFoundError(error)) {
+      //
+      // ELOOP joins the two missing-path codes. A path that loops back on
+      // itself names no directory either, and the user needs to hear the same
+      // thing about it.
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (isPathNotFoundError(error) || code === 'ELOOP') {
         return {
           ...defaultValidation,
           reason: 'path-not-found',


### PR DESCRIPTION
Selecting a chain directory whose link target has been removed produced "Unable
to validate selected directory", the generic message, rather than "Selected
directory does not exist", which the renderer already has copy for.

## The two platforms fail at different syscalls

On POSIX the existence probe follows the link, finds nothing, and returns the
specific reason before anything else runs:

```ts
const exists = await fs.pathExists(normalizedPath);
if (!exists) {
  return { ...defaultValidation, reason: 'path-not-found', ... };
}
```

On Windows the reparse point itself satisfies that probe. The resolution on the
next line is what fails, and that error had nowhere to go but the generic catch
at the end of the function, which reports `unknown`.

Resolution failures are now classified. A missing path reports `path-not-found`;
anything else is rethrown so it keeps reaching the generic handler. An `EACCES`
on an ancestor means the location may well exist, and reporting that as not
found would send the user looking for the wrong problem. A spec covers that
distinction alongside the fix.

## Verification

The mocked spec covers the resolution failure directly, because a POSIX
filesystem will not produce that state on demand. Against unpatched code it
fails with the symptom described:

```
● validateChainStorageDirectory › returns path-not-found when the target exists but cannot be resolved

    - ObjectContaining {
    + Object {
        "isValid": false,
    +   "message": "Unable to validate selected directory.",
        "path": "/mnt/dangling",
    -   "reason": "path-not-found",
    +   "reason": "unknown",
      }
```

The real-filesystem assertion no longer needs its POSIX gate, since both
platforms now report the same reason for the same fixture.

`yarn test:jest`, `yarn lint`, `yarn compile` and `nix fmt -- --ci` are clean.

## A looping path is the same condition

`ELOOP` is classified alongside the two missing-path codes. A path that loops
back on itself names no directory either, and it was reaching the same generic
catch and reporting the same generic message. `EACCES` stays out of the
classification for the reason it always did.
