### PR TITLE
Let the DRep status badge carry its own font family

### DIFF
--- a/source/renderer/app/components/governance/_shared/DRepStatusBadge.scss
+++ b/source/renderer/app/components/governance/_shared/DRepStatusBadge.scss
@@ -6,8 +6,8 @@
   align-items: center;
   border-radius: 4px;
   display: inline-flex;
+  font-family: var(--font-medium);
   font-size: 14px;
-  font-weight: 500;
   line-height: 1;
   padding: 4px 8px;
 }


### PR DESCRIPTION
Closes #3394

`.badge` in `DRepStatusBadge.scss` set `font-size` and `font-weight` but no `font-family`. On screens whose container supplies a family (DRep directory, Governance Center via `%regularText`) that goes unnoticed, but `.component` in `VotingPowerDelegation.scss` sets none — so on the delegation form the badge fell through to the deliberately ugly `Times New Roman` sentinel that `index.global.scss` sets on the root.

This adds `font-family: var(--font-medium)` on the badge itself, so the shared component renders correctly in any container, and drops `font-weight: 500` — the Noto Sans faces are loaded as separate families, so weight is expressed by picking a face and the numeric declaration had nothing to act on.

Fixing the shared component covers the directory, DRep detail page, Governance Center, and the delegation form together.