### PR TITLE
Give the selected DRep name an explicit color on the voting power delegation screen

### DIFF
--- a/source/renderer/app/components/voting/voting-governance/VotingPowerDelegation.scss
+++ b/source/renderer/app/components/voting/voting-governance/VotingPowerDelegation.scss
@@ -123,6 +123,7 @@ span.link {
 }
 
 .selectedDRepName {
+  color: var(--theme-gov-font-color-accent);
   font-family: var(--font-semibold);
   font-size: 14px;
   margin-bottom: 8px;


### PR DESCRIPTION
Closes #3393

`.selectedDRepName` in `VotingPowerDelegation.scss` set a font family and size but no `color`, and nothing in its ancestor chain (`.selectedDRepSection`, the `BorderedBox` wrapper, `.component`) supplies one — so the DRep name fell back to browser-default black, which is nearly unreadable on the `#1e1f31` panel in the Dark Cardano theme.

This adds `color: var(--theme-gov-font-color-accent)` to the rule, matching how `.targetName` in `GovernanceWallets.scss` styles the same value on the Governance Center. The alternative of coloring the container was avoided, as every other text rule on this card names its own token.

One-line change; the token is defined in every theme.