### PR TITLE
Align contributor documentation with the repository, and check that it stays aligned

### DIFF
--- a/.agent/readme.md
+++ b/.agent/readme.md
@@ -89,8 +89,8 @@ When an issue is resolved or a complex integration succeeds:
 
 | Skill                                                                  | Description                             |
 |------------------------------------------------------------------------|-----------------------------------------|
-| [`i18n-messaging`](./skills/frontend/i18n-messaging/SKILL.md)         | Manage react-intl i18n messaging        |
-| [`theme-management`](./skills/frontend/theme-management/SKILL.md)     | CSS variables theme system              |
+| [`i18n-messaging`](./skills/i18n-messaging/SKILL.md)         | Manage react-intl i18n messaging        |
+| [`theme-management`](./skills/theme-management/SKILL.md)     | CSS variables theme system              |
 | [`storybook-creation`](./skills/storybook-creation/SKILL.md)          | Create/update Storybook stories         |
 
 #### General
@@ -99,6 +99,7 @@ When an issue is resolved or a complex integration succeeds:
 |------------------------------------------------------------------------|-----------------------------------------|
 | [`e2e-test-creation`](./skills/e2e-test-creation/SKILL.md)            | Create Cucumber BDD e2e tests           |
 | [`git-commit-formatter`](./skills/git-commit-formatter/SKILL.md)      | Conventional commit formatting          |
+| [`thermo-nuclear-code-quality-review`](./skills/thermo-nuclear-code-quality-review/SKILL.md) | Strict maintainability audit |
 
 ---
 
@@ -171,7 +172,7 @@ Available workflows:
 
 | Layer                 | Technology            | Location                                      |
 |-----------------------|-----------------------|-----------------------------------------------|
-| **Desktop Framework** | Electron 24.2.0       | Root package.json                             |
+| **Desktop Framework** | Electron 41.3.0       | Root package.json                             |
 | **UI Library**        | React 16.14.0         | source/renderer/                              |
 | **State Management**  | MobX 5.15.7           | source/renderer/app/stores/                   |
 | **Component Library** | react-polymorph 1.0.4 | Widgets and forms                             |
@@ -179,7 +180,7 @@ Available workflows:
 | **Routing**           | React Router 5.2.0    | Hash history                                  |
 | **i18n**              | react-intl 2.9.0      | EN, JA locales                                |
 | **Build System**      | Nix + Webpack 5       | flake.nix, webpack configs                    |
-| **Testing**           | Jest + Cucumber       | tests/, *.test.tsx                            |
+| **Testing**           | Jest + Cucumber       | tests/, *.spec.ts                             |
 | **Hardware Wallets**  | Ledger, Trezor        | @cardano-foundation/ledgerjs, @trezor/connect |
 
 ### Key Directories

--- a/.agent/skills/theme-management/SKILL.md
+++ b/.agent/skills/theme-management/SKILL.md
@@ -425,9 +425,9 @@ Theme changes are validated in CI via:
 
 ## Related Documentation
 
