### PR TITLE
fix(chain-storage): do not block directory validation on the free space probe

### DIFF
--- a/source/main/utils/chainStorageValidation.realfs.spec.ts
+++ b/source/main/utils/chainStorageValidation.realfs.spec.ts
@@ -56,11 +56,11 @@ const expectWritesDenied = (dir: string) => {
 //
 // The real-reparse-point behaviour that is settled has its own suite in
 // chainStorageWindows.realfs.spec.ts.
-//
 // `checkDiskSpace` shells out on Windows, and a cold subprocess start costs
-// seconds, so every assertion reaching it needs more than Jest's default five.
-// Slow rather than broken, but worth knowing that a user-facing validation path
-// pays that cost on every call.
+// seconds. The probe is bounded now, so a case that reaches it takes at most
+// that bound plus the filesystem work, but the bound is itself longer than
+// Jest's default five seconds. Every case that reaches the probe therefore
+// carries this allowance.
 const DISK_SPACE_TIMEOUT_MS = 30_000;
 
 const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
@@ -169,18 +169,22 @@ describe('validateChainStorageDirectory against a real filesystem', () => {
     expect(result.isValid).toBe(false);
   });
 
-  it('accepts a directory whose path contains spaces and non-ASCII characters', async () => {
-    const target = path.join(tmpRoot, 'Ünïcödé 目録 dir');
-    fs.mkdirSync(target);
+  it(
+    'accepts a directory whose path contains spaces and non-ASCII characters',
+    async () => {
+      const target = path.join(tmpRoot, 'Ünïcödé 目録 dir');
+      fs.mkdirSync(target);
 
-    const result = await validateChainStorageDirectory(
-      target,
-      stateDir,
-      makeGetDefaultConfig(path.join(stateDir, 'chain')),
-      REQUIRED_SPACE
-    );
+      const result = await validateChainStorageDirectory(
+        target,
+        stateDir,
+        makeGetDefaultConfig(path.join(stateDir, 'chain')),
+        REQUIRED_SPACE
+      );
 
-    expect(result.reason).toBeUndefined();
-    expect(result.isValid).toBe(true);
-  });
+      expect(result.reason).toBeUndefined();
+      expect(result.isValid).toBe(true);
+    },
+    DISK_SPACE_TIMEOUT_MS
+  );
 });

--- a/source/main/utils/chainStorageValidation.spec.ts
+++ b/source/main/utils/chainStorageValidation.spec.ts
@@ -285,6 +285,60 @@ describe('validateChainStorageDirectory', () => {
     );
   });
 
