### PR TITLE
test(chain-storage): cover Windows path syntax with no POSIX equivalent

### DIFF
--- a/source/main/utils/chainStorageWindows.realfs.spec.ts
+++ b/source/main/utils/chainStorageWindows.realfs.spec.ts
@@ -357,68 +357,56 @@ onWindows('Windows reparse point handling', () => {
     });
   });
 
-  // Path syntax with no POSIX equivalent, all of it reachable by a user who
-  // types a location rather than browsing to one.
-  describe('path syntax the platform treats specially', () => {
-    // CON, PRN, NUL and AUX name devices in every directory, so a directory
-    // cannot be created with one of those names anywhere. The path can still be
-    // typed. What matters is that it comes back rejected with a reason the
-    // renderer has copy for, rather than through the generic catch: either the
-    // location does not exist, or it exists and is not a directory. Which of
-    // the two depends on how the device answers the probe, and both are honest.
+  // Names the Win32 API restricts, and Node does not.
+  //
+  // Both groups below were written expecting the documented Win32 behaviour,
+  // and both were wrong in the same direction, which is why they are worth
+  // keeping: `fs` reaches the filesystem through libuv, which addresses paths
+  // in their extended-length form. That form skips the Win32 parsing rules, so
+  // reserved device names are ordinary directory names and trailing dots and
+  // spaces survive. What Daedalus asks for is what it gets, and the hazard runs
+  // the other way from the one anticipated: it can create a directory that
+  // Win32 tooling addressing the same path cannot open.
+  describe('names the Win32 API restricts', () => {
+    // CON, PRN, NUL and AUX name devices to the Win32 API and cannot be used
+    // for a directory through it. Through `fs` they can.
     it.each(['CON', 'PRN', 'NUL', 'AUX'])(
-      'rejects a path named %s with a specific reason',
-      async (reservedName) => {
-        const stateDir = path.join(tmpRoot, 'state');
-        fs.ensureDirSync(stateDir);
+      'creates and resolves a directory named %s',
+      (reservedName) => {
         const reservedPath = path.join(tmpRoot, reservedName);
 
-        // Precondition: the platform genuinely refuses the name. If a future
-        // Windows accepts it, this test is no longer about what it claims and
-        // should fail rather than quietly pass.
-        expect(() => fs.mkdirSync(reservedPath)).toThrow();
+        fs.mkdirSync(reservedPath);
 
-        const result = await validateChainStorageDirectory(
-          reservedPath,
-          stateDir,
-          makeGetDefaultConfig(path.join(stateDir, CHAIN_DIRECTORY_NAME)),
-          0
-        );
+        expect(fs.statSync(reservedPath).isDirectory()).toBe(true);
 
-        expect(result.isValid).toBe(false);
-        expect(result.reason).not.toBe('unknown');
-      },
-      DISK_SPACE_TIMEOUT_MS
+        // The invariant that matters downstream. Every resolved path here ends
+        // up in a stored setting or on a subprocess command line, and an
+        // extended-length path in either place would not survive the round
+        // trip. libuv uses that form internally; it must not come back out.
+        const resolved = fs.realpathSync(reservedPath);
+        expect(resolved.startsWith('\\\\?\\')).toBe(false);
+        expect(resolved).toBe(reservedPath);
+      }
     );
 
-    // Windows strips a trailing dot or space when it creates the directory, so
-    // the name the user gave and the name on disk differ. Everything downstream
-    // compares paths, so the question is whether validation hands back the name
-    // that exists or the name that was typed.
+    // The Win32 API strips a trailing dot or space from a name. Node does not,
+    // so the directory on disk keeps the name exactly as given.
     it.each([
       ['space', 'trailing-space '],
       ['dot', 'trailing-dot.'],
-    ])(
-      'resolves a directory created with a trailing %s to the name on disk',
-      async (_label, spelledName) => {
-        const spelledPath = path.join(tmpRoot, spelledName);
-        fs.ensureDirSync(spelledPath);
+    ])('keeps a trailing %s in the name on disk', (_label, spelledName) => {
+      const spelledPath = path.join(tmpRoot, spelledName);
+      const strippedPath = path.join(tmpRoot, spelledName.slice(0, -1));
 
-        const strippedPath = path.join(tmpRoot, spelledName.slice(0, -1));
+      fs.ensureDirSync(spelledPath);
 
-        // Precondition: the platform really did strip it. Without this the
-        // assertions below would hold trivially on a filesystem that keeps the
-        // name intact.
-        expect(fs.existsSync(strippedPath)).toBe(true);
-        expect(fs.realpathSync(spelledPath)).toBe(strippedPath);
+      expect(fs.existsSync(spelledPath)).toBe(true);
+      expect(fs.existsSync(strippedPath)).toBe(false);
 
-        // The comparison the product uses does not strip, so the two spellings
-        // are not the same path to it, while they are the same directory to the
-        // filesystem. Recorded rather than worked around: it only matters once
-        // a stored custom path is compared against a resolved one.
-        expect(isSamePath(spelledPath, strippedPath)).toBe(false);
-      }
-    );
+      const resolved = fs.realpathSync(spelledPath);
+      expect(resolved.startsWith('\\\\?\\')).toBe(false);
+      expect(resolved).toBe(spelledPath);
+    });
 
     // Whether a path past the classic limit can be created depends on whether
     // long path support is enabled on the machine, and both answers are

--- a/source/main/utils/chainStorageWindows.realfs.spec.ts
+++ b/source/main/utils/chainStorageWindows.realfs.spec.ts
@@ -19,7 +19,11 @@ import path from 'path';
 import { execFileSync } from 'child_process';
 import { resolveMithrilWorkDir } from './chainStoragePathResolver';
 import { createSymlink } from './chainStorageManagerShared';
-import { isSamePath, isSubPath } from './chainStorageValidation';
+import {
+  isSamePath,
+  isSubPath,
+  validateChainStorageDirectory,
+} from './chainStorageValidation';
 
 jest.mock('../config', () => ({
   DISK_SPACE_REQUIRED: 0,
@@ -50,6 +54,21 @@ const findFreeDriveLetter = (candidates: string): string | null => {
 };
 
 const CHAIN_DIRECTORY_NAME = 'chain';
+
+// `checkDiskSpace` spawns a subprocess on Windows and a cold start costs
+// seconds, so any case that reaches it needs more than Jest's default five.
+const DISK_SPACE_TIMEOUT_MS = 30_000;
+
+// The classic Windows limit. A path longer than this needs the `\\?\` prefix,
+// or long path support enabled, or it does not work.
+const MAX_PATH = 260;
+
+const makeGetDefaultConfig = (defaultPath: string) =>
+  jest.fn().mockResolvedValue({
+    defaultPath,
+    availableSpaceBytes: Number.MAX_SAFE_INTEGER,
+    requiredSpaceBytes: 0,
+  });
 
 // `existsSync` follows the link, so it is false for a link that exists but
 // does not resolve — which is the state under test.
@@ -336,5 +355,115 @@ onWindows('Windows reparse point handling', () => {
         false
       );
     });
+  });
+
+  // Path syntax with no POSIX equivalent, all of it reachable by a user who
+  // types a location rather than browsing to one.
+  describe('path syntax the platform treats specially', () => {
+    // CON, PRN, NUL and AUX name devices in every directory, so a directory
+    // cannot be created with one of those names anywhere. The path can still be
+    // typed. What matters is that it comes back rejected with a reason the
+    // renderer has copy for, rather than through the generic catch: either the
+    // location does not exist, or it exists and is not a directory. Which of
+    // the two depends on how the device answers the probe, and both are honest.
+    it.each(['CON', 'PRN', 'NUL', 'AUX'])(
+      'rejects a path named %s with a specific reason',
+      async (reservedName) => {
+        const stateDir = path.join(tmpRoot, 'state');
+        fs.ensureDirSync(stateDir);
+        const reservedPath = path.join(tmpRoot, reservedName);
+
+        // Precondition: the platform genuinely refuses the name. If a future
+        // Windows accepts it, this test is no longer about what it claims and
+        // should fail rather than quietly pass.
+        expect(() => fs.mkdirSync(reservedPath)).toThrow();
+
+        const result = await validateChainStorageDirectory(
+          reservedPath,
+          stateDir,
+          makeGetDefaultConfig(path.join(stateDir, CHAIN_DIRECTORY_NAME)),
+          0
+        );
+
+        expect(result.isValid).toBe(false);
+        expect(result.reason).not.toBe('unknown');
+      },
+      DISK_SPACE_TIMEOUT_MS
+    );
+
+    // Windows strips a trailing dot or space when it creates the directory, so
+    // the name the user gave and the name on disk differ. Everything downstream
+    // compares paths, so the question is whether validation hands back the name
+    // that exists or the name that was typed.
+    it.each([
+      ['space', 'trailing-space '],
+      ['dot', 'trailing-dot.'],
+    ])(
+      'resolves a directory created with a trailing %s to the name on disk',
+      async (_label, spelledName) => {
+        const spelledPath = path.join(tmpRoot, spelledName);
+        fs.ensureDirSync(spelledPath);
+
+        const strippedPath = path.join(tmpRoot, spelledName.slice(0, -1));
+
+        // Precondition: the platform really did strip it. Without this the
+        // assertions below would hold trivially on a filesystem that keeps the
+        // name intact.
+        expect(fs.existsSync(strippedPath)).toBe(true);
+        expect(fs.realpathSync(spelledPath)).toBe(strippedPath);
+
+        // The comparison the product uses does not strip, so the two spellings
+        // are not the same path to it, while they are the same directory to the
+        // filesystem. Recorded rather than worked around: it only matters once
+        // a stored custom path is compared against a resolved one.
+        expect(isSamePath(spelledPath, strippedPath)).toBe(false);
+      }
+    );
+
+    // Whether a path past the classic limit can be created depends on whether
+    // long path support is enabled on the machine, and both answers are
+    // legitimate. So the assertion ties the verdict to the observable fact
+    // rather than to a guess about the runner: validation accepts the location
+    // exactly when the directory is there, and never falls through to the
+    // generic reason either way.
+    it(
+      'agrees with the filesystem about a path beyond MAX_PATH',
+      async () => {
+        const stateDir = path.join(tmpRoot, 'state');
+        fs.ensureDirSync(stateDir);
+
+        const segment = 'x'.repeat(40);
+        const segmentCount =
+          Math.ceil((MAX_PATH - tmpRoot.length) / (segment.length + 1)) + 2;
+        const longPath = path.join(
+          tmpRoot,
+          ...Array(segmentCount).fill(segment)
+        );
+        expect(longPath.length).toBeGreaterThan(MAX_PATH);
+
+        try {
+          fs.ensureDirSync(longPath);
+        } catch {
+          // Long paths are not available here. That is one of the two outcomes
+          // under test, not a failure to set the fixture up.
+        }
+        const exists = fs.existsSync(longPath);
+
+        // Pure string work, so it holds at any length and on either outcome.
+        // The nesting checks depend on it and run on whatever the user picked.
+        expect(isSubPath(tmpRoot, longPath)).toBe(true);
+
+        const result = await validateChainStorageDirectory(
+          longPath,
+          stateDir,
+          makeGetDefaultConfig(path.join(stateDir, CHAIN_DIRECTORY_NAME)),
+          0
+        );
+
+        expect(result.isValid).toBe(exists);
+        expect(result.reason).not.toBe('unknown');
+      },
+      DISK_SPACE_TIMEOUT_MS
+    );
   });
 });


