### PR TITLE
fix(transactions): label expired transactions as failed in CSV exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Correct transaction CSV exports to label expired transactions as failed instead of confirmed.
+- Correct transaction CSV exports to label expired transactions as failed instead of confirmed ([PR #3399](https://github.com/input-output-hk/daedalus/pull/3399)).
 
 ## 11.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Correct transaction CSV exports to label expired transactions as failed instead of confirmed.
+
 ## 11.3.0
 
 ### Features

--- a/source/renderer/app/i18n/locales/defaultMessages.json
+++ b/source/renderer/app/i18n/locales/defaultMessages.json
@@ -627,6 +627,11 @@
         "id": "wallet.transactions.csv.value.statusPending"
       },
       {
+        "defaultMessage": "!!!Failed",
+        "description": "Transactions CSV value - Status Failed",
+        "id": "wallet.transactions.csv.value.statusFailed"
+      },
+      {
         "defaultMessage": "!!!Transactions",
         "description": "Transactions CSV \"Transactions\" filename",
         "id": "wallet.transactions.csv.filenamePrefix"

--- a/source/renderer/app/i18n/locales/en-US.json
+++ b/source/renderer/app/i18n/locales/en-US.json
@@ -1606,6 +1606,7 @@
   "wallet.transactions.csv.column.withdrawals": "Withdrawals",
   "wallet.transactions.csv.filenamePrefix": "Transactions",
   "wallet.transactions.csv.value.statusConfirmed": "Confirmed",
+  "wallet.transactions.csv.value.statusFailed": "Failed",
   "wallet.transactions.csv.value.statusPending": "Pending",
   "wallet.transactions.csv.value.type.received": "Received",
   "wallet.transactions.csv.value.type.sent": "Sent",

--- a/source/renderer/app/i18n/locales/ja-JP.json
+++ b/source/renderer/app/i18n/locales/ja-JP.json
@@ -1606,6 +1606,7 @@
   "wallet.transactions.csv.column.withdrawals": "引き出し",
   "wallet.transactions.csv.filenamePrefix": "トランザクション",
   "wallet.transactions.csv.value.statusConfirmed": "承認済み",
+  "wallet.transactions.csv.value.statusFailed": "失敗しました",
   "wallet.transactions.csv.value.statusPending": "保留中",
   "wallet.transactions.csv.value.type.received": "入金",
   "wallet.transactions.csv.value.type.sent": "送金",

--- a/source/renderer/app/utils/transactionsCsvGenerator.spec.ts
+++ b/source/renderer/app/utils/transactionsCsvGenerator.spec.ts
@@ -1,0 +1,131 @@
+import BigNumber from 'bignumber.js';
+import { addLocaleData, IntlProvider } from 'react-intl';
+import ja from 'react-intl/locale-data/ja';
+import type { TransactionState } from '../api/transactions/types';
+import { WalletTransaction } from '../domains/WalletTransaction';
+import enTranslations from '../i18n/locales/en-US.json';
+import jaTranslations from '../i18n/locales/ja-JP.json';
+import { generateCsvChannel } from '../ipc/generateCsvChannel';
+import { showSaveDialogChannel } from '../ipc/show-file-dialog-channels';
+import transactionsCsvGenerator from './transactionsCsvGenerator';
+
+jest.mock('../ipc/generateCsvChannel', () => ({
+  generateCsvChannel: { send: jest.fn() },
+}));
+jest.mock('../ipc/show-file-dialog-channels', () => ({
+  showSaveDialogChannel: { send: jest.fn() },
+}));
+
+const saveDialog = showSaveDialogChannel.send as jest.MockedFunction<
+  typeof showSaveDialogChannel.send
+>;
+const generateCsv = generateCsvChannel.send as jest.MockedFunction<
+  typeof generateCsvChannel.send
+>;
+const filePath = '/desktop/transactions.csv';
+const date = new Date('2026-01-02T03:04:05.000Z');
+const createTransaction = (
+  state: TransactionState,
+  transactionDate: Date | null
+) =>
+  new WalletTransaction({
+    id: state,
+    type: 'expend',
+    title: '',
+    amount: new BigNumber('-1.2'),
+    fee: new BigNumber('0.2'),
+    deposit: new BigNumber(0),
+    date: transactionDate,
+    assets: [],
+    description: '',
+    addresses: {
+      from: ['source-address'],
+      to: ['target-address'],
+      withdrawals: [],
+    },
+    state,
+    confirmations: 0,
+    slotNumber: null,
+    epochNumber: null,
+    metadata: null,
+  });
+const params = {
+  desktopDirectoryPath: '/desktop',
+  walletName: 'Test wallet',
+  transactions: [
+    createTransaction('pending', date),
+    createTransaction('in_ledger', date),
+    createTransaction('expired', null),
+  ],
+  getAsset: jest.fn(),
+  isInternalAddress: jest.fn(),
+};
+
+describe('transactionsCsvGenerator', () => {
+  beforeAll(() => addLocaleData(ja));
+
+  beforeEach(() => {
+    saveDialog.mockResolvedValue({ canceled: false, filePath });
+  });
+
+  test.each([
+    {
+      locale: 'en-US',
+      messages: enTranslations,
+      statuses: ['Pending', 'Confirmed', 'Failed'],
+    },
+    {
+      locale: 'ja-JP',
+      messages: jaTranslations,
+      statuses: ['保留中', '承認済み', '失敗しました'],
+    },
+  ])(
+    'exports transaction statuses in $locale',
+    async ({ locale, messages, statuses }) => {
+      const { intl } = new IntlProvider(
+        { locale, messages },
+        {}
+      ).getChildContext();
+
+      await expect(transactionsCsvGenerator({ ...params, intl })).resolves.toBe(
+        true
+      );
+
+      expect(generateCsv).toHaveBeenCalledTimes(1);
+      const [request] = generateCsv.mock.calls[0];
+      expect(request.filePath).toBe(filePath);
+      const [columns, ...rows] = request.fileContent;
+      const statusColumn = columns.indexOf(
+        messages['wallet.transactions.csv.column.status']
+      );
+      const dateColumn = columns.indexOf(
+        messages['wallet.transactions.csv.column.dateTime']
+      );
+
+      expect(rows.map((row) => row[0])).toEqual([
+        'pending',
+        'in_ledger',
+        'expired',
+      ]);
+      expect(rows.map((row) => row[statusColumn])).toEqual(statuses);
+      expect(rows.map((row) => row[dateColumn])).toEqual([
+        date.toISOString(),
+        date.toISOString(),
+        '',
+      ]);
+    }
+  );
+
+  it('does not generate a CSV when the save dialog is canceled', async () => {
+    saveDialog.mockResolvedValue({ canceled: true });
+    const { intl } = new IntlProvider(
+      { locale: 'en-US', messages: enTranslations },
+      {}
+    ).getChildContext();
+
+    await expect(transactionsCsvGenerator({ ...params, intl })).resolves.toBe(
+      false
+    );
+    expect(generateCsv).not.toHaveBeenCalled();
+  });
+});

--- a/source/renderer/app/utils/transactionsCsvGenerator.ts
+++ b/source/renderer/app/utils/transactionsCsvGenerator.ts
@@ -14,6 +14,7 @@ import {
 } from './formatters';
 import { WALLET_ASSETS_ENABLED } from '../config/walletsConfig';
 import { filterAssets } from './assets';
+import type { TransactionState } from '../api/transactions/types';
 
 const messages = defineMessages({
   columnID: {
@@ -96,12 +97,26 @@ const messages = defineMessages({
     defaultMessage: '!!!Pending',
     description: 'Transactions CSV value - Status Pending',
   },
+  valueStatusFailed: {
+    id: 'wallet.transactions.csv.value.statusFailed',
+    defaultMessage: '!!!Failed',
+    description: 'Transactions CSV value - Status Failed',
+  },
   filenamePrefix: {
     id: 'wallet.transactions.csv.filenamePrefix',
     defaultMessage: '!!!Transactions',
     description: 'Transactions CSV "Transactions" filename',
   },
 });
+const statusMessages: Record<
+  TransactionState,
+  typeof messages.valueStatusPending
+> = {
+  pending: messages.valueStatusPending,
+  in_ledger: messages.valueStatusConfirmed,
+  expired: messages.valueStatusFailed,
+};
+
 type Params = {
   desktopDirectoryPath: string;
   intl: intlShape;
@@ -199,10 +214,7 @@ const transactionsCsvGenerator = async ({
         })
         .join(', ');
       const valueDateTime = date ? date.toISOString() : '';
-      const valueStatus =
-        state === 'pending'
-          ? intl.formatMessage(messages.valueStatusPending)
-          : intl.formatMessage(messages.valueStatusConfirmed);
+      const valueStatus = intl.formatMessage(statusMessages[state]);
       const valueAddressesFrom = !includes(addresses.from, null)
         ? addresses.from.join(', ')
         : ' ';

--- a/translations/messages.json
+++ b/translations/messages.json
@@ -627,6 +627,11 @@
         "id": "wallet.transactions.csv.value.statusPending"
       },
       {
+        "defaultMessage": "!!!Failed",
+        "description": "Transactions CSV value - Status Failed",
+        "id": "wallet.transactions.csv.value.statusFailed"
+      },
+      {
         "defaultMessage": "!!!Transactions",
         "description": "Transactions CSV \"Transactions\" filename",
         "id": "wallet.transactions.csv.filenamePrefix"


### PR DESCRIPTION
Expired transactions currently export as “Confirmed,” although transaction history shows them as failed. This maps all three states explicitly and exports “Failed” in English and “失敗しました” in Japanese, matching existing transaction-history wording.

| State | Previous English CSV | Updated English CSV | Updated Japanese CSV |
| --- | --- | --- | --- |
| `pending` | Pending | Pending | 保留中 |
| `in_ledger` | Confirmed | Confirmed | 承認済み |
| `expired` | Confirmed | Failed | 失敗しました |

Includes regression tests, generated translation catalogs, and an Unreleased changelog entry. Expired transactions without a date remain in the CSV with a blank date cell.

## Verification

- Regression tests fail against the original exporter and pass with this fix.
- Native Nix checks, production renderer build, and repository formatting pass.
- An isolated Electron fixture test verified real CSV files in both locales through native Save dialogs and actual IPC/file-writing handlers; cancellation wrote no file.

<details>
<summary>Validation details</summary>

On Apple Silicon macOS, using the repository’s pinned dependencies. The Nix commands below are equivalents for this PR checkout; validation used an isolated snapshot including the new regression spec.

- `nix build .#checks.aarch64-darwin.jest`: 71 suites, 933 tests and 6 snapshots passed; 3 tests skipped.
- `nix build .#checks.aarch64-darwin.cucumber-unit`: 32 scenarios and 102 steps passed.
- `yarn build:renderer` in the same Nix dependency derivation: passed; failed-state mapping present in the production bundle.
- Nix formatter: 2,113 files processed, zero changes.
- TypeScript, ESLint, stylelint, Storybook build, and i18n regeneration: passed. A second i18n regeneration produced no changes.
- Electron 41.3.0 fixture integration: all three status values and the blank expired date verified with an independent CSV parser. Native cancellation returned false without invoking the CSV writer.

The Electron check used synthetic transactions and a temporary profile; it did not exercise the full wallet UI or a blockchain backend. Existing lint/translation and Webpack asset-size warnings remain.

</details>