+  // The probe spawns a subprocess on Windows and can take seconds, or hang.
+  // Blocking the picker on it would make an unreadable disk indistinguishable
+  // from an unusable directory, so the selection is accepted without a figure.
+  it('accepts the directory when the free space probe does not answer in time', async () => {
+    const checkDiskSpace = require('check-disk-space');
+    checkDiskSpace.mockReturnValue(new Promise(() => {}));
+    (fs.pathExists as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    (fs.realpath as unknown as jest.Mock).mockImplementation(
+      async (p: string) => p
+    );
+    (fs.stat as jest.Mock).mockResolvedValue({ isDirectory: () => true });
+    (fs.access as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await validateChainStorageDirectory(
+      '/mnt/external',
+      STATE_DIR,
+      makeGetDefaultConfig(),
+      REQUIRED_SPACE,
+      10
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.availableSpaceBytes).toBeUndefined();
+  });
+
+  it('accepts the directory when the free space probe fails', async () => {
+    const checkDiskSpace = require('check-disk-space');
+    checkDiskSpace.mockRejectedValue(new Error('no such utility'));
+    (fs.pathExists as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    (fs.realpath as unknown as jest.Mock).mockImplementation(
+      async (p: string) => p
+    );
+    (fs.stat as jest.Mock).mockResolvedValue({ isDirectory: () => true });
+    (fs.access as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await validateChainStorageDirectory(
+      '/mnt/external',
+      STATE_DIR,
+      makeGetDefaultConfig(),
+      REQUIRED_SPACE
+    );
+
+    expect(result.isValid).toBe(true);
+    expect(result.reason).toBeUndefined();
+    expect(result.availableSpaceBytes).toBeUndefined();
+  });
+
   it('returns valid when all checks pass', async () => {
     const checkDiskSpace = require('check-disk-space');
     checkDiskSpace.mockResolvedValue({ free: 4096 });

--- a/source/main/utils/chainStorageValidation.ts
+++ b/source/main/utils/chainStorageValidation.ts
@@ -20,6 +20,59 @@ type GetDefaultConfig = () => Promise<
 >;
 
 /**
+ * How long the free-space probe is given before validation continues without it.
+ *
+ * `checkDiskSpace` spawns a subprocess on Windows and a cold start there costs
+ * seconds. This runs while the user waits on the directory picker, so it is held
+ * to a shorter allowance than the background poll in handleDiskSpace, which has
+ * nobody waiting on it.
+ */
+const DISK_SPACE_PROBE_TIMEOUT = 5 * 1000;
+
+/**
+ * Reads free space at `targetPath`, or resolves null when it cannot be read in
+ * time.
+ *
+ * A probe that is slow, hung or failing says nothing about whether the directory
+ * the user picked is usable, so it must not decide the outcome. handleDiskSpace
+ * already takes this position for the periodic check: an unreadable probe is
+ * logged and cardano-node is started anyway.
+ */
+const readFreeSpace = async (
+  targetPath: string,
+  timeout: number
+): Promise<number | null> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      checkDiskSpace(targetPath)
+        .then(({ free }) => free)
+        .catch((error) => {
+          logger.warn('ChainStorageManager: free space probe failed', {
+            error,
+            targetPath,
+          });
+          return null;
+        }),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => {
+          logger.warn('ChainStorageManager: free space probe timed out', {
+            targetPath,
+            timeout,
+          });
+          resolve(null);
+        }, timeout);
+      }),
+    ]);
+  } finally {
+    // Without this the timer holds the event loop open for its full duration
+    // after the probe has already answered.
+    if (timer) clearTimeout(timer);
+  }
+};
+
+/**
  * Returns true when `child` is equal to or nested under `parent`.
  */
 export function isSubPath(parent: string, child: string): boolean {
@@ -63,12 +116,14 @@ export function isSamePath(a: string, b: string): boolean {
  * @param stateDir      The Daedalus state directory path
  * @param getDefaultConfig  Resolves default storage metadata
  * @param requiredSpace Minimum free-space threshold in bytes
+ * @param diskSpaceTimeout How long to wait for the free-space probe, in ms
  */
 export async function validateChainStorageDirectory(
   targetDir: string | null,
   stateDir: string,
   getDefaultConfig: GetDefaultConfig,
-  requiredSpace: number = DISK_SPACE_REQUIRED
+  requiredSpace: number = DISK_SPACE_REQUIRED,
+  diskSpaceTimeout: number = DISK_SPACE_PROBE_TIMEOUT
 ): Promise<ChainStorageValidation> {
   const chainPath = path.join(stateDir, CHAIN_DIRECTORY_NAME);
   const normalizedPath =
@@ -261,8 +316,12 @@ export async function validateChainStorageDirectory(
       }
     }
 
-    const { free } = await checkDiskSpace(resolvedValidationPath);
-    if (free < requiredSpace) {
+    const free = await readFreeSpace(resolvedValidationPath, diskSpaceTimeout);
+
+    // Only a figure that was actually read can reject the directory. When the
+    // probe does not answer, the selection is accepted without a free-space
+    // figure rather than blocked on a reading nobody has.
+    if (free != null && free < requiredSpace) {
       return {
         ...defaultValidation,
         resolvedPath: resolvedValidationPath,
@@ -278,7 +337,7 @@ export async function validateChainStorageDirectory(
       isValid: true,
       path: validationPath,
       resolvedPath: resolvedValidationPath,
-      availableSpaceBytes: free,
+      availableSpaceBytes: free ?? undefined,
       requiredSpaceBytes: requiredSpace,
       chainSubdirectoryStatus,
     };


### PR DESCRIPTION
`checkDiskSpace` spawns a subprocess on Windows, and a cold start there costs
seconds. `validateChainStorageDirectory` runs it on every call, with the user
waiting on the directory picker, and awaited it without any bound:

```ts
const { free } = await checkDiskSpace(resolvedValidationPath);
if (free < requiredSpace) { ... }
```

Two consequences. A slow probe holds the dialog for as long as it takes. A
probe that throws sends the whole validation into the generic catch, so a disk
whose free space cannot be read is reported as "Unable to validate selected
directory", which is not what went wrong.

## What changed

The probe is raced against a timeout, and a probe that times out or fails
yields no figure rather than a verdict:

```ts
const free = await readFreeSpace(resolvedValidationPath, diskSpaceTimeout);

if (free != null && free < requiredSpace) {
  return { ...defaultValidation, reason: 'insufficient-space', ... };
}
```

Only a figure that was actually read can reject a directory. The selection is
otherwise accepted without a free-space figure.

This is the position `handleDiskSpace` already takes for the periodic check,
where an unreadable probe is logged and cardano-node is started anyway. The
allowance here is 5 seconds rather than the 9 that check uses, because the
periodic check has nobody waiting on it and this one does.

The pending timer is cleared once the race settles, so it does not hold the
event loop open after the probe has already answered.

## Verification

Both new cases fail against unpatched code. The hung probe exhausts the test
timeout:

```
✕ accepts the directory when the free space probe does not answer in time (5001 ms)
```

and the failing probe reports the wrong reason:

```
✕ accepts the directory when the free space probe fails (1 ms)
```

The timeout is a parameter with a default, so the specs drive it directly
instead of waiting on wall-clock seconds.

`yarn test:jest`, `yarn lint`, `yarn compile` and `nix fmt -- --ci` are clean.