### PR TITLE
fix(governance): preserve wallet in delegation flow

### DIFF
--- a/source/renderer/app/components/governance/wallets/GovernanceWallets.spec.tsx
+++ b/source/renderer/app/components/governance/wallets/GovernanceWallets.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { ThemeProvider } from 'react-polymorph/lib/components/ThemeProvider';
+import { SimpleSkins } from 'react-polymorph/lib/skins/simple';
+import { SimpleDefaults } from 'react-polymorph/lib/themes/simple';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import translations from '../../../i18n/locales/en-US.json';
+import { daedalusTheme } from '../../../themes/daedalus';
+import { themeOverrides } from '../../../themes/overrides';
+import GovernanceWallets from './GovernanceWallets';
+
+describe('GovernanceWallets', () => {
+  afterEach(cleanup);
+
+  it('starts delegation with the wallet selected in the Governance Center', () => {
+    const onChangeDelegation = jest.fn();
+
+    render(
+      <ThemeProvider
+        theme={daedalusTheme}
+        skins={SimpleSkins}
+        variables={SimpleDefaults}
+        themeOverrides={themeOverrides}
+      >
+        <IntlProvider locale="en-US" messages={translations}>
+          <GovernanceWallets
+            wallets={[
+              {
+                walletId: 'wallet-2',
+                walletName: 'Savings',
+                currentDRep: null,
+                drepEntry: null,
+              },
+            ]}
+            favoriteDRepIds={new Set()}
+            onToggleFavorite={jest.fn()}
+            onChangeDelegation={onChangeDelegation}
+            onViewDetails={jest.fn()}
+            onExternalLinkClick={jest.fn()}
+          />
+        </IntlProvider>
+      </ThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delegate' }));
+
+    expect(onChangeDelegation).toHaveBeenCalledWith('wallet-2');
+  });
+});

--- a/source/renderer/app/components/governance/wallets/GovernanceWallets.tsx
+++ b/source/renderer/app/components/governance/wallets/GovernanceWallets.tsx
@@ -71,7 +71,6 @@ type Props = {
   totalDRepStake?: BigNumber | null;
   onToggleFavorite: (drepId: string) => void;
   onChangeDelegation: (walletId: string) => void;
-  onChooseDRep: () => void;
   onViewDetails: (drepId: string, walletId: string) => void;
   onExternalLinkClick: (url: string, event?: React.MouseEvent) => void;
   intl: intlShape.isRequired;
@@ -88,13 +87,11 @@ type Props = {
 function WalletDelegationRow({
   wallet,
   onChangeDelegation,
-  onChooseDRep,
   onViewDetails,
   intl,
 }: {
   wallet: WalletDelegationSummary;
   onChangeDelegation: (walletId: string) => void;
-  onChooseDRep: () => void;
   onViewDetails: (drepId: string, walletId: string) => void;
   intl: intlShape.isRequired;
 }) {
@@ -173,9 +170,7 @@ function WalletDelegationRow({
               ? globalMessages.delegate
               : globalMessages.redelegate
           )}
-          onClick={() =>
-            currentDRep == null ? onChooseDRep() : onChangeDelegation(walletId)
-          }
+          onClick={() => onChangeDelegation(walletId)}
           skin={ButtonSkin}
         />
       </td>
@@ -189,7 +184,6 @@ function GovernanceWallets({
   totalDRepStake = null,
   onToggleFavorite,
   onChangeDelegation,
-  onChooseDRep,
   onViewDetails,
   onExternalLinkClick,
   intl,
@@ -254,7 +248,6 @@ function GovernanceWallets({
                   key={wallet.walletId}
                   wallet={wallet}
                   onChangeDelegation={onChangeDelegation}
-                  onChooseDRep={onChooseDRep}
                   onViewDetails={onViewDetails}
                   intl={intl}
                 />

--- a/source/renderer/app/containers/governance/GovernanceWalletsPage.tsx
+++ b/source/renderer/app/containers/governance/GovernanceWalletsPage.tsx
@@ -46,10 +46,6 @@ class GovernanceWalletsPage extends React.Component<Props> {
     this.props.history.push(ROUTES.GOVERNANCE.DREPS);
   };
 
-  handleChooseDRep = () => {
-    this.props.history.push(ROUTES.GOVERNANCE.DREPS);
-  };
-
   handleViewDetails = (drepId: string, walletId: string) => {
     const { governance } = this.props.stores ?? {};
     governance?.setDelegationNavState({ selectedWalletId: walletId });
@@ -81,7 +77,6 @@ class GovernanceWalletsPage extends React.Component<Props> {
         totalDRepStake={governance?.drepSummary?.totalDRepStake ?? null}
         onToggleFavorite={(drepId) => governance?.toggleFavorite(drepId)}
         onChangeDelegation={this.handleChangeDelegation}
-        onChooseDRep={this.handleChooseDRep}
         onViewDetails={this.handleViewDetails}
         onExternalLinkClick={(url, event) => app?.openExternalLink(url, event)}
       />

--- a/storybook/stories/governance/DRepDirectory.stories.tsx
+++ b/storybook/stories/governance/DRepDirectory.stories.tsx
@@ -465,8 +465,7 @@ storiesOf('Governance / DRep Directory', module)
                       favoriteDRepIds={new Set(store.state.favoriteDRepIds)}
                       totalDRepStake={TOTAL_DREP_STAKE}
                       onToggleFavorite={action('onToggleFavorite')}
-                      onChangeDelegation={action('onChangeDelegation')}
-                      onChooseDRep={() =>
+                      onChangeDelegation={() =>
                         store.set({
                           currentContentRoute: ROUTES.GOVERNANCE.DREPS,
                         })

--- a/storybook/stories/governance/GovernanceWallets.stories.tsx
+++ b/storybook/stories/governance/GovernanceWallets.stories.tsx
@@ -89,7 +89,6 @@ const render = (walletList: WalletDelegationSummary[]) => (
       totalDRepStake={TOTAL_DREP_STAKE}
       onToggleFavorite={action('onToggleFavorite')}
       onChangeDelegation={action('onChangeDelegation')}
-      onChooseDRep={action('onChooseDRep')}
       onViewDetails={action('onViewDetails')}
       onExternalLinkClick={action('onExternalLinkClick')}
     />

--- a/storybook/stories/governance/_utils/governancePages.tsx
+++ b/storybook/stories/governance/_utils/governancePages.tsx
@@ -101,7 +101,6 @@ export function renderGovernancePage(
         totalDRepStake={TOTAL_DREP_STAKE}
         onToggleFavorite={action('onToggleFavorite')}
         onChangeDelegation={action('onChangeDelegation')}
-        onChooseDRep={action('onChooseDRep')}
         onViewDetails={action('onViewDetails')}
       />
     );


### PR DESCRIPTION
## Summary

I route both Delegate and Redelegate actions through the same wallet-aware handler. This records the selected wallet before opening the DRep directory, so the delegation form no longer loses the choice or reuses stale navigation state.

I also added a focused component test that verifies an undelegated wallet's Delegate action forwards its wallet ID.

## Validation

- `jest source/renderer/app/components/governance/wallets/GovernanceWallets.spec.tsx --runInBand --coverage=false`
- `tsc --noEmit`
- `eslint --quiet` on the changed TypeScript and Storybook files
- `git diff --check origin/master...HEAD`

I did not run the full Nix/Electron build locally; CI can cover the complete build and suite.

Fixes #3392