-- **Theme Architecture**: [System Architecture - Theme System](./../../../system/architecture.md)
-- **Component Development**: [Storybook Workflow](./../../../workflows/storybook.md)
-- **Best Practices**: [BESTPRACTICES.md](./../../../../BESTPRACTICES.md)
+- **Theme Architecture**: [System Architecture - Theme System](../../system/architecture.md)
+- **Component Development**: [Storybook Workflow](../../workflows/storybook.md)
+- **Best Practices**: [BESTPRACTICES.md](../../../BESTPRACTICES.md)
 - **Theme Tutorial Series**: [Theme Tutorial Videos](https://www.youtube.com/playlist?list=PLhYa9Lr0WjdXN69m4B2pVyuP9UlAT1Xw_)
 
 ---
@@ -441,7 +441,7 @@ The Daedalus project includes comprehensive video tutorials on theme management:
 - **Part 3**: Writing theme CSS variables to output objects
 - **Part 4**: Using `themes:check:createTheme` for validation
 
-See [Theme README](./../../../../source/renderer/app/themes/README.md) for video links.
+See [Theme README](../../../source/renderer/app/themes/README.md) for video links.
 
 ---
 

--- a/.agent/system/state-management.md
+++ b/.agent/system/state-management.md
@@ -218,17 +218,29 @@ export type StoresMap = {
   // ... other stores
 };
 
-export const setupStores = (api: Api, actions: ActionsMap): StoresMap => {
-  const stores: Partial<StoresMap> = {};
-  
-  stores.widgets = new WidgetsStore(api, stores as StoresMap, actions);
-  // ... other stores
-  
-  // Setup all stores
-  Object.values(stores).forEach(store => store.setup?.());
-  
-  return stores as StoresMap;
-};
+export const setUpStores = action(
+  (
+    api: Api,
+    actions: ActionsMap,
+    router: RouterStore,
+    analyticsTracker: AnalyticsTracker
+  ): StoresMap => {
+    function createStoreInstanceOf<T extends Store>(
+      StoreSubClass: Class<T>
+    ): T {
+      return new StoreSubClass(api, actions, analyticsTracker);
+    }
+
+    stores = observable({
+      widgets: createStoreInstanceOf(WidgetsStore),
+      // ... other stores
+    });
+
+    // ... router wiring, then initialize every store
+    executeOnEveryStore((store) => store.initialize());
+    return stores;
+  }
+);
 ```
 
 ---

--- a/.agent/workflows/frontend.md
+++ b/.agent/workflows/frontend.md
@@ -173,7 +173,9 @@ components/wallet/
 ```typescript
 import React from 'react';
 import { observer } from 'mobx-react';
-import { defineMessages, intlShape } from 'react-intl';
+import { defineMessages, injectIntl } from 'react-intl';
+import { Input } from 'react-polymorph/lib/components';
+import { Intl } from '../../types/i18nTypes';
 import styles from './MyComponent.scss';
 
 const messages = defineMessages({
@@ -188,16 +190,14 @@ type Props = {
   onChange: (value: string) => void;
 };
 
-const MyComponent = observer(({ value, onChange }: Props) => {
-  const intl = useContext(IntlContext);
-  
-  return (
+const MyComponent = injectIntl(
+  observer(({ value, onChange, intl }: Props & { intl: Intl }) => (
     <div className={styles.container}>
       <h2>{intl.formatMessage(messages.title)}</h2>
       <Input value={value} onChange={onChange} />
     </div>
-  );
-});
+  ))
+);
 
 export default MyComponent;
 ```
@@ -241,7 +241,6 @@ import { InputSkin } from 'react-polymorph/lib/skins/simple';
 }
 
 .button {
-  composes: button from '../common/Button.scss';
   background: var(--theme-primary-color);
 }
 ```
@@ -293,7 +292,7 @@ yarn themes:update             # Update theme files
 yarn themes:copy               # Copy theme
 ```
 
-For full theme workflow details (createTheme object, validation, interactive CLI tools), see the [theme-management skill](../skills/frontend/theme-management/SKILL.md).
+For full theme workflow details (createTheme object, validation, interactive CLI tools), see the [theme-management skill](../skills/theme-management/SKILL.md).
 
 ---
 
@@ -339,7 +338,7 @@ yarn i18n:check     # Validate translations
 yarn i18n:manage    # Extract and validate
 ```
 
-For full i18n workflow details (message schema, naming conventions, locale management, and `!!!` placeholder handling after `yarn i18n:manage`), see the [i18n-messaging skill](../skills/frontend/i18n-messaging/SKILL.md).
+For full i18n workflow details (message schema, naming conventions, locale management, and `!!!` placeholder handling after `yarn i18n:manage`), see the [i18n-messaging skill](../skills/i18n-messaging/SKILL.md).
 
 ### Supported Locales
 

--- a/.agent/workflows/test.md
+++ b/.agent/workflows/test.md
@@ -264,16 +264,11 @@ This runs:
 2. `yarn test:unit` - Unit tests
 3. `yarn test:e2e:fail-fast` - E2E tests (stops on first failure)
 
-### Pre-commit Checks
+### Before pushing
 
-The pre-commit hook runs:
-```bash
-pretty-quick --staged
-```
+There are no git hooks in this repository, so nothing runs automatically on
+commit or push. Run the checks yourself:
 
-### Pre-push Checks
-
-The pre-push hook runs:
 ```bash
 yarn check:all
 ```

--- a/.agent/workflows/update-doc.md
+++ b/.agent/workflows/update-doc.md
@@ -83,7 +83,7 @@ Description of the workflow.
 
 \`\`\`bash
 # Primary command
-yarn command-here
+yarn {command}
 \`\`\`
 
 ## Detailed Steps

--- a/.github/ISSUE_TEMPLATE/hardware_wallet.yml
+++ b/.github/ISSUE_TEMPLATE/hardware_wallet.yml
@@ -1,0 +1,132 @@
+name: Hardware Wallet Problem
+description: Report a problem using a Ledger or Trezor device with Daedalus
+title: "[HW] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for problems connecting, pairing, or signing with a hardware wallet.
+
+        A hardware wallet problem depends on four versions that move independently: Daedalus, the device firmware, the Cardano app on the device, and the operating system. All four are asked for below, because a report missing any of them usually cannot be reproduced.
+
+        If you need individual help rather than to report a defect, please review the [Daedalus support guidance](https://github.com/input-output-hk/daedalus/blob/master/SUPPORT.md).
+
+        Never include a wallet recovery phrase, seed phrase, private key, spending password or other wallet secret in a GitHub issue. A hardware wallet will never ask you to type its recovery phrase into a computer.
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        In Daedalus, open `Help` > `Daedalus Diagnostics`, copy the diagnostic information using the copy control, and paste it here.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      options:
+        - Ledger Nano S
+        - Ledger Nano S Plus
+        - Ledger Nano X
+        - Trezor Model One
+        - Trezor Model T
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: device-firmware
+    attributes:
+      label: Device firmware version
+      description: Shown in the device settings, or in Ledger Live or Trezor Suite.
+      placeholder: "Example: 2.2.3"
+    validations:
+      required: true
+
+  - type: input
+    id: cardano-app-version
+    attributes:
+      label: Cardano app version (Ledger only)
+      description: The version of the Cardano application installed on the device, shown in Ledger Live under the installed apps. Trezor devices have no separate Cardano app, so leave this blank.
+      placeholder: "Example: 7.1.2"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: operation
+    attributes:
+      label: What were you doing
+      options:
+        - Pairing or adding the hardware wallet to Daedalus
+        - Daedalus does not detect the device at all
+        - Verifying an address on the device
+        - Signing a transaction
+        - Delegating or withdrawing rewards
+        - Voting or governance action
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: connection
+    attributes:
+      label: How is the device connected
+      options:
+        - USB directly to the computer
+        - USB through a hub, dock or adapter
+        - Bluetooth
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Describe what happened, including any message shown by Daedalus and anything shown on the device screen.
+
+        Device screen text matters. It is often the only indication of why the device rejected an operation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Connect the device and unlock it
+        2. Open the Cardano app on the device
+        3. In Daedalus, go to ...
+        4. Observe ...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: other-software
+    attributes:
+      label: Does the device work elsewhere
+      description: Whether the device is recognised by its own vendor software helps separate a Daedalus problem from a device or operating system one.
+      options:
+        - "Yes, Ledger Live or Trezor Suite recognises it"
+        - "No, the vendor software does not recognise it either"
+        - I have not tried
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing Daedalus issues and did not find one describing the same problem.
+          required: true
+        - label: I have not included a recovery phrase, seed phrase, private key, spending password or other wallet secret.
+          required: true
+        - label: I understand that this issue and anything I submit here will be publicly visible.
+          required: true

--- a/.github/ISSUE_TEMPLATE/sync_problem.yml
+++ b/.github/ISSUE_TEMPLATE/sync_problem.yml
@@ -1,0 +1,125 @@
+name: Sync or Connection Problem
+description: Report Daedalus failing to sync, connect, or start its node
+title: "[SYNC] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form when Daedalus will not connect, will not finish syncing, or the node stops or restarts on its own.
+
+        Sync problems are usually explained by the machine and the storage rather than by the steps taken, so the fields below ask about both.
+
+        If you need individual help rather than to report a defect, please review the [Daedalus support guidance](https://github.com/input-output-hk/daedalus/blob/master/SUPPORT.md).
+
+        Never include a wallet recovery phrase, seed phrase, private key, spending password or other wallet secret in a GitHub issue.
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        In Daedalus, open `Help` > `Daedalus Diagnostics`, copy the diagnostic information using the copy control, and paste it here.
+      render: text
+    validations:
+      required: true
+
+  - type: dropdown
+    id: symptom
+    attributes:
+      label: What happens
+      options:
+        - Sync starts but never completes
+        - Sync percentage goes backwards or resets
+        - Daedalus reports it cannot connect to the node
+        - The node stops or restarts repeatedly
+        - Daedalus stays on the loading screen
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: sync-percentage
+    attributes:
+      label: Sync percentage reached
+      description: The highest percentage Daedalus reached, if it reports one.
+      placeholder: "Example: 43%"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: storage-volume
+    attributes:
+      label: Where is the blockchain stored
+      description: |
+        The location is shown as the Daedalus state directory in `Help` > `Daedalus Diagnostics`. Do not paste the path itself; it contains your account name.
+      options:
+        - The default location on the system drive
+        - A different folder on the same internal drive
+        - A second internal drive
+        - An external USB or Thunderbolt drive
+        - A network drive, NAS, or mapped network location
+        - A cloud-synced folder, such as OneDrive, Dropbox or iCloud Drive
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: storage-link
+    attributes:
+      label: Was the storage location moved
+      description: Daedalus stores the blockchain in its state directory. Moving it elsewhere is usually done with a symbolic link or junction.
+      options:
+        - "No, it is where Daedalus put it"
+        - "Yes, moved using the setting in Daedalus"
+        - "Yes, moved manually with a symbolic link or junction"
+        - Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: onset
+    attributes:
+      label: When did this start
+      options:
+        - On a fresh installation
+        - After updating Daedalus
+        - After restoring or adding a wallet
+        - After moving the blockchain storage
+        - After an unexpected shutdown, crash or power loss
+        - It has always behaved this way
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Describe what you see, including any error text Daedalus displays.
+
+        If the problem is intermittent, say how often it happens and what tends to precede it.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What you have already tried
+      description: For example restarting, reinstalling, deleting the blockchain and resyncing, or moving the storage back to the default location.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing Daedalus issues and did not find one describing the same problem.
+          required: true
+        - label: I have not included a recovery phrase, seed phrase, private key, spending password or other wallet secret.
+          required: true
+        - label: I understand that this issue and anything I submit here will be publicly visible.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,73 +1,54 @@
 <!---
-Briefly describe the change.
+Briefly describe the change and why it is needed.
 -->
 
 This PR ...
 
-## Todos
-
-<!---
-Consider creating a TODO list to help others understand the progress of work in a WIP pull request.
--->
-
-- [ ] TODO
+Closes #
 
 ## Screenshots
 
 <!---
-Use the GitHub drag&drop feature to upload default-sized Daedalus window screenshots
-or animated GIFs of important UI changes in both English and Japanese.
-Do not use shadow or any effects. On macOS this can be accomplished the following way:
-1. Use the Command+Shift+4 keyboard shortcut.
-2. Press the Spacebar.
-3. Hold the Option button and click the window you want to capture.
+For user interface changes, attach screenshots or a short recording of a
+default-sized Daedalus window. Include both English and Japanese where the
+change affects text.
 -->
 
-## Testing Checklist
+## Verification
 
 <!---
-Open a thread on #daedalus-qa on Slack, mention `@daedalusqa` and `@daedalusteam`, link the thread below
+Name the checks you ran. Every CI check has an exact local equivalent:
+
+  nix build .#checks.x86_64-linux.lint
+  nix build .#checks.x86_64-linux.compile
+  nix build .#checks.x86_64-linux.stylelint
+  nix build .#checks.x86_64-linux.i18n
+  nix build .#checks.x86_64-linux.docs
+  nix build .#checks.x86_64-linux.jest
+  nix build .#checks.x86_64-linux.cucumber-unit
+  nix build .#checks.x86_64-linux.storybook
+
+Describe anything verified by hand that no check covers, and how.
 -->
 
-- [Slack QA thread](https://input-output-rnd.slack.com/messages/GGKFXSKC6)
-- [ ] Test
+- [ ] The checks relevant to this change pass locally
+- [ ] Anything verified by hand is described above
 
----
+## Tests
 
-## Review Checklist
+- [ ] A bug fix includes a test that fails without the fix
+- [ ] New behaviour is covered by tests, or the reason it cannot be is stated
 
-### Basics
+## Code quality
 
-- [ ] PR assigned to the PR author(s)
-- [ ] `input-output-hk/daedalus-dev` and `input-output-hk/daedalus-qa` assigned as PR reviewers
-- [ ] If there are UI changes, Alexander Rukin assigned as an additional reviewer
-- [ ] PR has appropriate labels (`release-vNext`, `feature`/`bug`/`chore`, `WIP`)
-- [ ] PR link is added to a Jira ticket, ticket moved to In Review
-- [ ] PR is updated to the most recent version of the target branch (and there are no conflicts)
-- [ ] PR has a good description that summarizes all changes
-- [ ] PR contains screenshots (in case of UI changes)
-- [ ] CHANGELOG entry has been added to the top of the appropriate section (_Features_, _Fixes_, _Chores_) and is linked to the correct PR on GitHub
-- [ ] There are no missing translations (running `yarn manage:translations` produces no changes)
-- [ ] Text changes are proofread and approved (Jane Wild / Amy Reeve)
-- [ ] Japanese text changes are proofread and approved (Junko Oda)
-- [ ] Storybook works and no stories are broken (`yarn storybook`)
-- [ ] In case of dependency changes `yarn.lock` file is updated
+- [ ] Code is typed, and introduces no new `@ts-ignore`
+- [ ] React components are split up enough to avoid unnecessary re-renders
+- [ ] Code that only works in the main process is separated from components
+- [ ] `yarn.lock` is updated if dependencies changed
 
-### Code Quality
+## Review
 
-- [ ] Important parts of the code are properly commented and documented
-- [ ] Code is properly typed with typescript types
-- [ ] React components are split-up enough to avoid unnecessary re-renderings
-- [ ] Any code that only works in main process is neatly separated from components
-
-### Testing
-
-- [ ] New feature/change is covered by acceptance tests
-- [ ] New feature/change is manually tested and approved by QA team
-- [ ] All existing acceptance tests are still up-to-date
-- [ ] New feature/change is covered by Daedalus Testing scenario
-- [ ] All existing Daedalus Testing scenarios are still up-to-date
-
-### After Review
-
-- [ ] Update Slack QA thread by marking it with a green checkmark
+- [ ] PR is assigned to its author
+- [ ] PR carries the labels that apply to it
+- [ ] PR is current with the target branch and has no conflicts
+- [ ] The description above summarises every change in the PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Use these slash commands to access workflows:
 
 | Layer              | Technology                  |
 |--------------------|-----------------------------|
-| Desktop Framework  | Electron 24.2.0             |
+| Desktop Framework  | Electron 41.3.0             |
 | UI Library         | React 16.14.0               |
 | State Management   | MobX 5.15.7                 |
 | Component Library  | react-polymorph 1.0.4       |

--- a/installers/README.md
+++ b/installers/README.md
@@ -14,16 +14,10 @@ The certificate is required to be in PKCS#12 format. It will prompt
 for a certificate decryption password, or you can put this in the
 `CERT_PASS` environment variable.
 
-## Bumping cardano-sl version
+## Bumping the backend versions
 
-The cardano-sl node and configuration files used by the installer
-builder are available as the `daedalus-bridge` attribute of the
-top-level file [`default.nix`](../default.nix). To get/build the
-files, run:
-
-    nix-build -A daedalus-bridge
-    ls result/
-
-To update the cardano-sl version, update the revision in
-[`cardano-sl-src.json`](../cardano-sl-src.json). This replaces the
-`CARDANO_SL_BRANCH` environment variable which was previously used.
+The node and wallet the installer bundles are pinned as flake inputs in
+[`flake.nix`](../flake.nix), with the resolved revisions in
+[`flake.lock`](../flake.lock). To change either version, update its input
+revision and run `nix flake lock --update-input cardano-node` (or
+`cardano-wallet`).

--- a/perSystem/checks.nix
+++ b/perSystem/checks.nix
@@ -77,6 +77,11 @@
         '';
         storybook = mkJsCheck "daedalus-storybook-build" "yarn storybook:build";
         shellcheck = pkgs.callPackage ../tests/shellcheck.nix {src = inputs.self;};
+        # Documentation drifts silently because prose cannot fail. This asserts
+        # the parts of it that are mechanically decidable: that links resolve,
+        # that scripts named in instructions exist, that dead references stay
+        # dead, and that versions restated in prose match package.json.
+        docs = pkgs.callPackage ../tests/docs.nix {src = inputs.self;};
       };
   };
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -68,22 +68,9 @@ still broken.
 
 ### Running tests for development
 1. Mark the test or scenario you are working with @watch annotation
-2. Make sure you are in the nix console (`yarn nix:dev`)
+2. Make sure you are in the nix shell (`yarn nix:selfnode`)
 3. Make sure your state is clean (`rm -rf ~/Library/Application\ Support/Daedalus\ Selfnode/`)
 4. Run tests with `yarn test:e2e:watch:once`
-
-### Run all tests
-
-```bash
-$ yarn test
-```
-
-### Running Byron specific tests
-1. Make sure you are in the nix console (`yarn nix:dev`)
-2. Make sure your state is clean (`rm -rf ~/Library/Application\ Support/Daedalus\ Selfnode/`)
-3. Run tests with `yarn test:e2e:byron`
-
-Once tests are complete you will get a summary of passed/failed tests in the Terminal window.
 
 ### Run all tests
 

--- a/tests/docs-check.js
+++ b/tests/docs-check.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+//
+// Asserts that the documentation says things that are still true.
+//
+// Documentation in this repository has drifted before in ways no check could
+// catch: a link to a directory that was renamed, an instruction to run a script
+// that was itself renamed, a version number restated in prose that fell 17
+// major releases behind the dependency it named. Each of those is mechanically
+// decidable, and none of them was decided, because nothing looked.
+//
+// The four assertions below are the ones that can be made without a judgement
+// call. A claim this check cannot express belongs in prose; a claim it can
+// belongs here, because prose is not load-bearing and a failing build is.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.argv[2] || process.cwd();
+
+// Directories that never contain documentation we assert over.
+const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'release',
+  'installers/icons',
+]);
+
+// `.agent/plans/` is a record of work as it stood when it was written, and
+// `CHANGELOG.md` is a record of releases that have shipped. Both are correct
+// as history and wrong as present-tense instruction, by design. Asserting
+// present-tense truth over them would either fail permanently or require
+// rewriting the record to keep a check green, and rewriting the record is
+// worse than the drift.
+const EXCLUDED = [
+  (f) => f.startsWith('.agent/plans/'),
+  (f) => f === 'CHANGELOG.md',
+];
+
+// yarn's own subcommands. `yarn link` is not a missing script.
+const YARN_BUILTINS = new Set([
+  'add',
+  'audit',
+  'autoclean',
+  'bin',
+  'cache',
+  'check',
+  'config',
+  'create',
+  'dedupe',
+  'exec',
+  'generate-lock-entry',
+  'global',
+  'help',
+  'import',
+  'info',
+  'init',
+  'install',
+  'licenses',
+  'link',
+  'list',
+  'login',
+  'logout',
+  'node',
+  'outdated',
+  'owner',
+  'pack',
+  'policies',
+  'publish',
+  'remove',
+  'run',
+  'set',
+  'tag',
+  'team',
+  'unlink',
+  'upgrade',
+  'upgrade-interactive',
+  'version',
+  'versions',
+  'why',
+  'workspace',
+  'workspaces',
+]);
+
+// Commands documented here that are deliberately not Daedalus scripts. Each
+// entry needs a reason; without one it is indistinguishable from drift.
+const YARN_EXCEPTIONS = {
+  // README's yarn-link instructions run this in the linked library's tree.
+  'README.md': new Set(['build:watch']),
+};
+
+// References to systems this project no longer uses. They are dead rather than
+// merely stale: following one leads to a workspace, tracker or toolchain that
+// is not there. A reader cannot tell the difference from the page, which is
+// why these are worth naming individually rather than trusting review to catch.
+const DENIED = [
+  ['input-output-rnd.slack.com', 'a Slack workspace this project cannot reach'],
+  ['daedalus-qa', 'a GitHub team that does not exist'],
+  ['daedalus-dev', 'a GitHub team that does not exist'],
+  ['manage:translations', 'renamed; the script is i18n:manage'],
+  ['flow-typed', 'Flow was removed from this codebase'],
+  ['DDW-', 'an issue-tracker prefix no longer in use'],
+  ['YouTrack', 'not the tracker for this project'],
+  ['Jira', 'not the tracker for this project'],
+];
+
+// Files exempted from the denylist, with the reason. An exemption is a debt,
+// not a resolution.
+const DENY_EXCEPTIONS = {
+  // Retiring this document is a decision in its own right. Until it is taken,
+  // exempt the file rather than half-editing a document that is going away.
+  'BESTPRACTICES.md': true,
+};
+
+// Versions restated in prose, and the dependency each one claims to describe.
+// Longest key first: "React Router" must not be read as "React".
+const VERSION_CLAIMS = [
+  ['React Router', 'react-router'],
+  ['react-polymorph', 'react-polymorph'],
+  ['react-intl', 'react-intl'],
+  ['Electron', 'electron'],
+  ['Webpack', 'webpack'],
+  ['MobX', 'mobx'],
+  ['React', 'react'],
+];
+
+const failures = [];
+const fail = (file, line, msg) =>
+  failures.push(`${file}${line ? ':' + line : ''}  ${msg}`);
+
+function walk(dir, out) {
+  for (const entry of fs.readdirSync(path.join(ROOT, dir || '.'))) {
+    const rel = dir ? `${dir}/${entry}` : entry;
+    if (SKIP_DIRS.has(rel) || SKIP_DIRS.has(entry)) continue;
+    const stat = fs.lstatSync(path.join(ROOT, rel));
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) walk(rel, out);
+    else if (entry.endsWith('.md')) out.push(rel);
+  }
+  return out;
+}
+
+const lineOf = (text, index) => text.slice(0, index).split('\n').length;
+
+// Everything outside fenced blocks and inline code, for link checking. Links
+// inside a code sample are illustrative and are not expected to resolve.
+const prose = (text) =>
+  text
+    .replace(/```[\s\S]*?```/g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/`[^`\n]*`/g, (m) => ' '.repeat(m.length));
+
+// Only code spans and fenced blocks, for command checking. A command named in
+// prose without backticks is usually a noun, not an instruction.
+function codeRegions(text) {
+  const out = [];
+  for (const m of text.matchAll(/```[a-zA-Z]*\n([\s\S]*?)```/g))
+    out.push([m[1], m.index + m[0].indexOf('\n') + 1]);
+  for (const m of text.matchAll(/`([^`\n]+)`/g)) out.push([m[1], m.index + 1]);
+  return out;
+}
+
+function checkLinks(file, text) {
+  const body = prose(text);
+  for (const m of body.matchAll(/\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)) {
+    const target = m[1];
+    if (/^(https?:|mailto:|#)/.test(target)) continue;
+    const [p] = target.split('#');
+    if (!p) continue;
+    let decoded;
+    try {
+      decoded = decodeURIComponent(p);
+    } catch {
+      decoded = p;
+    }
+    const abs = path.resolve(ROOT, path.dirname(file), decoded);
+    if (!fs.existsSync(abs))
+      fail(file, lineOf(text, m.index), `link does not resolve: ${target}`);
+  }
+}
+
+function checkYarnScripts(file, text, scripts) {
+  const allowed = YARN_EXCEPTIONS[file] || new Set();
+  for (const [region, offset] of codeRegions(text)) {
+    for (const m of region.matchAll(/\byarn\s+([a-zA-Z][a-zA-Z0-9:_.-]*)/g)) {
+      const name = m[1];
+      // `yarn nix:*` and `yarn nix:<network>` stand for a set, not a script.
+      const next = region[m.index + m[0].length];
+      if (name.endsWith(':') || next === '*' || next === '<') continue;
+      if (scripts.has(name) || YARN_BUILTINS.has(name) || allowed.has(name))
+        continue;
+      fail(
+        file,
+        lineOf(text, offset + m.index),
+        `documents 'yarn ${name}', which is not a script in package.json`
+      );
+    }
+  }
+}
+
+function checkDenied(file, text) {
+  if (DENY_EXCEPTIONS[file]) return;
+  for (const [needle, why] of DENIED) {
+    let i = text.indexOf(needle);
+    while (i !== -1) {
+      fail(file, lineOf(text, i), `refers to '${needle}': ${why}`);
+      i = text.indexOf(needle, i + needle.length);
+    }
+  }
+}
+
+function checkVersions(file, text, deps) {
+  const seen = [];
+  for (const [label, pkg] of VERSION_CLAIMS) {
+    const actual = deps[pkg];
+    if (!actual) continue;
+    const re = new RegExp(
+      `\\b${label.replace(/ /g, '\\s+')}\\s+v?(\\d+(?:\\.\\d+)*)\\b`,
+      'g'
+    );
+    for (const m of text.matchAll(re)) {
+      // "React Router 5.2.0" already consumed; do not read it again as "React".
+      if (seen.some(([s, e]) => m.index >= s && m.index < e)) continue;
+      seen.push([m.index, m.index + m[0].length]);
+      const claimed = m[1];
+      const resolved = actual.replace(/^[\^~>=<\s]+/, '');
+      if (resolved !== claimed && !resolved.startsWith(claimed + '.'))
+        fail(
+          file,
+          lineOf(text, m.index),
+          `states ${label} ${claimed}; package.json resolves ${pkg} to ${resolved}`
+        );
+    }
+  }
+}
+
+function main() {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8')
+  );
+  const scripts = new Set(Object.keys(pkg.scripts || {}));
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+
+  const files = walk('', []).filter((f) => !EXCLUDED.some((fn) => fn(f)));
+  files.sort();
+
+  for (const file of files) {
+    const text = fs.readFileSync(path.join(ROOT, file), 'utf8');
+    checkLinks(file, text);
+    checkYarnScripts(file, text, scripts);
+    checkDenied(file, text);
+    checkVersions(file, text, deps);
+  }
+
+  if (failures.length) {
+    console.error(
+      `\nDocumentation check failed, ${failures.length} problem(s):\n`
+    );
+    for (const f of failures) console.error('  ' + f);
+    console.error('');
+    process.exit(1);
+  }
+  console.log(`Documentation check passed over ${files.length} files.`);
+}
+
+main();

--- a/tests/docs.nix
+++ b/tests/docs.nix
@@ -1,0 +1,13 @@
+{
+  nodejs,
+  runCommand,
+  src,
+}:
+# The whole source tree is the input, not just the markdown. The link assertion
+# resolves references to any tracked file (flake.nix, a component, a SKILL.md),
+# so a filtered source would report links as broken here that resolve for every
+# reader, which is the opposite of what this check is for.
+runCommand "daedalus-docs" {nativeBuildInputs = [nodejs];} ''
+  node ${src}/tests/docs-check.js ${src}
+  touch $out
+''


### PR DESCRIPTION
## Summary

Brings the contributor-facing documentation in line with the repository as it actually is, and adds a check so the next divergence fails a build instead of misleading a reader.

Every correction below was verified against the tree rather than assumed.

Tracking: se7en-labs-inc/daedalus#14, whose first two tasks ship in #3387. The two forms here cover the report categories that a general bug form serves worst.

## The pull request template

The checklist required a thread on a Slack workspace this project cannot reach, two GitHub teams that do not exist, a named individual reviewer, and a Jira ticket. It asked for `yarn manage:translations`, which is now `yarn i18n:manage`, and a CHANGELOG entry that 20 of the last 25 merged pull requests did not add.

The replacement names the exact local command for every CI check, so a reviewer reproduces what the build will do rather than asserting it from memory. The code quality items carry over unchanged.

## Issue forms for sync and hardware wallet problems

Sync failures are explained by where the blockchain is stored and on what kind of volume, not by the steps the user took. Hardware wallet failures depend on four components that version independently: Daedalus, the device firmware, the Cardano app, and the operating system. A general bug form asks for none of that, so those reports arrive needing a round trip before triage can begin.

Both forms open with the diagnostic information from `Help` > `Daedalus Diagnostics`. That instruction assumes the copy control in #3384; until it lands there is nothing for a reporter to click, so the two want to land together or close to it.

The device list is the set Daedalus supports, from `source/common/types/hardware-wallets.types.ts`.

## Corrections to the guidance set

| Claim | Reality |
|---|---|
| `AGENTS.md` and `.agent/readme.md`: Electron 24.2.0 | `package.json` resolves 41.3.0 |
| Both tables: tests are `*.test.tsx` | 73 `*.spec.ts`, zero `*.test.tsx` |
| Two skills linked under `skills/frontend/` | They live directly under `skills/` |
| `theme-management/SKILL.md`: four links | All resolve above the repository root |
| `frontend.md`: `useContext(IntlContext)` | Absent from the tree; the API postdates react-intl 2.9.0 |
| `frontend.md`: `composes:` in SCSS | Zero occurrences in `source/` |
| `test.md`: pre-commit and pre-push hooks | No git hooks; no husky, no lefthook |
| `state-management.md`: `setupStores(api, actions)` | `setUpStores`, four parameters |
| `tests/README.md`: `yarn test:e2e:byron`, `yarn nix:dev` | Neither script exists; no `@byron` scenarios |
| `installers/README.md`: `default.nix`, `cardano-sl-src.json` | Neither file is present |

The skills table also omitted `thermo-nuclear-code-quality-review`.

## The check

Documentation drifts here because nothing can fail. Each correction above was mechanically decidable and none of it was decided, because no check looked.

`nix build .#checks.x86_64-linux.docs` makes four assertions over tracked markdown:

1. Every relative link resolves.
2. Every `yarn` command named inside backticks is a script in `package.json`, a yarn subcommand, or a listed exception carrying its reason.
3. References to systems this project no longer uses do not reappear.
4. Versions restated in prose match what `package.json` resolves.

`.agent/plans/` and `CHANGELOG.md` are excluded. Both are records of what was true when written, correct as history and wrong as present-tense instruction. Asserting over them would either fail permanently or require editing the record to keep a build green.

`BESTPRACTICES.md` is exempt from the third assertion, with the reason recorded in the check. Its Git chapter prescribes a `develop` branch and YouTrack identifiers; retiring that document is a decision in its own right, and half-editing a file that may be going away is worse than naming the exemption.

## Verification

`nix build .#checks.x86_64-linux.docs` passes over 51 files. Reintroducing each historical failure was confirmed to fail it:

```
.agent/readme.md:92   link does not resolve: ./skills/frontend/i18n-messaging/SKILL.md
.agent/readme.md:274  documents 'yarn manage:translations', which is not a script in package.json
.agent/readme.md:274  refers to 'daedalus-qa': a GitHub team that does not exist
AGENTS.md:49          states Electron 24.2.0; package.json resolves electron to 41.3.0
```

`nix fmt` reports no changes. Both issue forms parse as GitHub issue form schemas.