### PR DESCRIPTION
Three path shapes a user can produce by typing a location rather than browsing
to one. None can be exercised anywhere but on Windows.

Two of the three were written against the documented Win32 rules, and a real
runner showed both were wrong in the same direction. They are kept because what
they now assert is more useful than what they were written to assert.

## Reserved device names are not reserved through `fs`

`CON`, `PRN`, `NUL` and `AUX` name devices to the Win32 API and cannot be used
for a directory through it. `fs.mkdirSync` creates them without complaint.

## A trailing dot or space is not stripped through `fs`

The Win32 API strips both from a name. `fs.ensureDirSync` keeps them, and the
directory on disk carries the name exactly as given.

## One cause, and the hazard runs the other way

`fs` reaches the filesystem through libuv, which addresses paths in their
extended-length form, and that form skips the Win32 parsing rules both cases
assumed. So Daedalus is not prevented from creating these directories. It can
create one that Win32 tooling addressing the same path cannot open.

Both groups assert the measured behaviour, and both assert the invariant that
matters downstream:

```ts
const resolved = fs.realpathSync(reservedPath);
expect(resolved.startsWith('\\\\?\\')).toBe(false);
expect(resolved).toBe(reservedPath);
```

Resolved paths reach stored settings and subprocess command lines, and neither
survives a `\\?\` prefix. libuv uses that form internally; it must not come back
out.

## Paths beyond MAX_PATH

Whether a path past 260 characters can be created depends on whether long path
support is enabled on the machine, and both answers are legitimate. The verdict
is tied to the observable fact rather than to an assumption about the runner:

```ts
expect(result.isValid).toBe(exists);
expect(result.reason).not.toBe('unknown');
```

`isSubPath` is pure string work, so it is asserted unconditionally: the nesting
checks run on whatever the user picked, at whatever length.

## Verification

The suite is gated to `win32` at the describe level. On the Windows job the
branch runs 827 tests against 820 on `master`, so all seven new cases execute
there; on Linux they are skipped and the rest of the suite is unaffected.

`yarn test:jest`, `yarn lint`, `yarn compile` and `nix fmt -- --ci` are clean.
